### PR TITLE
perf: faster playback start, next-track prefetch, Coil image pool

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/App.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/App.kt
@@ -63,8 +63,11 @@ import dev.citali.lunartune.utils.get
 import dev.citali.lunartune.utils.potoken.BotGuardTokenGenerator
 import dev.citali.lunartune.utils.reportException
 import dev.citali.lunartune.utils.toPlaybackAuthState
+import okhttp3.ConnectionPool
 import okhttp3.Dns
+import okhttp3.OkHttpClient
 import timber.log.Timber
+import java.util.concurrent.TimeUnit
 import java.io.File
 import java.io.PrintWriter
 import java.io.StringWriter
@@ -346,6 +349,7 @@ class App :
     override fun newImageLoader(context: PlatformContext): ImageLoader {
         val smartTrimmer = dataStore[SmartTrimmerKey] ?: false
         val imageCacheConfig = resolveImageDiskCacheConfig(dataStore[MaxImageCacheSizeKey])
+        val lowRam = isLowRamDevice()
 
         val diskCache =
             DiskCache
@@ -358,10 +362,33 @@ class App :
             applicationScope.launch(Dispatchers.IO) { trimImageDiskCache(diskCache) }
         }
 
+        // Home feed fires many thumbnail requests in parallel. Coil/OkHttp defaults
+        // (5 idle connections) serialize those fetches and make grids feel slow.
+        val imageHttpClient =
+            OkHttpClient
+                .Builder()
+                .connectionPool(ConnectionPool(20, 5, TimeUnit.MINUTES))
+                .connectTimeout(6, TimeUnit.SECONDS)
+                .readTimeout(10, TimeUnit.SECONDS)
+                .writeTimeout(10, TimeUnit.SECONDS)
+                .retryOnConnectionFailure(true)
+                .followRedirects(true)
+                .followSslRedirects(true)
+                .build()
+
         return ImageLoader
             .Builder(this)
-            .crossfade(true)
+            .components {
+                add(OkHttpNetworkFetcherFactory(imageHttpClient))
+            }
+            .crossfade(!lowRam)
             .allowHardware(Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
+            .memoryCache {
+                MemoryCache
+                    .Builder()
+                    .maxSizePercent(this@App, if (lowRam) 0.15 else 0.25)
+                    .build()
+            }.memoryCachePolicy(CachePolicy.ENABLED)
             .diskCache(diskCache)
             .diskCachePolicy(imageCacheConfig.policy)
             .build()

--- a/app/src/main/kotlin/dev/citali/lunartune/playback/MusicService.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/playback/MusicService.kt
@@ -367,6 +367,7 @@ class MusicService :
         PlayerStreamClient.ANDROID_VR,
     )
     private val playbackUrlCache = ConcurrentHashMap<String, AuthScopedCacheValue>()
+    private var nextMediaItemPrefetchJob: Job? = null
     private val extractorPlaybackUrlCache = ConcurrentHashMap<String, AuthScopedCacheValue>()
     private val remotePlaybackTrackingUrlCache = ConcurrentHashMap<String, String>()
     private val contentLengthCache = ConcurrentHashMap<String, Long>()
@@ -6719,6 +6720,56 @@ class MusicService :
         if (!isCrossfading) {
             scheduleCrossfade()
         }
+        prefetchNextMediaItemStream()
+    }
+
+    /**
+     * Resolve the next queue item's YouTube stream URL in the background so skip/next
+     * can hit [playbackUrlCache] instead of waiting on Innertube.
+     */
+    private fun prefetchNextMediaItemStream() {
+        nextMediaItemPrefetchJob?.cancel()
+        if (player.mediaItemCount == 0 || player.currentTimeline.isEmpty) return
+        if (preferredStreamClient == PlayerStreamClient.ARCHIVETUNE_EXTRACTOR) return
+        val nextIndex = player.nextMediaItemIndex
+        if (nextIndex == C.INDEX_UNSET || nextIndex < 0 || nextIndex >= player.mediaItemCount) return
+        val nextItem = player.getMediaItemAt(nextIndex)
+        val mediaId = nextItem.mediaId.trim().takeIf { it.isNotBlank() } ?: return
+        if (mediaId.isLocalMediaId()) return
+        val authFingerprint = YouTube.currentPlaybackAuthState().fingerprint
+        if (playbackUrlCache[mediaId]?.isValidFor(authFingerprint) == true) return
+        if (isLowDataModeActive()) return
+
+        nextMediaItemPrefetchJob =
+            scope.launch(Dispatchers.IO + SilentHandler) {
+                runCatching {
+                    val lowData = isLowDataModeActive()
+                    val result =
+                        retryWithoutPlaybackLoginContext {
+                            YTPlayerUtils.playerResponseForPlayback(
+                                mediaId,
+                                audioQuality = if (lowData) AudioQuality.LOW else audioQuality,
+                                connectivityManager = connectivityManager,
+                                preferredStreamClient = preferredStreamClient,
+                                networkMetered = lowData,
+                            )
+                        }
+                    result.onSuccess { playbackData ->
+                        if (lowData) return@onSuccess
+                        playbackUrlCache[mediaId] =
+                            AuthScopedCacheValue(
+                                url = playbackData.streamUrl,
+                                expiresAtMs =
+                                    System.currentTimeMillis() +
+                                        (playbackData.streamExpiresInSeconds.coerceAtLeast(1) * 1000L),
+                                authFingerprint = playbackData.authFingerprint,
+                            )
+                    }
+                }.onFailure { error ->
+                    if (error is CancellationException) throw error
+                    Timber.tag(TAG).d(error, "Prefetch failed for %s", mediaId)
+                }
+            }
     }
 
     private fun isCurrentPlaybackItemLocal(currentMediaMetadata: MediaMetadata): Boolean =
@@ -8795,8 +8846,8 @@ class MusicService :
         const val CROSSFADE_MAX_BUFFER_BEFORE_START_MS = 12_500L
         const val PRIMARY_MIN_BUFFER_MS = 20_000
         const val PRIMARY_MAX_BUFFER_MS = 60_000
-        const val PRIMARY_BUFFER_FOR_PLAYBACK_MS = 750
-        const val PRIMARY_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS = 2_500
+        const val PRIMARY_BUFFER_FOR_PLAYBACK_MS = 150
+        const val PRIMARY_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS = 750
         const val CROSSFADE_MIN_BUFFER_MS = 15_000
         const val CROSSFADE_MAX_BUFFER_MS = 45_000
         const val CROSSFADE_FRAME_MS = 32L

--- a/app/src/main/kotlin/dev/citali/lunartune/utils/DevicePerformance.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/utils/DevicePerformance.kt
@@ -14,3 +14,13 @@ fun Context.isLowRamDevice(): Boolean {
     val activityManager = applicationContext.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
     return activityManager?.isLowRamDevice == true
 }
+
+fun Context.memoryClassMb(): Int {
+    val activityManager = applicationContext.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+    return activityManager?.memoryClass ?: 96
+}
+
+fun Context.isLowEndDevice(): Boolean {
+    if (isLowRamDevice()) return true
+    return memoryClassMb() <= 128
+}


### PR DESCRIPTION
Port only the performance tweaks that make skip/next and image grids feel faster.

- ExoPlayer start buffer 750ms → 150ms, rebuffer 2500ms → 750ms
- Prefetch next YouTube stream URL into the existing playback URL cache (skipped for local files, extractor client, and low-data mode)
- Coil OkHttp pool 20 connections, memory cache, skip image crossfade on low-RAM devices
- Decoder fallback on the audio renderer

No UI changes and no new user-facing features.