### PR TITLE
fix: compile errors blocking signed APKs

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/App.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/App.kt
@@ -19,9 +19,12 @@ import coil3.PlatformContext
 import coil3.SingletonImageLoader
 import coil3.disk.DiskCache
 import coil3.disk.directory
+import coil3.memory.MemoryCache
+import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import coil3.request.CachePolicy
 import coil3.request.allowHardware
 import coil3.request.crossfade
+import dev.citali.lunartune.utils.isLowRamDevice
 import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi

--- a/app/src/main/kotlin/dev/citali/lunartune/playback/MusicService.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/playback/MusicService.kt
@@ -226,7 +226,7 @@ import dev.citali.lunartune.models.MediaMetadata
 import dev.citali.lunartune.models.PersistPlayerState
 import dev.citali.lunartune.models.PersistQueue
 import dev.citali.lunartune.models.toMediaMetadata
-import moe.rukamori.archivetune.moriextractor.LunarTuneExtractorException
+import moe.rukamori.archivetune.moriextractor.ArchiveTuneExtractorException
 import moe.rukamori.archivetune.moriextractor.InMemoryBearerTokenRepository
 import moe.rukamori.archivetune.moriextractor.StreamingExtractionManager
 import dev.citali.lunartune.playback.queues.EmptyQueue
@@ -7820,7 +7820,7 @@ class MusicService :
                         )
                     }
 
-                    throwable is LunarTuneExtractorException -> {
+                    throwable is ArchiveTuneExtractorException -> {
                         throw PlaybackException(
                             getString(R.string.error_no_stream),
                             throwable,


### PR DESCRIPTION
Secrets are fine (Telegram notify already succeeded). Build APKs still failed at Kotlin compile:

- missing Coil / `isLowRamDevice` imports in `App.kt`
- `LunarTuneExtractorException` does not exist in the moriextractor submodule (still `ArchiveTuneExtractorException`)

This unblocks the original Build APKs + Telegram pipeline.