### PR TITLE
fix: compile MainActivity after news-button removal

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/MainActivity.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/MainActivity.kt
@@ -1665,7 +1665,10 @@ class MainActivity : ComponentActivity() {
 
                             Scaffold(
                                 topBar = {
-                                   navBackStackEntry?.destination?.route == Screens.Home.route ||
+                                    if (shouldShowTopBar) {
+                                        val shouldUseFloatingTopBar =
+                                            remember(navBackStackEntry) {
+                                                navBackStackEntry?.destination?.route == Screens.Home.route ||
                                                     navBackStackEntry?.destination?.route == Screens.Search.route ||
                                                     navBackStackEntry?.destination?.route == Screens.Library.route
                                             }

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/NavigationBuilder.kt
@@ -67,6 +67,7 @@ import dev.citali.lunartune.ui.screens.settings.LastFMSettings
 import dev.citali.lunartune.ui.screens.settings.LogcatScreen
 import dev.citali.lunartune.ui.screens.settings.LyricsAnimationSettings
 import dev.citali.lunartune.ui.screens.settings.LyricsSettings
+import dev.citali.lunartune.ui.screens.settings.NavigationBarSettings
 import dev.citali.lunartune.ui.screens.settings.MusicTogetherScreen
 import dev.citali.lunartune.ui.screens.settings.PalettePickerScreen
 import dev.citali.lunartune.ui.screens.settings.PlayerSettings


### PR DESCRIPTION
PR #12 failed Kotlin compile: the top-bar edit left Scaffold malformed, so ACTION_SEARCH/ACTION_LIBRARY and the rest of MainActivity no longer resolved. This restores the shouldShowTopBar wrapper and adds the missing NavigationBarSettings import.