### PR TITLE
fix: delete leftover MainActivity junk breaking CI

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/MainActivity.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/MainActivity.kt
@@ -3159,8 +3159,3 @@ private fun Context.isTvDevice(): Boolean {
         packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK) ||
         packageManager.hasSystemFeature(PackageManager.FEATURE_TELEVISION)
 }
-ration.UI_MODE_TYPE_TELEVISION
-    return isTelevisionUiMode ||
-        packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK) ||
-        packageManager.hasSystemFeature(PackageManager.FEATURE_TELEVISION)
-}


### PR DESCRIPTION
CI is **not** failing because of `.gitmodules`.

`actions/checkout` with `submodules: true` succeeds: core, lyrics, morideobfuscator, and moriextractor all check out. IconPack is gone and is no longer registered.

PR #11 failed on a duplicate `string/general`.
PR #12/#13 failed Kotlin compile: `MainActivity.kt` still had a duplicated fragment after `isTvDevice()` (`ration.UI_MODE_TYPE_TELEVISION...`), so the compiler reported “Expecting a top level declaration” at the end of the file.

This PR only deletes that leftover tail.