### PR TITLE
fix: make LunarTune visible in the launcher again

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -67,10 +67,16 @@
         <activity
             android:name=".MainActivity"
             android:configChanges="uiMode"
+            android:enabled="true"
             android:exported="true"
             android:launchMode="singleTask"
             android:theme="@style/Theme.LunarTune"
             android:windowSoftInputMode="adjustResize">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.MUSIC_PLAYER" />

--- a/app/src/main/kotlin/dev/citali/lunartune/App.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/App.kt
@@ -9,8 +9,10 @@ package dev.citali.lunartune
 
 import android.app.ActivityManager
 import android.app.Application
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Build
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
@@ -421,6 +423,16 @@ class App :
             }
         } catch (_: Exception) {
         }
+    }
+
+    private fun ensureMainActivityLaunchable() {
+        runCatching {
+            packageManager.setComponentEnabledSetting(
+                ComponentName(this, MainActivity::class.java),
+                PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+                PackageManager.DONT_KILL_APP,
+            )
+        }.onFailure(Timber::w)
     }
 
     companion object {


### PR DESCRIPTION
After IconPack was removed, the generated activity-aliases that owned MAIN/LAUNCHER disappeared. MainActivity itself never had a launcher filter, so the APK installs but does not appear in the app drawer.

This adds MAIN/LAUNCHER on MainActivity and re-enables the component if an older icon-picker state left it disabled.

The lyrics submodule was not removed.