### PR TITLE
feat: home polish, About credits, Solar player icons

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/MainActivity.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/MainActivity.kt
@@ -1051,10 +1051,7 @@ class MainActivity : ComponentActivity() {
                             expandedBound = maxHeight,
                         )
                     var homeOverflowMenuExpanded by rememberSaveable { mutableStateOf(false) }
-                    val showHomeOverflowFab =
-                        shouldShowHomeShuffleButton &&
-                            !useRail &&
-                            (playerBottomSheetState.isDismissed || playerBottomSheetState.isCollapsed)
+                    val showHomeOverflowFab = false
 
                     LaunchedEffect(showHomeOverflowFab) {
                         if (!showHomeOverflowFab) {

--- a/app/src/main/kotlin/dev/citali/lunartune/onboarding/OnboardingUseCases.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/onboarding/OnboardingUseCases.kt
@@ -201,25 +201,11 @@ class BuildOnboardingUiStateUseCase
                         url = "https://github.com/cognitiveshadows03/ArchiveTune",
                     ),
                     OnboardingCommunityActionUiModel(
-                        id = "discord",
-                        titleResId = R.string.onboarding_community_discord_title,
-                        descriptionResId = R.string.onboarding_community_telegram_desc,
-                        iconResId = R.drawable.discord,
-                        url = "https://discord.gg/XF2fpb9rTq",
-                    ),
-                    OnboardingCommunityActionUiModel(
                         id = "telegram",
                         titleResId = R.string.onboarding_community_telegram_title,
                         descriptionResId = R.string.onboarding_community_telegram_desc,
                         iconResId = R.drawable.telegram,
                         url = "https://t.me/LunarTuneGC",
-                    ),
-                    OnboardingCommunityActionUiModel(
-                        id = "donate",
-                        titleResId = R.string.about_content_desc_donate,
-                        descriptionResId = R.string.onboarding_community_donate_desc,
-                        iconResId = R.drawable.coffee,
-                        url = "https://koiiverse.cloud/donate",
                     ),
                 )
         }

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/component/FloatingNavigationToolbar.kt
@@ -333,12 +333,17 @@ fun FloatingNavigationToolbar(
                                         }
                                     }
                                 },
-                                label = {
-                                    Text(
-                                        text = stringResource(screen.titleId),
-                                        maxLines = 1,
-                                    )
-                                },
+                                label =
+                                    if (hideNavigationLabels) {
+                                        null
+                                    } else {
+                                        {
+                                            Text(
+                                                text = stringResource(screen.titleId),
+                                                maxLines = 1,
+                                            )
+                                        }
+                                    },
                             )
                         }
                     }

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/library/LibraryMixScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/library/LibraryMixScreen.kt
@@ -301,15 +301,6 @@ fun LibraryMixScreen(
                     }
                 }
 
-                if (supportLunarTuneAvailable) {
-                    item(key = "support_archive_tune", contentType = "support_ad") {
-                        SupportLunarTuneSection(
-                            onMessage = showMessage,
-                            modifier = Modifier.padding(horizontal = 24.dp),
-                        )
-                    }
-                }
-
                 // 3. Recently Played Horizontal Row
                 if (recentSongs.isNotEmpty()) {
                     item(key = "recently_played") {

--- a/app/src/main/kotlin/dev/citali/lunartune/viewmodels/AboutViewModel.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/viewmodels/AboutViewModel.kt
@@ -419,34 +419,10 @@ class AboutViewModel
                             url = "https://github.com/cognitiveshadows03/ArchiveTune",
                         ),
                         AboutLinkUiModel(
-                            id = "website",
-                            iconResId = R.drawable.website,
-                            labelResId = R.string.about_content_desc_website,
-                            url = "https://lunartune.koiiverse.cloud",
-                        ),
-                        AboutLinkUiModel(
                             id = "telegram",
                             iconResId = R.drawable.telegram,
                             labelResId = R.string.about_content_desc_telegram,
                             url = "https://t.me/LunarTuneGC",
-                        ),
-                        AboutLinkUiModel(
-                            id = "donate",
-                            iconResId = R.drawable.coffee,
-                            labelResId = R.string.about_content_desc_donate,
-                            url = "https://koiiverse.cloud/donate",
-                        ),
-                        AboutLinkUiModel(
-                            id = "discord",
-                            iconResId = R.drawable.discord,
-                            labelResId = R.string.discord,
-                            url = "https://discord.gg/XF2fpb9rTq",
-                        ),
-                        AboutLinkUiModel(
-                            id = "privacy_policy",
-                            iconResId = R.drawable.lock,
-                            labelResId = R.string.privacy,
-                            url = "https://lunartune.koiiverse.cloud/privacy",
                         ),
                     ),
                 leadDeveloper =
@@ -465,80 +441,42 @@ class AboutViewModel
                                 ),
                             ),
                     ),
-                credits =
-                    TeamMemberCollection.of(
-                        TeamMember(
-                            avatarUrl = "https://avatars.githubusercontent.com/u/107134739?v=4",
-                            name = "ArchiveTune",
-                            positionResId = R.string.about_position_original,
-                            profileUrl = "https://github.com/cognitiveshadows03/ArchiveTune",
-                            links =
-                                AboutLinkCollection.of(
-                                    AboutLinkUiModel(
-                                        id = "github",
-                                        iconResId = R.drawable.github,
-                                        labelResId = R.string.about_content_desc_github,
-                                        url = "https://github.com/cognitiveshadows03/ArchiveTune",
-                                    ),
-                                ),
-                        ),
-                    ),
+                credits = TeamMemberCollection.of(),
                 collaborators =
                     TeamMemberCollection.of(
                         TeamMember(
-                            avatarUrl = "https://avatars.githubusercontent.com/u/89002922?v=4",
-                            name = "Miko",
+                            avatarUrl = "https://avatars.githubusercontent.com/u/317606351?v=4",
+                            name = "TherealCitali",
                             positionResId = R.string.about_position_developers,
-                            profileUrl = "https://github.com/mikooochi",
+                            profileUrl = "https://github.com/TherealCitali",
                             links =
                                 AboutLinkCollection.of(
                                     AboutLinkUiModel(
                                         id = "github",
                                         iconResId = R.drawable.github,
                                         labelResId = R.string.about_content_desc_github,
-                                        url = "https://github.com/mikooochi",
-                                    ),
-                                ),
-                        ),
-                        TeamMember(
-                            avatarUrl = "https://avatars.githubusercontent.com/u/93458424?v=4",
-                            name = "WTTexe",
-                            positionResId = R.string.about_position_developers,
-                            profileUrl = "https://github.com/Windowstechtips",
-                            links =
-                                AboutLinkCollection.of(
-                                    AboutLinkUiModel(
-                                        id = "github",
-                                        iconResId = R.drawable.github,
-                                        labelResId = R.string.about_content_desc_github,
-                                        url = "https://github.com/Windowstechtips",
-                                    ),
-                                    AboutLinkUiModel(
-                                        id = "discord",
-                                        iconResId = R.drawable.alternate_email,
-                                        labelResId = R.string.about_content_desc_discord,
-                                        url = "https://discord.com/users/840839409640800258",
-                                    ),
-                                ),
-                        ),
-                        TeamMember(
-                            avatarUrl = "https://avatars.githubusercontent.com/u/203143605?v=4",
-                            name = "Yuki/Reze",
-                            positionResId = R.string.about_position_yuki,
-                            profileUrl = "https://github.com/4nx3b",
-                            links =
-                                AboutLinkCollection.of(
-                                    AboutLinkUiModel(
-                                        id = "github",
-                                        iconResId = R.drawable.github,
-                                        labelResId = R.string.about_content_desc_github,
-                                        url = "https://github.com/4nx3b",
+                                        url = "https://github.com/TherealCitali",
                                     ),
                                 ),
                         ),
                     ),
                 respecters =
                     TeamMemberCollection.of(
+                        TeamMember(
+                            avatarUrl = "https://avatars.githubusercontent.com/u/107134739?v=4",
+                            name = "ArchiveTune",
+                            positionResId = R.string.about_position_original,
+                            profileUrl = "https://github.com/rukamori/ArchiveTune",
+                            links =
+                                AboutLinkCollection.of(
+                                    AboutLinkUiModel(
+                                        id = "github",
+                                        iconResId = R.drawable.github,
+                                        labelResId = R.string.about_content_desc_github,
+                                        url = "https://github.com/rukamori/ArchiveTune",
+                                    ),
+                                ),
+                        ),
                         TeamMember(
                             avatarUrl = "https://avatars.githubusercontent.com/u/80542861?v=4",
                             name = "MO AGAMY",
@@ -551,21 +489,6 @@ class AboutViewModel
                                         iconResId = R.drawable.github,
                                         labelResId = R.string.about_content_desc_github,
                                         url = "https://github.com/mostafaalagamy",
-                                    ),
-                                ),
-                        ),
-                        TeamMember(
-                            avatarUrl = "https://avatars.githubusercontent.com/u/110614797?v=4",
-                            name = "Zion Huang",
-                            positionResId = R.string.about_position_zion_huang,
-                            profileUrl = "https://github.com/z-huang",
-                            links =
-                                AboutLinkCollection.of(
-                                    AboutLinkUiModel(
-                                        id = "github",
-                                        iconResId = R.drawable.github,
-                                        labelResId = R.string.about_content_desc_github,
-                                        url = "https://github.com/z-huang",
                                     ),
                                 ),
                         ),

--- a/app/src/main/kotlin/dev/citali/lunartune/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/viewmodels/HomeViewModel.kt
@@ -479,11 +479,11 @@ class HomeViewModel
 
             try {
                 val aiContentFilterPolicy = loadAiContentFilterPolicy()
+                val hideExplicit = context.dataStore.get(HideExplicitKey, false)
+                val hideVideo = context.dataStore.get(HideVideoKey, false)
+                val blockedArtistIds = database.getBlockedArtistIds().toSet()
+                val fromTimeStamp = System.currentTimeMillis() - 86400000 * 7 * 2
                 supervisorScope {
-                    val hideExplicit = context.dataStore.get(HideExplicitKey, false)
-                    val hideVideo = context.dataStore.get(HideVideoKey, false)
-                    val blockedArtistIds = database.getBlockedArtistIds().toSet()
-                    val fromTimeStamp = System.currentTimeMillis() - 86400000 * 7 * 2
 
                     launch { loadSpeedDialItems() }
                     launch {
@@ -524,51 +524,51 @@ class HomeViewModel
                         keepListening.value = (keepListeningSongs + keepListeningAlbums + keepListeningArtists).shuffled()
                     }
 
-                    launch {
-                        YouTube
-                            .home()
-                            .onSuccess { page ->
-                                val filteredPage =
-                                    page.copy(
-                                        chips = filterHomeChips(page.chips),
-                                        sections =
-                                            page.sections.map { section ->
-                                                section.copy(
-                                                    items =
-                                                        filterAiContent(
-                                                            section.items
-                                                                .filterExplicit(hideExplicit)
-                                                                .filterVideo(hideVideo)
-                                                                .filterBlockedArtists(blockedArtistIds),
-                                                            aiContentFilterPolicy,
-                                                        ),
-                                                )
-                                            },
-                                    )
-                                val (pageWithoutQuickPicks, quickPicksSection) = filteredPage.extractQuickPicks()
-                                remoteQuickPicks.value = quickPicksSection
-                                homePage.value = pageWithoutQuickPicks
-                            }.onFailure {
-                                reportException(it)
-                                loadError.value = R.string.error_unknown
-                            }
-                    }
                 }
 
                 updateAllLocalItems()
+                isInitialLoadComplete.value = true
 
                 viewModelScope.launch(Dispatchers.IO) {
+                    YouTube
+                        .home()
+                        .onSuccess { page ->
+                            val filteredPage =
+                                page.copy(
+                                    chips = filterHomeChips(page.chips),
+                                    sections =
+                                        page.sections.map { section ->
+                                            section.copy(
+                                                items =
+                                                    filterAiContent(
+                                                        section.items
+                                                            .filterExplicit(hideExplicit)
+                                                            .filterVideo(hideVideo)
+                                                            .filterBlockedArtists(blockedArtistIds),
+                                                        aiContentFilterPolicy,
+                                                    ),
+                                            )
+                                        },
+                                )
+                            val (pageWithoutQuickPicks, quickPicksSection) = filteredPage.extractQuickPicks()
+                            remoteQuickPicks.value = quickPicksSection
+                            homePage.value = pageWithoutQuickPicks
+                            _allYtItems.value =
+                                similarRecommendations.value?.flatMap { it.items }.orEmpty() +
+                                    quickPicksSection?.items.orEmpty() +
+                                    pageWithoutQuickPicks.sections.flatMap { it.items }
+                        }.onFailure {
+                            reportException(it)
+                            loadError.value = R.string.error_unknown
+                        }
                     loadSimilarRecommendations()
+                    _allYtItems.value = similarRecommendations.value?.flatMap { it.items }.orEmpty() +
+                        remoteQuickPicks.value?.items.orEmpty() +
+                        homePage.value
+                            ?.sections
+                            ?.flatMap { it.items }
+                            .orEmpty()
                 }
-
-                _allYtItems.value = similarRecommendations.value?.flatMap { it.items }.orEmpty() +
-                    remoteQuickPicks.value?.items.orEmpty() +
-                    homePage.value
-                        ?.sections
-                        ?.flatMap { it.items }
-                        .orEmpty()
-
-                isInitialLoadComplete.value = true
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {

--- a/app/src/main/res/drawable/pause.xml
+++ b/app/src/main/res/drawable/pause.xml
@@ -5,15 +5,9 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="@android:color/transparent"
-        android:pathData="M2 18C2 19.8856 2 20.8284 2.58579 21.4142C3.17157 22 4.11438 22 6 22C7.88562 22 8.82843 22 9.41421 21.4142C10 20.8284 10 19.8856 10 18V6C10 4.11438 10 3.17157 9.41421 2.58579C8.82843 2 7.88562 2 6 2C4.11438 2 3.17157 2 2.58579 2.58579C2 3.17157 2 4.11438 2 6V14"
-        android:strokeColor="@android:color/white"
-        android:strokeWidth="1.5"
-        android:strokeLineCap="round" />
+        android:fillColor="@android:color/white"
+        android:pathData="M2 6C2 4.11438 2 3.17157 2.58579 2.58579C3.17157 2 4.11438 2 6 2C7.88562 2 8.82843 2 9.41421 2.58579C10 3.17157 10 4.11438 10 6V18C10 19.8856 10 20.8284 9.41421 21.4142C8.82843 22 7.88562 22 6 22C4.11438 22 3.17157 22 2.58579 21.4142C2 20.8284 2 19.8856 2 18V6Z" />
     <path
-        android:fillColor="@android:color/transparent"
-        android:pathData="M22 6C22 4.11438 22 3.17157 21.4142 2.58579C20.8284 2 19.8856 2 18 2C16.1144 2 15.1716 2 14.5858 2.58579C14 3.17157 14 4.11438 14 6V18C14 19.8856 14 20.8284 14.5858 21.4142C15.1716 22 16.1144 22 18 22C19.8856 22 20.8284 22 21.4142 21.4142C22 20.8284 22 19.8856 22 18V10"
-        android:strokeColor="@android:color/white"
-        android:strokeWidth="1.5"
-        android:strokeLineCap="round" />
+        android:fillColor="@android:color/white"
+        android:pathData="M14 6C14 4.11438 14 3.17157 14.5858 2.58579C15.1716 2 16.1144 2 18 2C19.8856 2 20.8284 2 21.4142 2.58579C22 3.17157 22 4.11438 22 6V18C22 19.8856 22 20.8284 21.4142 21.4142C20.8284 22 19.8856 22 18 22C16.1144 22 15.1716 22 14.5858 21.4142C14 20.8284 14 19.8856 14 18V6Z" />
 </vector>

--- a/app/src/main/res/drawable/play.xml
+++ b/app/src/main/res/drawable/play.xml
@@ -5,9 +5,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="@android:color/transparent"
-        android:pathData="M3 12L3 18.9671C3 21.2763 5.53435 22.736 7.59662 21.6145L10.7996 19.8727M3 8L3 5.0329C3 2.72368 5.53435 1.26402 7.59661 2.38548L20.4086 9.35258C22.5305 10.5065 22.5305 13.4935 20.4086 14.6474L14.0026 18.131"
-        android:strokeColor="@android:color/white"
-        android:strokeWidth="1.5"
-        android:strokeLineCap="round" />
+        android:fillColor="@android:color/white"
+        android:pathData="M21.4086 9.35258C23.5305 10.5065 23.5305 13.4935 21.4086 14.6474L8.59662 21.6145C6.53435 22.736 4 21.2763 4 18.9671L4 5.0329C4 2.72368 6.53435 1.26402 8.59661 2.38548L21.4086 9.35258Z" />
 </vector>

--- a/app/src/main/res/drawable/skip_next.xml
+++ b/app/src/main/res/drawable/skip_next.xml
@@ -5,15 +5,9 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="@android:color/transparent"
-        android:pathData="M2 11L2 18.9671C2 21.2763 4.13419 22.736 5.87083 21.6145L16.6598 14.6474C18.4467 13.4935 18.4467 10.5065 16.6598 9.35258L5.87084 2.38548C4.13419 1.26402 2 2.72368 2 5.03289V7"
-        android:strokeColor="@android:color/white"
-        android:strokeWidth="1.5"
-        android:strokeLineCap="round" />
+        android:fillColor="@android:color/white"
+        android:pathData="M16.6598 14.6474C18.4467 13.4935 18.4467 10.5065 16.6598 9.35258L5.87083 2.38548C4.13419 1.26402 2 2.72368 2 5.0329V18.9671C2 21.2763 4.13419 22.736 5.87083 21.6145L16.6598 14.6474Z" />
     <path
-        android:fillColor="@android:color/transparent"
-        android:pathData="M22 5V12M22 16V19"
-        android:strokeColor="@android:color/white"
-        android:strokeWidth="1.5"
-        android:strokeLineCap="round" />
+        android:fillColor="@android:color/white"
+        android:pathData="M22.75 5C22.75 4.58579 22.4142 4.25 22 4.25C21.5858 4.25 21.25 4.58579 21.25 5V19C21.25 19.4142 21.5858 19.75 22 19.75C22.4142 19.75 22.75 19.4142 22.75 19V5Z" />
 </vector>

--- a/app/src/main/res/drawable/skip_previous.xml
+++ b/app/src/main/res/drawable/skip_previous.xml
@@ -5,15 +5,9 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="@android:color/transparent"
-        android:pathData="M22 11L22 18.9671C22 21.2763 19.8658 22.736 18.1292 21.6145L7.34016 14.6474C5.55328 13.4935 5.55328 10.5065 7.34015 9.35258L18.1292 2.38548C19.8658 1.26402 22 2.72368 22 5.03289V7"
-        android:strokeColor="@android:color/white"
-        android:strokeWidth="1.5"
-        android:strokeLineCap="round" />
+        android:fillColor="@android:color/white"
+        android:pathData="M8.09015 14.6474C6.30328 13.4935 6.30328 10.5065 8.09015 9.35258L18.8792 2.38548C20.6158 1.26402 22.75 2.72368 22.75 5.0329V18.9671C22.75 21.2763 20.6158 22.736 18.8792 21.6145L8.09015 14.6474Z" />
     <path
-        android:fillColor="@android:color/transparent"
-        android:pathData="M2 5V12M2 19V16"
-        android:strokeColor="@android:color/white"
-        android:strokeWidth="1.5"
-        android:strokeLineCap="round" />
+        android:fillColor="@android:color/white"
+        android:pathData="M2 5C2 4.58579 2.33579 4.25 2.75 4.25C3.16421 4.25 3.5 4.58579 3.5 5V19C3.5 19.4142 3.16421 19.75 2.75 19.75C2.33579 19.75 2 19.4142 2 19V5Z" />
 </vector>

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -737,7 +737,7 @@
     <string name="about_position_bot_contributor">Contributor</string>
     <string name="about_position_developers">Developer | Team</string>
     <string name="about_position_yuki">dummy reze | Admin</string>
-    <string name="about_position_mo_agamy">Base Framework | Metrolist</string>
+    <string name="about_position_mo_agamy">Playback client</string>
     <string name="about_position_zion_huang">Creator of InnerTune · Foundation for Metrolist, LunarTune, and other forks</string>
     <string name="about_content_desc_github">GitHub</string>
     <string name="about_content_desc_website">Website</string>


### PR DESCRIPTION
- Remove the floating home overflow button
- Honor Hide labels on the navigation bar
- About keeps GitHub and Telegram only
- Onboarding community no longer includes Discord or Donate
- Remove the library Support LunarTune card
- Team is TherealCitali; Respecter lists ArchiveTune (base framework) and MO AGAMY (playback client)
- Play / pause / next / previous use Solar Bold icons
- Home shows local shelves immediately, then fills YouTube sections