### PR TITLE
feat: lyrics blur, settings search, Vivi EQ, LAN together, original quick picks

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,3 +322,8 @@ See the [`LICENSE`](LICENSE) file for the complete GPLv3 terms.
   <br />
   <img src="https://raw.githubusercontent.com/cognitiveshadows03/ArchiveTune/refs/heads/dev/assets/badge_part.png" alt="LunarTune Banner" style="width: 180px">
 </div>
+
+## Credits
+
+- [ArchiveTune](https://github.com/rukamori/ArchiveTune) — base app
+- [Vivi Music](https://github.com/vivizzz007/vivi-music) — Dolby and Dirac equalizer presets

--- a/app/src/main/kotlin/dev/citali/lunartune/MainActivity.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/MainActivity.kt
@@ -1744,6 +1744,14 @@ class MainActivity : ComponentActivity() {
                                                         )
                                                     }
                                                     TranslucentTopAppBarIconButton(
+                                                        onClick = { navController.navigate("settings/music_together") },
+                                                    ) {
+                                                        Icon(
+                                                            painter = painterResource(R.drawable.multi_user),
+                                                            contentDescription = stringResource(R.string.music_together),
+                                                        )
+                                                    }
+                                                    TranslucentTopAppBarIconButton(
                                                         onClick = { navController.navigate("new_release") },
                                                     ) {
                                                         Icon(

--- a/app/src/main/kotlin/dev/citali/lunartune/equalizer/ViviEqualizerPresets.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/equalizer/ViviEqualizerPresets.kt
@@ -11,7 +11,7 @@ package dev.citali.lunartune.equalizer
  * 10-band millibel curves from Vivi Music (vivizzz007/vivi-music).
  */
 object ViviEqualizerPresets {
-    val chips =
+    val chips: List<Pair<String, String>> =
         listOf(
             "dolby_open" to "Dolby Open",
             "dolby_rich" to "Dolby Rich",

--- a/app/src/main/kotlin/dev/citali/lunartune/equalizer/ViviEqualizerPresets.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/equalizer/ViviEqualizerPresets.kt
@@ -1,0 +1,34 @@
+/*
+ * LunarTune (2026)
+ * © cognitiveshadows03 — github.com/cognitiveshadows03
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package dev.citali.lunartune.equalizer
+
+/**
+ * 10-band millibel curves from Vivi Music (vivizzz007/vivi-music).
+ */
+object ViviEqualizerPresets {
+    val chips =
+        listOf(
+            "dolby_open" to "Dolby Open",
+            "dolby_rich" to "Dolby Rich",
+            "dolby_focused" to "Dolby Focused",
+            "dirac_music" to "Dirac Music",
+            "dirac_movie" to "Dirac Movie",
+            "dirac_game" to "Dirac Game",
+        )
+
+    fun levelsMb(id: String): List<Int>? =
+        when (id) {
+            "dolby_open" -> listOf(150, 180, 220, 180, 160, 210, 250, 280, 180, 80)
+            "dolby_rich" -> listOf(100, 160, 200, 220, 280, 260, 240, 200, 150, 50)
+            "dolby_focused" -> listOf(-300, -50, 130, 180, 220, 120, 140, 100, -50, -300)
+            "dirac_music" -> listOf(200, 140, 80, 0, 30, 80, 140, 200, 280, 350)
+            "dirac_movie" -> listOf(300, 250, 150, 0, 70, 120, 180, 250, 320, 400)
+            "dirac_game" -> listOf(150, 250, 200, 0, 80, 150, 300, 450, 400, 280)
+            else -> null
+        }
+}

--- a/app/src/main/kotlin/dev/citali/lunartune/lyrics/LyricsPreloadManager.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/lyrics/LyricsPreloadManager.kt
@@ -22,15 +22,12 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
-import dev.citali.lunartune.constants.LowDataModeKey
-import dev.citali.lunartune.constants.PreloadQueueLyricsEnabledKey
 import dev.citali.lunartune.constants.QueueLyricsPreloadCountKey
 import dev.citali.lunartune.db.MusicDatabase
 import dev.citali.lunartune.db.entities.LyricsEntity
 import dev.citali.lunartune.models.MediaMetadata
 import dev.citali.lunartune.utils.NetworkConnectivityObserver
 import dev.citali.lunartune.utils.dataStore
-import dev.citali.lunartune.utils.isLowDataModeActive
 import dev.citali.lunartune.utils.reportException
 import javax.inject.Inject
 
@@ -67,10 +64,9 @@ class LyricsPreloadManager
                 scope.launch {
                     try {
                         val preferences = context.dataStore.data.first()
-                        val isEnabled = preferences[PreloadQueueLyricsEnabledKey] ?: true
-
-                        if (!isEnabled) {
-                            Log.d(TAG, "Queue lyrics pre-load is disabled")
+                        val preloadCount = preferences[QueueLyricsPreloadCountKey] ?: DEFAULT_PRELOAD_COUNT
+                        if (preloadCount <= 0) {
+                            Log.d(TAG, "Queue lyrics pre-load is off (count = 0)")
                             return@launch
                         }
 
@@ -85,13 +81,6 @@ class LyricsPreloadManager
                             Log.w(TAG, "Network unavailable, skipping lyrics pre-load")
                             return@launch
                         }
-
-                        if (context.isLowDataModeActive(preferences[LowDataModeKey] ?: true)) {
-                            Log.d(TAG, "Low Data Mode active, skipping lyrics pre-load")
-                            return@launch
-                        }
-
-                        val preloadCount = preferences[QueueLyricsPreloadCountKey] ?: DEFAULT_PRELOAD_COUNT
                         val nextSongs = getNextSongs(queue, currentIndex, preloadCount)
 
                         if (nextSongs.isEmpty()) {

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
@@ -10,6 +10,8 @@
 package dev.citali.lunartune.ui.player
 
 import android.content.res.Configuration
+import android.graphics.Bitmap
+import android.os.Build
 import android.view.HapticFeedbackConstants
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
@@ -17,6 +19,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -54,6 +57,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -63,6 +67,7 @@ import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
@@ -120,6 +125,7 @@ import dev.citali.lunartune.ui.component.LyricsV2
 import dev.citali.lunartune.ui.component.PlayerSliderTrack
 import dev.citali.lunartune.ui.menu.LyricsMenu
 import dev.citali.lunartune.ui.theme.PlayerColorExtractor
+import dev.citali.lunartune.utils.ImageBlurUtils
 import dev.citali.lunartune.utils.makeTimeString
 import dev.citali.lunartune.utils.rememberEnumPreference
 import dev.citali.lunartune.utils.rememberPreference
@@ -590,16 +596,51 @@ private fun AppleMusicBackground(
             label = "lyrics-apple-background",
         ) { thumbnailUrl ->
             if (thumbnailUrl != null) {
-                AsyncImage(
-                    model = thumbnailUrl,
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
-                    modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .blur(46.dp)
-                            .alpha(0.62f),
-                )
+                val context = LocalContext.current
+                val isPreS = Build.VERSION.SDK_INT < Build.VERSION_CODES.S
+                if (isPreS) {
+                    val imageLoader = context.imageLoader
+                    val blurredBitmap by produceState<Bitmap?>(null, thumbnailUrl) {
+                        value =
+                            withContext(Dispatchers.IO) {
+                                runCatching {
+                                    val request =
+                                        ImageRequest
+                                            .Builder(context)
+                                            .data(thumbnailUrl)
+                                            .allowHardware(false)
+                                            .size(Size(720, 720))
+                                            .build()
+                                    val image = imageLoader.execute(request).image ?: return@runCatching null
+                                    val bitmap = image.toBitmap().copy(Bitmap.Config.ARGB_8888, true)
+                                    val density = context.resources.displayMetrics.density
+                                    ImageBlurUtils.blur(bitmap, 46f * density)
+                                }.getOrNull()
+                            }
+                    }
+                    blurredBitmap?.let { bitmap ->
+                        Image(
+                            bitmap = bitmap.asImageBitmap(),
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                            modifier =
+                                Modifier
+                                    .fillMaxSize()
+                                    .alpha(0.62f),
+                        )
+                    }
+                } else {
+                    AsyncImage(
+                        model = thumbnailUrl,
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                                .blur(46.dp)
+                                .alpha(0.62f),
+                    )
+                }
             }
         }
         Box(

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/HomeScreen.kt
@@ -58,6 +58,7 @@ import kotlinx.coroutines.CoroutineScope
 import dev.citali.lunartune.LocalPlayerAwareWindowInsets
 import dev.citali.lunartune.LocalPlayerConnection
 import dev.citali.lunartune.R
+import dev.citali.lunartune.constants.QuickPicks
 
 import dev.citali.lunartune.home.HomeAction
 import dev.citali.lunartune.home.HomeScreenState
@@ -273,6 +274,10 @@ private fun HomeContent(
 ) {
     val tonalStart = MaterialTheme.colorScheme.primaryContainer
     val tonalMiddle = MaterialTheme.colorScheme.secondaryContainer
+    val remoteQuickPicks =
+        uiState
+            .takeIf { it.quickPicksMode == QuickPicks.QUICK_PICKS }
+            ?.remoteQuickPicks
     Box(modifier = modifier.fillMaxSize()) {
         if (uiState.showTonalBackdrop) {
             Box(
@@ -334,7 +339,33 @@ private fun HomeContent(
                         }
                     }
 
-                    if (uiState.quickPicks.isNotEmpty()) {
+                    if (remoteQuickPicks?.items?.isNotEmpty() == true) {
+                        item(
+                            key = "home_remote_quick_picks_header",
+                            contentType = "section_header",
+                        ) {
+                            HomeSectionHeader(
+                                title = remoteQuickPicks.title,
+                                modifier = Modifier.animateItem(),
+                            )
+                        }
+                        item(
+                            key = "home_remote_quick_picks",
+                            contentType = "media_shelf",
+                        ) {
+                            HomePageSectionContent(
+                                section = remoteQuickPicks,
+                                mediaMetadata = mediaMetadata,
+                                isPlaying = isPlaying,
+                                navController = navController,
+                                playerConnection = playerConnection,
+                                menuState = menuState,
+                                haptic = haptic,
+                                scope = scope,
+                                modifier = Modifier.animateItem(),
+                            )
+                        }
+                    } else if (uiState.quickPicks.isNotEmpty()) {
                         item(
                             key = "home_quick_picks_header",
                             contentType = "section_header",

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/HomeScreenComponents.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/HomeScreenComponents.kt
@@ -61,8 +61,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.carousel.HorizontalCenteredHeroCarousel
-import androidx.compose.material3.carousel.maskBorder
-import androidx.compose.material3.carousel.maskClip
 import androidx.compose.material3.carousel.rememberCarouselState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
@@ -308,8 +306,8 @@ fun QuickPicksSection(
                         modifier =
                             Modifier
                                 .fillMaxSize()
-                                .maskClip(MaterialTheme.shapes.extraLarge)
-                                .maskBorder(
+                                .clip(MaterialTheme.shapes.extraLarge)
+                                .border(
                                     BorderStroke(
                                         1.dp,
                                         MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.72f),

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/HomeScreenComponents.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/HomeScreenComponents.kt
@@ -12,6 +12,7 @@ import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.focusable

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/HomeScreenComponents.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/HomeScreenComponents.kt
@@ -61,6 +61,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.carousel.HorizontalCenteredHeroCarousel
+import androidx.compose.material3.carousel.maskBorder
+import androidx.compose.material3.carousel.maskClip
 import androidx.compose.material3.carousel.rememberCarouselState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
@@ -264,25 +266,56 @@ fun QuickPicksSection(
 
     when (displayMode) {
         QuickPicksDisplayMode.CARD -> {
-            val cardWidth = 196.dp
-            val artSize = 168.dp
-            LazyRow(
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                contentPadding = PaddingValues(horizontal = 16.dp),
-                modifier = modifier.fillMaxWidth(),
-            ) {
-                items(
-                    items = distinctQuickPicks,
-                    key = { it.id },
-                ) { song ->
+            BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
+                val heroHeight =
+                    when {
+                        maxWidth >= 840.dp -> 380.dp
+                        maxWidth >= 600.dp -> 356.dp
+                        else -> 332.dp
+                    }
+                val heroMaxWidth =
+                    (maxWidth - 48.dp)
+                        .coerceAtLeast(232.dp)
+                        .coerceAtMost(440.dp)
+                val density = LocalDensity.current
+                val requestWidthPx = with(density) { heroMaxWidth.roundToPx().coerceAtLeast(1) }
+                val requestHeightPx = with(density) { heroHeight.roundToPx().coerceAtLeast(1) }
+
+                HorizontalCenteredHeroCarousel(
+                    state = rememberCarouselState { distinctQuickPicks.size },
+                    maxItemWidth = heroMaxWidth,
+                    itemSpacing = 10.dp,
+                    contentPadding = PaddingValues(horizontal = 16.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(heroHeight),
+                ) { index ->
+                    val song = distinctQuickPicks[index]
                     val isActive = song.id == mediaMetadata?.id
-                    Surface(
-                        shape = RoundedCornerShape(24.dp),
-                        color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                        tonalElevation = 1.dp,
+                    val context = LocalContext.current
+                    val imageRequest =
+                        remember(song.song.thumbnailUrl, requestWidthPx, requestHeightPx) {
+                            ImageRequest
+                                .Builder(context)
+                                .data(song.song.thumbnailUrl)
+                                .size(Size(requestWidthPx, requestHeightPx))
+                                .crossfade(true)
+                                .build()
+                        }
+
+                    Box(
                         modifier =
                             Modifier
-                                .width(cardWidth)
+                                .fillMaxSize()
+                                .maskClip(MaterialTheme.shapes.extraLarge)
+                                .maskBorder(
+                                    BorderStroke(
+                                        1.dp,
+                                        MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.72f),
+                                    ),
+                                    MaterialTheme.shapes.extraLarge,
+                                ).focusable()
                                 .combinedClickable(
                                     onClick = {
                                         if (isActive) {
@@ -309,28 +342,66 @@ fun QuickPicksSection(
                                     },
                                 ),
                     ) {
-                        Column(modifier = Modifier.padding(10.dp)) {
-                            AsyncImage(
-                                model = song.song.thumbnailUrl,
-                                contentDescription = null,
-                                contentScale = ContentScale.Crop,
+                        AsyncImage(
+                            model = imageRequest,
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier.fillMaxSize(),
+                        )
+
+                        Box(
+                            modifier =
+                                Modifier
+                                    .fillMaxSize()
+                                    .background(
+                                        Brush.verticalGradient(
+                                            0f to Color.Transparent,
+                                            0.48f to Color.Black.copy(alpha = 0.08f),
+                                            1f to Color.Black.copy(alpha = 0.84f),
+                                        ),
+                                    ),
+                        )
+
+                        if (isActive && isPlaying) {
+                            Surface(
+                                color = MaterialTheme.colorScheme.primary,
+                                contentColor = MaterialTheme.colorScheme.onPrimary,
+                                shape = CircleShape,
+                                tonalElevation = 2.dp,
                                 modifier =
                                     Modifier
-                                        .size(artSize)
-                                        .clip(RoundedCornerShape(18.dp)),
-                            )
-                            Spacer(Modifier.height(10.dp))
+                                        .align(Alignment.TopEnd)
+                                        .padding(14.dp)
+                                        .size(36.dp),
+                            ) {
+                                Box(contentAlignment = Alignment.Center) {
+                                    Icon(
+                                        painter = painterResource(R.drawable.volume_up),
+                                        contentDescription = null,
+                                        modifier = Modifier.size(19.dp),
+                                    )
+                                }
+                            }
+                        }
+
+                        Column(
+                            verticalArrangement = Arrangement.spacedBy(2.dp),
+                            modifier =
+                                Modifier
+                                    .align(Alignment.BottomStart)
+                                    .padding(20.dp),
+                        ) {
                             Text(
                                 text = song.song.title,
-                                style = MaterialTheme.typography.titleSmall,
-                                fontWeight = FontWeight.SemiBold,
+                                style = MaterialTheme.typography.titleLargeEmphasized,
+                                color = Color.White,
                                 maxLines = 2,
                                 overflow = TextOverflow.Ellipsis,
                             )
                             Text(
                                 text = song.artists.joinToString { it.name },
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = Color.White.copy(alpha = 0.78f),
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis,
                             )

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/MusicTogetherScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/MusicTogetherScreen.kt
@@ -690,24 +690,6 @@ private fun HostControlsCard(
         subtitleResId = R.string.together_display_name,
         accent = MaterialTheme.colorScheme.primary,
     ) {
-        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-            SegmentedButton(
-                selected = !host.onlineMode,
-                onClick = { viewModel.setHostModeOnline(false) },
-                shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
-                icon = {},
-            ) {
-                Text(text = stringResource(R.string.together_lan))
-            }
-            SegmentedButton(
-                selected = host.onlineMode,
-                onClick = { viewModel.setHostModeOnline(true) },
-                shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
-                icon = {},
-            ) {
-                Text(text = stringResource(R.string.together_online))
-            }
-        }
         SettingsRow(
             iconResId = R.drawable.person,
             titleResId = R.string.together_display_name,
@@ -777,26 +759,6 @@ private fun JoinControlsCard(
         subtitleResId = R.string.join_session,
         accent = MaterialTheme.colorScheme.tertiary,
     ) {
-        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-            SegmentedButton(
-                selected = !join.onlineMode,
-                enabled = !join.disabled,
-                onClick = { viewModel.setJoinModeOnline(false) },
-                shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
-                icon = {},
-            ) {
-                Text(text = stringResource(R.string.together_join_link))
-            }
-            SegmentedButton(
-                selected = join.onlineMode,
-                enabled = !join.disabled,
-                onClick = { viewModel.setJoinModeOnline(true) },
-                shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
-                icon = {},
-            ) {
-                Text(text = stringResource(R.string.together_join_code))
-            }
-        }
         SettingsRow(
             iconResId = R.drawable.input,
             titleResId = R.string.join_session,

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/SettingsScreen.kt
@@ -19,10 +19,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -33,6 +35,8 @@ import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -111,6 +115,24 @@ fun SettingsScreen(
             Updater.isUpdateAvailable(latestVersionName, BuildConfig.VERSION_NAME)
     var isUpdateDismissed by remember { mutableStateOf(false) }
     val settingsGroups = buildSettingsGroups(navController, isAndroid12OrLater, hasUpdate, context)
+    var searchQuery by remember { mutableStateOf("") }
+    val visibleGroups =
+        remember(searchQuery, settingsGroups) {
+            val query = searchQuery.trim().lowercase()
+            if (query.isEmpty()) {
+                settingsGroups
+            } else {
+                settingsGroups.mapNotNull { group ->
+                    val items =
+                        group.items.filter { item ->
+                            item.title.lowercase().contains(query) ||
+                                item.subtitle.orEmpty().lowercase().contains(query) ||
+                                item.key.lowercase().contains(query)
+                        }
+                    if (items.isEmpty()) null else group.copy(items = items)
+                }
+            }
+        }
 
     Scaffold(
         modifier =
@@ -200,7 +222,44 @@ fun SettingsScreen(
                 }
             }
 
-            settingsGroups.forEachIndexed { groupIndex, group ->
+            item(key = "search_bar", contentType = "search_bar") {
+                TextField(
+                    value = searchQuery,
+                    onValueChange = { searchQuery = it },
+                    placeholder = {
+                        Text(
+                            text = stringResource(R.string.search_settings),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    },
+                    leadingIcon = {
+                        Icon(
+                            painter = painterResource(R.drawable.search),
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    },
+                    singleLine = true,
+                    shape = RoundedCornerShape(28.dp),
+                    colors =
+                        TextFieldDefaults.colors(
+                            focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                            focusedIndicatorColor = MaterialTheme.colorScheme.primary,
+                            unfocusedIndicatorColor = androidx.compose.ui.graphics.Color.Transparent,
+                        ),
+                    modifier =
+                        Modifier
+                            .padding(horizontal = SettingsDimensions.SegmentedGroupHorizontalPadding)
+                            .fillMaxWidth(),
+                )
+            }
+
+            item(key = "search_spacing", contentType = "spacing") {
+                Spacer(modifier = Modifier.height(SettingsDimensions.SectionSpacing))
+            }
+
+            visibleGroups.forEachIndexed { groupIndex, group ->
                 if (groupIndex > 0) {
                     item(
                         key = "settings_group_spacing_$groupIndex",

--- a/app/src/main/kotlin/dev/citali/lunartune/viewmodels/AboutViewModel.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/viewmodels/AboutViewModel.kt
@@ -492,6 +492,21 @@ class AboutViewModel
                                     ),
                                 ),
                         ),
+                        TeamMember(
+                            avatarUrl = "https://avatars.githubusercontent.com/vivizzz007?v=4",
+                            name = "Vivi Music",
+                            positionResId = R.string.about_position_vivi,
+                            profileUrl = "https://github.com/vivizzz007/vivi-music",
+                            links =
+                                AboutLinkCollection.of(
+                                    AboutLinkUiModel(
+                                        id = "github",
+                                        iconResId = R.drawable.github,
+                                        labelResId = R.string.about_content_desc_github,
+                                        url = "https://github.com/vivizzz007/vivi-music",
+                                    ),
+                                ),
+                        ),
                     ),
                 contributorsState = contributorsState,
                 contributorsReadMoreUrl = ContributorsReadMoreUrl,

--- a/app/src/main/kotlin/dev/citali/lunartune/viewmodels/EqualizerViewModel.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/viewmodels/EqualizerViewModel.kt
@@ -244,6 +244,14 @@ class EqualizerViewModel
 
         fun applyPreset(presetId: String) {
             draft.value = EqualizerDraft()
+            if (presetId.startsWith("vivi:")) {
+                val curve = ViviEqualizerPresets.levelsMb(presetId.removePrefix("vivi:")) ?: return
+                val count = configuration?.capabilities?.bandCount ?: curve.size
+                launchUpdate {
+                    updateEqualizer.updateBandLevels(resampleLevels(curve, count))
+                }
+                return
+            }
             if (!applyPreset.invoke(presetId)) {
                 effectsFlow.tryEmit(EqualizerEffect.ShowMessage(R.string.eq_waiting_for_audio_session))
             }
@@ -448,6 +456,9 @@ private fun EqualizerConfiguration.toUiModel(
             capabilities.systemPresets.mapIndexed { index, name ->
                 val id = "system:$index"
                 EqualizerPresetUiModel(id, name, selectedProfileId == id)
+            } +
+            ViviEqualizerPresets.chips.map { (id, name) ->
+                EqualizerPresetUiModel("vivi:$id", name, selectedProfileId == "vivi:$id")
             }
     return EqualizerUiModel(
         enabled = settings.enabled,

--- a/app/src/main/kotlin/dev/citali/lunartune/viewmodels/EqualizerViewModel.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/viewmodels/EqualizerViewModel.kt
@@ -34,6 +34,7 @@ import dev.citali.lunartune.equalizer.EqualizerTone
 import dev.citali.lunartune.equalizer.ManageEqualizerProfilesUseCase
 import dev.citali.lunartune.equalizer.ObserveEqualizerUseCase
 import dev.citali.lunartune.equalizer.UpdateEqualizerUseCase
+import dev.citali.lunartune.equalizer.ViviEqualizerPresets
 import dev.citali.lunartune.equalizer.equalizerToneIndices
 import dev.citali.lunartune.equalizer.resampleLevels
 import dev.citali.lunartune.playback.EqProfile

--- a/app/src/main/kotlin/dev/citali/lunartune/viewmodels/MusicTogetherViewModel.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/viewmodels/MusicTogetherViewModel.kt
@@ -391,7 +391,7 @@ class MusicTogetherViewModel
                 updatePreferences.setLastJoinLink(trimmed)
             }
             sessionActions.joinSession(
-                mode = if (model.join.onlineMode) MusicTogetherConnectionMode.ONLINE else MusicTogetherConnectionMode.LAN,
+                mode = MusicTogetherConnectionMode.LAN,
                 rawInput = trimmed,
                 displayName = model.host.displayName,
             )

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -738,6 +738,7 @@
     <string name="about_position_developers">Developer | Team</string>
     <string name="about_position_yuki">dummy reze | Admin</string>
     <string name="about_position_mo_agamy">Playback client</string>
+    <string name="about_position_vivi">Dolby and Dirac equalizer presets</string>
     <string name="about_position_zion_huang">Creator of InnerTune · Foundation for Metrolist, LunarTune, and other forks</string>
     <string name="about_content_desc_github">GitHub</string>
     <string name="about_content_desc_website">Website</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -319,6 +319,7 @@
     <string name="queue_autoplaying_similar">Autoplaying similar music</string>
     <string name="music_player">Music Player</string>
     <string name="settings">Settings</string>
+    <string name="search_settings">Search settings</string>
     <string name="appearance">Appearance</string>
     <string name="app_icon_description">Choose the launcher icon</string>
     <string name="app_icon_default">Default</string>


### PR DESCRIPTION
## Summary
- Lyrics page: static pre-Android 12 album blur (no moving blur), and queue lyrics preload follows the count setting only so Low Data Mode no longer silently skips it.
- Settings: search field to filter preference groups.
- Equalizer: Vivi Music Dolby and Dirac 10-band millibel presets; credited in About and README.
- Listen Together: LAN only (online host/join controls removed) and a top-bar shortcut next to History.
- Home: original ArchiveTune Quick Picks hero carousel, with remote YouTube section first when available.

## Test plan
- [ ] Open lyrics on Android 11 or below and confirm a static blurred cover (not a drifting/moving blur).
- [ ] Confirm lyrics for upcoming queue tracks load without needing Low Data Mode off.
- [ ] Search settings and jump to a matching row.
- [ ] Apply Dolby/Dirac EQ chips and hear the curve change.
- [ ] Host/join Listen Together on LAN from the top bar; online mode should not appear.
- [ ] Home Quick Picks uses the original card carousel; YouTube remote picks show first when present.
