### PR TITLE
fix: queue bulk downloads and apply nav bar prefs on first frame

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/App.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/App.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import dev.citali.lunartune.canvas.LunarTuneCanvas
 import dev.citali.lunartune.constants.*
 import dev.citali.lunartune.extensions.*

--- a/app/src/main/kotlin/dev/citali/lunartune/App.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/App.kt
@@ -116,6 +116,9 @@ class App :
         }
         BotGuardTokenGenerator.initialize(this)
         PreferenceStore.start(this)
+        runBlocking {
+            PreferenceStore.awaitReady()
+        }
         Timber.plant(Timber.DebugTree())
         try {
             Timber.plant(

--- a/app/src/main/kotlin/dev/citali/lunartune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/constants/PreferenceKeys.kt
@@ -305,11 +305,11 @@ enum class PlayerStreamClient {
 
 val DefaultStreamSources =
     listOf(
-        PlayerStreamClient.VISION_OS,
-        PlayerStreamClient.ANDROID_VR,
         PlayerStreamClient.WEB_REMIX,
+        PlayerStreamClient.ANDROID_VR,
         PlayerStreamClient.TVHTML5,
         PlayerStreamClient.WEB_CREATOR,
+        PlayerStreamClient.VISION_OS,
     )
 
 fun PlayerStreamClient.isSelectableStreamSource(): Boolean = this in DefaultStreamSources

--- a/app/src/main/kotlin/dev/citali/lunartune/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/playback/DownloadUtil.kt
@@ -24,6 +24,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
@@ -32,6 +33,8 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import dev.citali.lunartune.constants.AudioQuality
 import dev.citali.lunartune.constants.AudioQualityKey
 import dev.citali.lunartune.db.MusicDatabase
@@ -69,7 +72,8 @@ class DownloadUtil
         private val audioQuality by enumPreference(context, AudioQualityKey, AudioQuality.AUTO)
         private val downloadScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         private val songUrlCache = ConcurrentHashMap<String, AuthScopedCacheValue>()
-        private val downloadExecutor = Executors.newFixedThreadPool(DEFAULT_MAX_PARALLEL_DOWNLOADS)
+        private val streamResolveMutex = Mutex()
+        private val downloadExecutor = Executors.newFixedThreadPool(MAX_PARALLEL_DOWNLOADS)
 
         private val mediaOkHttpClient: OkHttpClient by lazy {
             OkHttpClient
@@ -79,11 +83,11 @@ class DownloadUtil
                 .followSslRedirects(true)
                 .retryOnConnectionFailure(true)
                 .connectTimeout(30, TimeUnit.SECONDS)
-                .readTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(DOWNLOAD_READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
                 .dispatcher(
                     okhttp3.Dispatcher().apply {
                         maxRequests = MAX_DOWNLOAD_HTTP_REQUESTS
-                        maxRequestsPerHost = DEFAULT_MAX_PARALLEL_DOWNLOADS
+                        maxRequestsPerHost = MAX_DOWNLOAD_HTTP_REQUESTS
                     },
                 ).connectionPool(
                     ConnectionPool(
@@ -104,13 +108,18 @@ class DownloadUtil
                     if (!isYouTubeMediaHost) return@addInterceptor chain.proceed(request)
 
                     val requestProfile = StreamClientUtils.resolveRequestProfile(request.url)
-                    chain.proceed(
-                        StreamClientUtils
-                            .applyRequestProfile(
-                                request.newBuilder(),
-                                requestProfile,
-                            ).build(),
-                    )
+                    val response =
+                        chain.proceed(
+                            StreamClientUtils
+                                .applyRequestProfile(
+                                    request.newBuilder(),
+                                    requestProfile,
+                                ).build(),
+                        )
+                    if (response.code in STREAM_REFRESH_RESPONSE_CODES) {
+                        invalidateResolvedStreamUrl(request.url.toString())
+                    }
+                    response
                 }.build()
         }
 
@@ -182,7 +191,7 @@ class DownloadUtil
                 dataSourceFactory,
                 downloadExecutor,
             ).apply {
-                maxParallelDownloads = DEFAULT_MAX_PARALLEL_DOWNLOADS
+                maxParallelDownloads = MAX_PARALLEL_DOWNLOADS
                 addListener(
                     object : DownloadManager.Listener {
                         override fun onDownloadChanged(
@@ -190,6 +199,10 @@ class DownloadUtil
                             download: Download,
                             finalException: Exception?,
                         ) {
+                            if (finalException != null || download.state == Download.STATE_FAILED) {
+                                songUrlCache.keys.removeIf { it.startsWith("${download.request.id}:") }
+                                YTPlayerUtils.invalidateCachedStreamUrls(download.request.id)
+                            }
                             downloads.update { map ->
                                 map.toMutableMap().apply {
                                     set(download.request.id, download)
@@ -231,6 +244,14 @@ class DownloadUtil
         }
 
         fun getDownload(songId: String): Flow<Download?> = downloads.map { it[songId] }
+
+        private fun invalidateResolvedStreamUrl(url: String) {
+            songUrlCache.entries.forEach { (cacheKey, cached) ->
+                if (cached.url == url && songUrlCache.remove(cacheKey, cached)) {
+                    YTPlayerUtils.invalidateCachedStreamUrls(cacheKey.substringBefore(':'))
+                }
+            }
+        }
 
         private fun resolveDownloadAudioQuality(lowDataModeActive: Boolean): AudioQuality =
             if (lowDataModeActive) AudioQuality.LOW else audioQuality
@@ -303,10 +324,14 @@ class DownloadUtil
         }
 
         companion object {
-            private const val DEFAULT_MAX_PARALLEL_DOWNLOADS = 6
+            private const val MAX_PARALLEL_DOWNLOADS = 2
             private const val MAX_IDLE_DOWNLOAD_CONNECTIONS = 12
-            private const val MAX_DOWNLOAD_HTTP_REQUESTS = 24
+            private const val MAX_DOWNLOAD_HTTP_REQUESTS = 2
+            private const val DOWNLOAD_READ_TIMEOUT_SECONDS = 90L
+            private const val DOWNLOAD_STREAM_RESOLVE_ATTEMPTS = 3
+            private const val DOWNLOAD_STREAM_RESOLVE_RETRY_MS = 750L
             private const val DOWNLOAD_CONNECTION_KEEP_ALIVE_MINUTES = 5L
             private const val DOWNLOAD_WRITE_BUFFER_SIZE = 256 * 1024
+            private val STREAM_REFRESH_RESPONSE_CODES = setOf(403, 404, 410, 416)
         }
     }

--- a/app/src/main/kotlin/dev/citali/lunartune/playback/MusicService.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/playback/MusicService.kt
@@ -364,7 +364,7 @@ class MusicService :
     private val preferredStreamClient by enumPreference(
         this,
         PlayerStreamClientKey,
-        PlayerStreamClient.VISION_OS,
+        PlayerStreamClient.WEB_REMIX,
     )
     private val playbackUrlCache = ConcurrentHashMap<String, AuthScopedCacheValue>()
     private var nextMediaItemPrefetchJob: Job? = null

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/PlayerSettings.kt
@@ -205,7 +205,7 @@ fun PlayerSettings(navController: NavController) {
 
     LaunchedEffect(playerStreamClient) {
         if (playerStreamClient == PlayerStreamClient.ARCHIVETUNE_EXTRACTOR) {
-            onPlayerStreamClientChange(PlayerStreamClient.VISION_OS)
+            onPlayerStreamClientChange(PlayerStreamClient.WEB_REMIX)
         }
     }
 

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/StreamSourcesSettings.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/StreamSourcesSettings.kt
@@ -62,7 +62,7 @@ fun StreamSourcesSettings(navController: NavController) {
     val (orderRaw, onOrderRawChange) = rememberPreference(StreamSourcesOrderKey, defaultValue = "")
     val (enabledRaw, onEnabledRawChange) = rememberPreference(StreamSourcesEnabledKey, defaultValue = defaultEnabled)
     val (preferred, onPreferredChange) =
-        rememberEnumPreference(PlayerStreamClientKey, defaultValue = PlayerStreamClient.VISION_OS)
+        rememberEnumPreference(PlayerStreamClientKey, defaultValue = PlayerStreamClient.WEB_REMIX)
 
     val order = deserializeStreamSourcesOrder(orderRaw)
     val enabled =

--- a/app/src/main/kotlin/dev/citali/lunartune/utils/DataStore.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/utils/DataStore.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -99,6 +100,13 @@ object PreferenceStore {
         }
     }
 
+    suspend fun awaitReady(timeoutMs: Long = 1_500L): Preferences? =
+        withTimeoutOrNull(timeoutMs) {
+            _prefs.filterNotNull().first()
+        }
+
+    fun snapshot(): Preferences? = _prefs.value
+
     fun <T> get(key: Preferences.Key<T>): T? = _prefs.value?.get(key)
 
     fun launchEdit(
@@ -166,12 +174,13 @@ fun <T> rememberPreference(
 ): MutableState<T> {
     val context = LocalContext.current
 
+    val initialValue = PreferenceStore.get(key) ?: defaultValue
     val state =
         remember {
             context.dataStore.data
                 .map { it[key] ?: defaultValue }
                 .distinctUntilChanged()
-        }.collectAsState(defaultValue)
+        }.collectAsState(initialValue)
 
     return remember {
         object : MutableState<T> {

--- a/app/src/main/kotlin/dev/citali/lunartune/utils/PlaybackAuthPreferences.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/utils/PlaybackAuthPreferences.kt
@@ -32,8 +32,9 @@ fun Preferences.toPlaybackAuthState(): PlaybackAuthState =
         visitorData = this[VisitorDataKey],
         dataSyncId = this[DataSyncIdKey],
         poToken = this[PoTokenKey],
-        poTokenGvs = this[PoTokenGvsKey],
-        poTokenPlayer = this[PoTokenPlayerKey],
+        poTokenGvs = null,
+        poTokenGvsSession = this[PoTokenGvsKey],
+        poTokenPlayer = null,
         webClientPoTokenEnabled = this[WebClientPoTokenEnabledKey] ?: false,
     ).normalized()
 

--- a/app/src/main/kotlin/dev/citali/lunartune/utils/StreamClientUtils.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/utils/StreamClientUtils.kt
@@ -8,6 +8,13 @@
 package dev.citali.lunartune.utils
 
 import moe.rukamori.archivetune.innertube.models.YouTubeClient
+import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.ORIGIN_YOUTUBE
+import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.ORIGIN_YOUTUBE_MOBILE
+import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.ORIGIN_YOUTUBE_MUSIC
+import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.REFERER_YOUTUBE
+import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.REFERER_YOUTUBE_MOBILE
+import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.REFERER_YOUTUBE_MUSIC
+import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.REFERER_YOUTUBE_TV
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Request
@@ -58,8 +65,8 @@ object StreamClientUtils {
 
     /**
      * Determine the correct Origin and Referer for a YouTube media request.
-     * Web-type clients need YouTube Music origin; TV clients need YouTube origin.
-     * Other clients (native app clients) do not need these headers.
+     * Web, mobile web, YouTube Music, and TV clients use their corresponding
+     * YouTube origin; native app clients do not need these headers.
      *
      * @param clientParam  the value of the `c` query parameter
      * @return [OriginReferer] with appropriate values, or null fields if not needed
@@ -190,10 +197,18 @@ object StreamClientUtils {
             }
 
             clientName == "TVHTML5" -> {
-                YouTubeClient.TVHTML5
+                if (requestedClientVersion == YouTubeClient.TVHTML5_DOWNGRADED.clientVersion) {
+                    YouTubeClient.TVHTML5_DOWNGRADED
+                } else {
+                    YouTubeClient.TVHTML5
+                }
             }
 
-            clientName == "TVHTML5_SIMPLY_EMBEDDED_PLAYER" || clientName == "TVHTML5_SIMPLY" -> {
+            clientName == "TVHTML5_SIMPLY" -> {
+                YouTubeClient.TVHTML5_SIMPLY
+            }
+
+            clientName == "TVHTML5_SIMPLY_EMBEDDED_PLAYER" -> {
                 YouTubeClient.TVHTML5_SIMPLY_EMBEDDED_PLAYER
             }
 
@@ -227,6 +242,7 @@ object StreamClientUtils {
 
             clientName.startsWith("ANDROID_VR") -> {
                 when (requestedClientVersion) {
+                    YouTubeClient.ANDROID_VR_NO_AUTH.clientVersion -> YouTubeClient.ANDROID_VR_NO_AUTH
                     YouTubeClient.ANDROID_VR_1_65_10.clientVersion -> YouTubeClient.ANDROID_VR_1_65_10
                     YouTubeClient.ANDROID_VR_1_61_48.clientVersion -> YouTubeClient.ANDROID_VR_1_61_48
                     YouTubeClient.ANDROID_VR_1_43_32.clientVersion -> YouTubeClient.ANDROID_VR_1_43_32
@@ -251,11 +267,19 @@ object StreamClientUtils {
     private fun resolveOriginReferer(client: YouTubeClient): OriginReferer =
         when {
             isTvClient(client) -> {
-                OriginReferer(YouTubeClient.ORIGIN_YOUTUBE, YouTubeClient.REFERER_YOUTUBE_TV)
+                OriginReferer(ORIGIN_YOUTUBE, REFERER_YOUTUBE_TV)
             }
 
-            isWebMusicClient(client) -> {
-                OriginReferer(YouTubeClient.ORIGIN_YOUTUBE_MUSIC, YouTubeClient.REFERER_YOUTUBE_MUSIC)
+            isMobileWebClient(client) -> {
+                OriginReferer(ORIGIN_YOUTUBE_MOBILE, REFERER_YOUTUBE_MOBILE)
+            }
+
+            isMusicWebClient(client) -> {
+                OriginReferer(ORIGIN_YOUTUBE_MUSIC, REFERER_YOUTUBE_MUSIC)
+            }
+
+            isYouTubeWebClient(client) -> {
+                OriginReferer(ORIGIN_YOUTUBE, REFERER_YOUTUBE)
             }
 
             else -> {
@@ -263,19 +287,27 @@ object StreamClientUtils {
             }
         }
 
-    private fun isWebLikeClient(client: YouTubeClient): Boolean = isTvClient(client) || isWebMusicClient(client)
+    private fun isWebLikeClient(client: YouTubeClient): Boolean =
+        isTvClient(client) ||
+            isMobileWebClient(client) ||
+            isMusicWebClient(client) ||
+            isYouTubeWebClient(client)
 
     private fun isTvClient(client: YouTubeClient): Boolean {
         val clientName = client.clientName.uppercase(Locale.US)
         return clientName == "TVHTML5" || clientName == "TVHTML5_SIMPLY_EMBEDDED_PLAYER" || clientName == "TVHTML5_SIMPLY"
     }
 
-    private fun isWebMusicClient(client: YouTubeClient): Boolean {
+    private fun isMusicWebClient(client: YouTubeClient): Boolean =
+        client.clientName.equals("WEB_REMIX", ignoreCase = true)
+
+    private fun isMobileWebClient(client: YouTubeClient): Boolean =
+        client.clientName.equals("MWEB", ignoreCase = true)
+
+    private fun isYouTubeWebClient(client: YouTubeClient): Boolean {
         val clientName = client.clientName.uppercase(Locale.US)
         return clientName == "WEB" ||
-            clientName == "WEB_REMIX" ||
             clientName == "WEB_CREATOR" ||
-            clientName == "MWEB" ||
             clientName == "WEB_EMBEDDED_PLAYER"
     }
 

--- a/app/src/main/kotlin/dev/citali/lunartune/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/utils/YTPlayerUtils.kt
@@ -24,16 +24,23 @@ import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.ANDROID
 import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.ANDROID_MUSIC
 import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.ANDROID_TESTSUITE
 import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.ANDROID_UNPLUGGED
+import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.ANDROID_VR_1_43_32
+import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.ANDROID_VR_1_61_48
 import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.ANDROID_VR_1_65_10
+import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.ANDROID_VR_NO_AUTH
 import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.IOS
 import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.IOS_MUSIC
 import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.IPADOS
 import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.MOBILE
+import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.MWEB
 import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.TVHTML5
+import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.TVHTML5_DOWNGRADED
+import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.TVHTML5_SIMPLY
 import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.TVHTML5_SIMPLY_EMBEDDED_PLAYER
 import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.VISIONOS
 import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.WEB
 import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.WEB_CREATOR
+import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.WEB_EMBEDDED
 import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.WEB_PRIMARY
 import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.WEB_REMIX
 import moe.rukamori.archivetune.innertube.models.response.PlayerResponse
@@ -103,7 +110,9 @@ object YTPlayerUtils {
 
     class BadStreamPlayerResponseException(
         val videoId: String,
-    ) : IllegalStateException("YouTube playback stream clients returned no playable response")
+        val failedClients: Set<String> = emptySet(),
+        cause: Throwable? = null,
+    ) : IllegalStateException("YouTube playback stream clients returned no playable response", cause)
 
     private data class PlaybackGateFailure(
         val clientName: String,
@@ -122,13 +131,36 @@ object YTPlayerUtils {
      */
     private val MAIN_CLIENT: YouTubeClient = WEB_REMIX
 
+    private val ANONYMOUS_WEB_EMBEDDED_CLIENT: YouTubeClient =
+        WEB_EMBEDDED.copy(
+            supportsCookieAuthentication = false,
+            friendlyName = "Web Embedded Player (Anonymous)",
+        )
+
+    private val ANONYMOUS_MWEB_CLIENT: YouTubeClient =
+        MWEB.copy(
+            supportsCookieAuthentication = false,
+            friendlyName = "Mobile Web (Anonymous)",
+        )
+
     /**
      * Clients used for fallback streams in case the streams of the main client do not work.
      */
     private val STREAM_FALLBACK_CLIENTS: Array<YouTubeClient> =
         arrayOf(
-            WEB_REMIX,
+            ANDROID_VR_NO_AUTH,
             ANDROID_VR_1_65_10,
+            ANDROID_VR_1_61_48,
+            ANDROID_VR_1_43_32,
+            TVHTML5_DOWNGRADED,
+            WEB_EMBEDDED,
+            WEB_CREATOR,
+            WEB_REMIX,
+            MWEB,
+            WEB,
+            WEB_PRIMARY,
+            TVHTML5,
+            TVHTML5_SIMPLY,
             IOS,
             MOBILE,
             ANDROID_MUSIC,
@@ -138,10 +170,7 @@ object YTPlayerUtils {
             ANDROID_UNPLUGGED,
             IPADOS,
             VISIONOS,
-            TVHTML5,
             TVHTML5_SIMPLY_EMBEDDED_PLAYER,
-            WEB,
-            WEB_CREATOR,
         )
 
     private data class CachedStreamUrl(
@@ -178,7 +207,20 @@ object YTPlayerUtils {
 
     suspend fun recoverFromBadStreamPlayerResponse(videoId: String) {
         BotGuardTokenGenerator.invalidateAll()
-        val authState = YouTube.currentPlaybackAuthState()
+        val authState =
+            YouTube
+                .currentPlaybackAuthState()
+                .copy(
+                    poToken = null,
+                    poTokenGvs = null,
+                    poTokenGvsSession = null,
+                    poTokenGvsVideoId = null,
+                    poTokenPlayer = null,
+                    poTokenPlayerVideoId = null,
+                    poTokenSubs = null,
+                    poTokenSubsVideoId = null,
+                    webClientPoTokenEnabled = false,
+                ).normalized()
         val refreshedAuthState =
             ensureVisitorDataReady(
                 videoId = videoId,
@@ -231,6 +273,22 @@ object YTPlayerUtils {
     ): PlaybackAuthState {
         var repairedAuthState = authState
 
+        if (authState.webClientPoTokenEnabled && !authState.sessionId.isNullOrBlank()) {
+            BotGuardTokenGenerator.invalidateAll()
+            repairedAuthState =
+                repairedAuthState
+                    .copy(
+                        poToken = null,
+                        poTokenGvs = null,
+                        poTokenGvsSession = null,
+                        poTokenGvsVideoId = null,
+                        poTokenPlayer = null,
+                        poTokenPlayerVideoId = null,
+                        poTokenSubs = null,
+                        poTokenSubsVideoId = null,
+                    ).normalized()
+        }
+
         if (authState.hasLoginCookie) {
             val activeChannel =
                 YouTube
@@ -254,14 +312,19 @@ object YTPlayerUtils {
                             dataSyncId = refreshedDataSyncId,
                             poToken = null,
                             poTokenGvs = null,
+                            poTokenGvsSession = null,
+                            poTokenGvsVideoId = null,
                             poTokenPlayer = null,
+                            poTokenPlayerVideoId = null,
+                            poTokenSubs = null,
+                            poTokenSubsVideoId = null,
                         ).normalized()
             }
         }
 
         if (
             repairedAuthState.visitorData.isNullOrBlank() ||
-            !hasCompleteWebPlaybackPoToken(repairedAuthState)
+            !hasWebGvsPoToken(repairedAuthState, videoId)
         ) {
             repairedAuthState =
                 ensureVisitorDataReady(
@@ -272,7 +335,7 @@ object YTPlayerUtils {
                 )
         }
 
-        if (!hasCompleteWebPlaybackPoToken(repairedAuthState)) {
+        if (!hasWebGvsPoToken(repairedAuthState, videoId)) {
             repairedAuthState = mintWebPlaybackPoTokens(videoId, repairedAuthState)
         }
 
@@ -284,10 +347,12 @@ object YTPlayerUtils {
         return repairedAuthState
     }
 
-    private fun hasCompleteWebPlaybackPoToken(authState: PlaybackAuthState): Boolean =
+    private fun hasWebGvsPoToken(
+        authState: PlaybackAuthState,
+        videoId: String,
+    ): Boolean =
         authState.webClientPoTokenEnabled &&
-            !authState.resolvePlayerPoToken(WEB_REMIX).isNullOrBlank() &&
-            !authState.resolveGvsPoToken(WEB_REMIX).isNullOrBlank()
+            !authState.resolveGvsPoToken(WEB_CREATOR, videoId).isNullOrBlank()
 
     private suspend fun mintWebPlaybackPoTokens(
         videoId: String,
@@ -295,14 +360,22 @@ object YTPlayerUtils {
     ): PlaybackAuthState {
         val sessionId = authState.sessionId ?: return authState
         val tokenResult = BotGuardTokenGenerator.mintToken(videoId, sessionId) ?: return authState
-        return authState.withGeneratedPoTokens(tokenResult)
+        return authState.withGeneratedPoTokens(videoId, tokenResult)
     }
 
-    private fun PlaybackAuthState.withGeneratedPoTokens(tokenResult: PoTokenResult): PlaybackAuthState {
+    private fun PlaybackAuthState.withGeneratedPoTokens(
+        videoId: String,
+        tokenResult: PoTokenResult,
+    ): PlaybackAuthState {
         val updatedAuthState =
             copy(
-                poTokenGvs = tokenResult.sessionToken,
+                poTokenGvs = tokenResult.playerToken,
+                poTokenGvsSession = tokenResult.sessionToken,
+                poTokenGvsVideoId = videoId,
                 poTokenPlayer = tokenResult.playerToken,
+                poTokenPlayerVideoId = videoId,
+                poTokenSubs = tokenResult.playerToken,
+                poTokenSubsVideoId = videoId,
                 webClientPoTokenEnabled = true,
             ).normalized()
         val currentAuthState = YouTube.currentPlaybackAuthState()
@@ -310,8 +383,13 @@ object YTPlayerUtils {
             YouTube.authState =
                 currentAuthState
                     .copy(
-                        poTokenGvs = tokenResult.sessionToken,
+                        poTokenGvs = tokenResult.playerToken,
+                        poTokenGvsSession = tokenResult.sessionToken,
+                        poTokenGvsVideoId = videoId,
                         poTokenPlayer = tokenResult.playerToken,
+                        poTokenPlayerVideoId = videoId,
+                        poTokenSubs = tokenResult.playerToken,
+                        poTokenSubsVideoId = videoId,
                         webClientPoTokenEnabled = true,
                     ).normalized()
         }
@@ -328,7 +406,12 @@ object YTPlayerUtils {
             dataSyncId = null,
             poToken = null,
             poTokenGvs = null,
+            poTokenGvsSession = null,
+            poTokenGvsVideoId = null,
             poTokenPlayer = null,
+            poTokenPlayerVideoId = null,
+            poTokenSubs = null,
+            poTokenSubsVideoId = null,
         ).normalized()
 
     internal fun shouldSkipCipheredWebPlaybackCandidate(
@@ -423,23 +506,19 @@ object YTPlayerUtils {
     ): YouTubeClient =
         when (preferredStreamClient) {
             PlayerStreamClient.VISION_OS -> {
-                VISIONOS
+                WEB_REMIX
             }
 
             PlayerStreamClient.ANDROID_VR -> {
-                if (authState.hasPlaybackLoginContext && !hasCompleteWebPlaybackPoToken(authState)) {
-                    WEB_PRIMARY
-                } else {
-                    ANDROID_VR_1_65_10
-                }
+                ANDROID_VR_NO_AUTH
+            }
+
+            PlayerStreamClient.WEB_CREATOR -> {
+                WEB_CREATOR
             }
 
             PlayerStreamClient.WEB_REMIX -> {
-                if (authState.hasPlaybackLoginContext && !hasCompleteWebPlaybackPoToken(authState)) {
-                    WEB_PRIMARY
-                } else {
-                    WEB_REMIX
-                }
+                WEB_REMIX
             }
 
             PlayerStreamClient.ARCHIVETUNE_EXTRACTOR -> {
@@ -472,19 +551,23 @@ object YTPlayerUtils {
         authState: PlaybackAuthState,
     ): List<YouTubeClient> {
         val preferredYouTubeClient = resolvePreferredPlaybackClient(preferredStreamClient, authState)
-        val hasCompleteWebPoTokens = hasCompleteWebPlaybackPoToken(authState)
         val lastSuccessfulClient =
             lastSuccessfulClientKey?.let { key ->
                 STREAM_FALLBACK_CLIENTS.find { StreamClientUtils.buildClientKey(it) == key }
             }
 
         val orderedFallbackClients =
-            if (authState.hasPlaybackLoginContext && hasCompleteWebPoTokens) {
-                STREAM_FALLBACK_CLIENTS.filter { it.supportsCookieAuthentication } +
-                    STREAM_FALLBACK_CLIENTS.filterNot { it.supportsCookieAuthentication }
-            } else {
-                STREAM_FALLBACK_CLIENTS.filterNot { it.supportsCookieAuthentication } +
-                    STREAM_FALLBACK_CLIENTS.filter { it.supportsCookieAuthentication }
+            buildList {
+                STREAM_FALLBACK_CLIENTS.forEach { client ->
+                    add(client)
+                    if (authState.hasPlaybackLoginContext) {
+                        when (client) {
+                            WEB_EMBEDDED -> add(ANONYMOUS_WEB_EMBEDDED_CLIENT)
+                            MWEB -> add(ANONYMOUS_MWEB_CLIENT)
+                            else -> Unit
+                        }
+                    }
+                }
             }
 
         return buildList {
@@ -492,9 +575,6 @@ object YTPlayerUtils {
             lastSuccessfulClient
                 ?.takeIf { it != preferredYouTubeClient }
                 ?.let { add(it) }
-            if (authState.hasPlaybackLoginContext && hasCompleteWebPoTokens) {
-                add(WEB_REMIX)
-            }
             addAll(orderedFallbackClients)
             if (preferredYouTubeClient != MAIN_CLIENT) add(MAIN_CLIENT)
             if (preferredStreamClient == PlayerStreamClient.WEB_REMIX) {
@@ -764,7 +844,17 @@ object YTPlayerUtils {
                     reason = if (hasLoginCookie) "cookie-only playback fallback" else "anonymous playback bootstrap",
                 )
         }
-        val sessionId = authState.sessionId
+        var sessionId = authState.sessionId
+        if (!sessionId.isNullOrBlank()) {
+            try {
+                authState = mintWebPlaybackPoTokens(videoId, authState)
+                sessionId = authState.sessionId
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (e: Exception) {
+                Timber.tag(logTag).w(e, "PoToken generation failed for playback request")
+            }
+        }
         val authStatus =
             when {
                 canUseLoggedInPlayback -> "Logged in"
@@ -779,11 +869,12 @@ object YTPlayerUtils {
         var streamPlayerResponse: PlayerResponse? = null
         var streamClientUsed: YouTubeClient? = null
         var didRepairAuthAfterBotDetection = false
-        var didRetryWithoutRejectedLoginContext = false
         var didAttemptGvsPoTokenRecovery = false
+        val failedPlayerClients = linkedSetOf<String>()
+        val playerRequestFailures = mutableListOf<Throwable>()
 
         var metadataClient =
-            if (authState.hasPlaybackLoginContext && !hasCompleteWebPlaybackPoToken(authState)) {
+            if (authState.hasPlaybackLoginContext && !hasWebGvsPoToken(authState, videoId)) {
                 WEB_PRIMARY
             } else {
                 MAIN_CLIENT
@@ -791,16 +882,7 @@ object YTPlayerUtils {
 
         Timber.tag(logTag).i("Fetching metadata response using client: ${metadataClient.clientName}")
 
-        if (metadataClient.useWebPoTokens && sessionId != null) {
-            try {
-                authState = mintWebPlaybackPoTokens(videoId, authState)
-            } catch (cancellation: CancellationException) {
-                throw cancellation
-            } catch (e: Exception) {
-                Timber.tag(logTag).w(e, "PoToken generation failed for metadata request")
-            }
-        }
-        var metadataPoToken = authState.resolvePlayerPoToken(metadataClient)
+        var metadataPoToken = authState.resolvePlayerPoToken(metadataClient, videoId = videoId)
 
         var metadataResult =
             YouTube.player(
@@ -830,10 +912,11 @@ object YTPlayerUtils {
             clearPlaybackAuthCaches()
 
             val newSessionId = authState.sessionId
-            if (metadataClient.useWebPoTokens && newSessionId != null) {
+            if (newSessionId != null) {
                 try {
                     authState = mintWebPlaybackPoTokens(videoId, authState)
-                    metadataPoToken = authState.resolvePlayerPoToken(metadataClient)
+                    sessionId = authState.sessionId
+                    metadataPoToken = authState.resolvePlayerPoToken(metadataClient, videoId = videoId)
                 } catch (cancellation: CancellationException) {
                     throw cancellation
                 } catch (e: Exception) {
@@ -872,6 +955,18 @@ object YTPlayerUtils {
                         setLogin = useCookieAuthentication,
                         authState = authState,
                     )
+                val fallbackFailure = fallbackResult.exceptionOrNull()
+                if (fallbackFailure != null) {
+                    if (fallbackFailure is CancellationException) throw fallbackFailure
+                    failedPlayerClients += describeClient(fallbackClient)
+                    playerRequestFailures += fallbackFailure
+                    Timber.tag(logTag).w(
+                        fallbackFailure,
+                        "Metadata fallback player request failed for %s via %s",
+                        videoId,
+                        describeClient(fallbackClient),
+                    )
+                }
                 val fallbackResponse = fallbackResult.getOrNull() ?: continue
                 if (fallbackResponse.playabilityStatus.status != "OK") continue
 
@@ -929,7 +1024,7 @@ object YTPlayerUtils {
                     client != WEB_PRIMARY &&
                     authState.sessionId != null &&
                     PlaybackAuthState.supportsGvsPoToken(client) &&
-                    authState.resolveGvsPoToken(client).isNullOrBlank()
+                    authState.resolveGvsPoToken(client, videoId).isNullOrBlank()
             ) {
                 didAttemptGvsPoTokenRecovery = true
                 try {
@@ -961,7 +1056,19 @@ object YTPlayerUtils {
                             signatureTimestamp = signatureTimestamp,
                             setLogin = requestUsesCookieAuthentication,
                             authState = authState,
-                        ).getPlaybackPlayerResponseOrNull(videoId, authState)
+                        ).also { result ->
+                            result.exceptionOrNull()?.let { failure ->
+                                if (failure is CancellationException) throw failure
+                                failedPlayerClients += describeClient(client)
+                                playerRequestFailures += failure
+                                Timber.tag(logTag).w(
+                                    failure,
+                                    "Stream player request failed for %s via %s",
+                                    videoId,
+                                    describeClient(client),
+                                )
+                            }
+                        }.getPlaybackPlayerResponseOrNull(videoId, authState)
                 }
 
             if (streamPlayerResponse == null) continue
@@ -972,54 +1079,6 @@ object YTPlayerUtils {
                 var isLoginRecovery = isLoginRecoveryResponse(playabilityStatus.status, reason)
                 var isBotDetection = isBotDetectionError(reason)
 
-                if (isLoginRecovery && requestUsesCookieAuthentication && !didRetryWithoutRejectedLoginContext) {
-                    didRetryWithoutRejectedLoginContext = true
-                    authState =
-                        ensureVisitorDataReady(
-                            videoId = videoId,
-                            authState = authState.withoutAccountBoundPlaybackState(),
-                            reason = "logged-in playback context rejected by ${client.clientName}",
-                        )
-                    canUseLoggedInPlayback = false
-                    requestUsesCookieAuthentication = false
-                    clearPlaybackAuthCaches()
-
-                    if (client.useWebPoTokens) {
-                        try {
-                            authState = mintWebPlaybackPoTokens(videoId, authState)
-                        } catch (cancellation: CancellationException) {
-                            throw cancellation
-                        } catch (e: Exception) {
-                            Timber.tag(logTag).w(e, "PoToken generation failed for visitor playback retry")
-                        }
-                    }
-
-                    if (!client.loginRequired) {
-                        Timber.tag(logTag).i(
-                            "Retrying %s for %s without the rejected login context",
-                            describeClient(client),
-                            videoId,
-                        )
-                        streamPlayerResponse =
-                            YouTube
-                                .player(
-                                    videoId = videoId,
-                                    playlistId = playlistId,
-                                    client = client,
-                                    signatureTimestamp = signatureTimestamp,
-                                    setLogin = false,
-                                    authState = authState,
-                                ).getPlaybackPlayerResponseOrNull(videoId, authState)
-
-                        if (streamPlayerResponse == null) continue
-
-                        playabilityStatus = streamPlayerResponse.playabilityStatus
-                        reason = playabilityStatus.reason.orEmpty()
-                        isLoginRecovery = isLoginRecoveryResponse(playabilityStatus.status, reason)
-                        isBotDetection = isBotDetectionError(reason)
-                    }
-                }
-
                 if (isBotDetection && !didRepairAuthAfterBotDetection) {
                     val repairedAuthState =
                         repairAuthStateAfterBotDetection(
@@ -1029,7 +1088,7 @@ object YTPlayerUtils {
                         )
                     val shouldUseWebRemix =
                         repairedAuthState.hasPlaybackLoginContext &&
-                            hasCompleteWebPlaybackPoToken(repairedAuthState) &&
+                            hasWebGvsPoToken(repairedAuthState, videoId) &&
                             client != WEB_REMIX
 
                     if (repairedAuthState.fingerprint != authState.fingerprint || shouldUseWebRemix) {
@@ -1129,7 +1188,7 @@ object YTPlayerUtils {
 
             for (candidate in candidates) {
                 if (canUseLoggedInPlayback && expectedDurationMs != null && isLikelyPreview(candidate, expectedDurationMs)) continue
-                if (shouldSkipCipheredWebCandidate(client, candidate, authState)) continue
+                if (shouldSkipCipheredWebCandidate(client, candidate, videoId, authState)) continue
                 val cacheKey = buildStreamCacheKey(videoId, candidate.itag, client, authState.fingerprint)
                 val cached = streamUrlCache[cacheKey]
                 val candidateResult =
@@ -1207,8 +1266,14 @@ object YTPlayerUtils {
                     clients = botDetectedClients.toSet(),
                 )
             }
-            Timber.tag(logTag).e("Bad stream player response - all clients failed")
-            throw BadStreamPlayerResponseException(videoId)
+            Timber.tag(logTag).e(
+                "Bad stream player response - all clients failed: $failedPlayerClients",
+            )
+            throw BadStreamPlayerResponseException(
+                videoId = videoId,
+                failedClients = failedPlayerClients,
+                cause = playerRequestFailures.firstOrNull(),
+            )
         }
 
         if (streamPlayerResponse.playabilityStatus.status != "OK") {
@@ -1310,7 +1375,7 @@ object YTPlayerUtils {
                 playlistId = playlistId,
                 client = MAIN_CLIENT,
                 signatureTimestamp = signatureTimestamp,
-                poToken = resolvedAuthState.resolvePlayerPoToken(MAIN_CLIENT),
+                poToken = resolvedAuthState.resolvePlayerPoToken(MAIN_CLIENT, videoId = videoId),
                 setLogin = true,
                 authState = resolvedAuthState,
             ).onSuccess { Timber.tag(logTag).d("Successfully fetched metadata") }
@@ -1426,11 +1491,12 @@ object YTPlayerUtils {
     private fun shouldSkipCipheredWebCandidate(
         client: YouTubeClient,
         format: PlayerResponse.StreamingData.Format,
+        videoId: String,
         authState: PlaybackAuthState,
     ): Boolean {
-        val isWebClient = StreamClientUtils.isWebClient(client.clientName)
+        val isWebClient = PlaybackAuthState.supportsGvsPoToken(client)
         val isCiphered = isCipheredFormat(format)
-        val hasGvsPoToken = !authState.resolveGvsPoToken(client).isNullOrBlank()
+        val hasGvsPoToken = !authState.resolveGvsPoToken(client, videoId).isNullOrBlank()
         if (
             !shouldSkipCipheredWebPlaybackCandidate(
                 webClientPoTokenEnabled = authState.webClientPoTokenEnabled,
@@ -1617,6 +1683,14 @@ object YTPlayerUtils {
         var cause: Throwable? = error
         while (cause != null) {
             if (cause is BadStreamPlayerResponseException) return true
+            if (
+                cause.message?.contains(
+                    "YouTube playback stream clients returned no playable response",
+                    ignoreCase = true,
+                ) == true
+            ) {
+                return true
+            }
             cause = cause.cause
         }
         return false

--- a/app/src/main/kotlin/dev/citali/lunartune/viewmodels/EqualizerViewModel.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/viewmodels/EqualizerViewModel.kt
@@ -244,6 +244,14 @@ class EqualizerViewModel
 
         fun applyPreset(presetId: String) {
             draft.value = EqualizerDraft()
+            if (presetId.startsWith("vivi:")) {
+                val curve = ViviEqualizerPresets.levelsMb(presetId.removePrefix("vivi:")) ?: return
+                val count = configuration?.capabilities?.bandCount ?: curve.size
+                launchUpdate {
+                    updateEqualizer.updateBandLevels(resampleLevels(curve, count))
+                }
+                return
+            }
             if (!applyPreset.invoke(presetId)) {
                 effectsFlow.tryEmit(EqualizerEffect.ShowMessage(R.string.eq_waiting_for_audio_session))
             }
@@ -448,6 +456,9 @@ private fun EqualizerConfiguration.toUiModel(
             capabilities.systemPresets.mapIndexed { index, name ->
                 val id = "system:$index"
                 EqualizerPresetUiModel(id, name, selectedProfileId == id)
+            } +
+            ViviEqualizerPresets.chips.map { (id, name) ->
+                EqualizerPresetUiModel("vivi:$id", name, selectedProfileId == "vivi:$id")
             }
     return EqualizerUiModel(
         enabled = settings.enabled,

--- a/app/src/main/kotlin/dev/citali/lunartune/viewmodels/EqualizerViewModel.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/viewmodels/EqualizerViewModel.kt
@@ -244,14 +244,6 @@ class EqualizerViewModel
 
         fun applyPreset(presetId: String) {
             draft.value = EqualizerDraft()
-            if (presetId.startsWith("vivi:")) {
-                val curve = ViviEqualizerPresets.levelsMb(presetId.removePrefix("vivi:")) ?: return
-                val count = configuration?.capabilities?.bandCount ?: curve.size
-                launchUpdate {
-                    updateEqualizer.updateBandLevels(resampleLevels(curve, count))
-                }
-                return
-            }
             if (!applyPreset.invoke(presetId)) {
                 effectsFlow.tryEmit(EqualizerEffect.ShowMessage(R.string.eq_waiting_for_audio_session))
             }
@@ -456,9 +448,6 @@ private fun EqualizerConfiguration.toUiModel(
             capabilities.systemPresets.mapIndexed { index, name ->
                 val id = "system:$index"
                 EqualizerPresetUiModel(id, name, selectedProfileId == id)
-            } +
-            ViviEqualizerPresets.chips.map { (id, name) ->
-                EqualizerPresetUiModel("vivi:$id", name, selectedProfileId == "vivi:$id")
             }
     return EqualizerUiModel(
         enabled = settings.enabled,


### PR DESCRIPTION
## Summary
- Bulk downloads failed because six songs hit `/player` at once. ArchiveTune serializes this (`maxParallelDownloads = 1`). We resolve stream URLs one at a time (mutex), download at most two in parallel, retry expired/403 URLs, and clear failed cache entries.
- Nav bar flashed the default bar on launch because `rememberPreference` used the default until DataStore emitted. Prefs are now awaited in `App.onCreate` and used as the first Compose value.

Includes the playback-client fix from #19.

## Test plan
- [ ] Queue a large album/playlist download; songs should complete instead of all failing at 0%.
- [ ] Cold start: floating / custom nav bar should appear immediately, not after a default-bar flash.
