### PR TITLE
feat: navbar long-press actions and thinner player icons

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/MainActivity.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/MainActivity.kt
@@ -215,6 +215,7 @@ import dev.citali.lunartune.constants.NAVIGATION_BAR_HEIGHT_DEFAULT
 import dev.citali.lunartune.constants.NavigationBarHeight
 import dev.citali.lunartune.constants.NavigationBarHeightKey
 import dev.citali.lunartune.constants.NavigationBarHorizontalPadding
+import dev.citali.lunartune.constants.NavBarLongPressActionsKey
 import dev.citali.lunartune.constants.NavigationBarStyle
 import dev.citali.lunartune.constants.NavigationBarStyleKey
 import dev.citali.lunartune.constants.PauseSearchHistoryKey
@@ -1478,6 +1479,7 @@ class MainActivity : ComponentActivity() {
                                 else -> null
                             }
                         }
+                    val (navBarLongPressActions) = rememberPreference(NavBarLongPressActionsKey, defaultValue = true)
                     val haptic = LocalHapticFeedback.current
                     val (enableHapticFeedback) = rememberPreference(EnableHapticFeedbackKey, true)
                     val customHaptic =
@@ -2075,6 +2077,13 @@ class MainActivity : ComponentActivity() {
                                                 },
                                                 onItemClick = { screen, isSelected ->
                                                     handlePrimaryNavigationClick(screen, isSelected)
+                                                },
+                                                onItemLongClick = { screen ->
+                                                    when (screen) {
+                                                        Screens.Home -> playRandomHistorySong()
+                                                        Screens.Search -> navController.navigate(MusicRecognitionRoute)
+                                                        else -> Unit
+                                                    }
                                                 },
                                                 onSearchItemDoubleClick = {
                                                     searchSource = SearchSource.ONLINE
@@ -2963,6 +2972,129 @@ private fun HomeOverflowFab(
                         iconRes = R.drawable.shuffle,
                         contentDescription = stringResource(R.string.shuffle),
                         pureBlack = pureBlack,
+                    )
+                },
+                colors = menuItemColors,
+            )
+        }
+    }
+}
+
+@Composable
+private fun HomeOverflowMenuIcon(
+    @DrawableRes iconRes: Int,
+    contentDescription: String?,
+    pureBlack: Boolean,
+) {
+    Surface(
+        modifier = Modifier.size(HomeOverflowMenuIconSize),
+        shape = CircleShape,
+        color =
+            if (pureBlack) {
+                Color.White.copy(alpha = 0.12f)
+            } else {
+                MaterialTheme.colorScheme.secondaryContainer
+            },
+        contentColor = if (pureBlack) Color.White else MaterialTheme.colorScheme.onSecondaryContainer,
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Icon(
+                painter = painterResource(iconRes),
+                contentDescription = contentDescription,
+            )
+        }
+    }
+}
+
+private const val TopAppBarIconButtonContainerAlpha = 0.48f
+
+@Composable
+private fun TranslucentTopAppBarIconButton(
+    onClick: () -> Unit,
+    content: @Composable () -> Unit,
+) {
+    IconButton(
+        onClick = onClick,
+        colors =
+            IconButtonDefaults.iconButtonColors(
+                containerColor =
+                    MaterialTheme.colorScheme.surfaceContainerHighest.copy(
+                        alpha = TopAppBarIconButtonContainerAlpha,
+                    ),
+                contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            ),
+        content = content,
+    )
+}
+
+@Composable
+private fun OnlineSearchSortMenu(
+    selectedSort: OnlineSearchSort,
+    onSortSelected: (OnlineSearchSort) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val options =
+        remember {
+            listOf(
+                OnlineSearchSort.DEFAULT,
+                OnlineSearchSort.VIEWS,
+            )
+        }
+
+    Box {
+        IconButton(onClick = { expanded = true }) {
+            Icon(
+                painter = painterResource(R.drawable.filter_alt),
+                contentDescription = null,
+            )
+        }
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            options.forEach { sort ->
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text =
+                                stringResource(
+                                    when (sort) {
+                                        OnlineSearchSort.DEFAULT -> R.string.default_style
+                                        OnlineSearchSort.VIEWS -> R.string.views
+                                    },
+                                ),
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        onSortSelected(sort)
+                    },
+                    leadingIcon = {
+                        if (sort == selectedSort) {
+                            Icon(
+                                painter = painterResource(R.drawable.done),
+                                contentDescription = null,
+                            )
+                        } else {
+                            Spacer(Modifier.size(24.dp))
+                        }
+                    },
+                )
+            }
+        }
+    }
+}
+
+private fun Context.isTvDevice(): Boolean {
+    val isTelevisionUiMode =
+        (resources.configuration.uiMode and Configuration.UI_MODE_TYPE_MASK) ==
+            Configuration.UI_MODE_TYPE_TELEVISION
+    return isTelevisionUiMode ||
+        packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK) ||
+        packageManager.hasSystemFeature(PackageManager.FEATURE_TELEVISION)
+}
+ck = pureBlack,
                     )
                 },
                 colors = menuItemColors,

--- a/app/src/main/kotlin/dev/citali/lunartune/MainActivity.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/MainActivity.kt
@@ -2078,13 +2078,55 @@ class MainActivity : ComponentActivity() {
                                                 onItemClick = { screen, isSelected ->
                                                     handlePrimaryNavigationClick(screen, isSelected)
                                                 },
-                                                onItemLongClick = { screen ->
-                                                    when (screen) {
-                                                        Screens.Home -> playRandomHistorySong()
-                                                        Screens.Search -> navController.navigate(MusicRecognitionRoute)
-                                                        else -> Unit
-                                                    }
-                                                },
+                                                onItemLongClick =
+                                                    if (navBarLongPressActions) {
+                                                        { screen ->
+                                                            when (screen) {
+                                                                Screens.Home -> {
+                                                                    coroutineScope.launch {
+                                                                        val song =
+                                                                            withContext(Dispatchers.IO) {
+                                                                                val from =
+                                                                                    System.currentTimeMillis() -
+                                                                                        90L * 24 * 60 * 60 * 1000
+                                                                                val history =
+                                                                                    database
+                                                                                        .mostPlayedSongs(from, limit = 80)
+                                                                                        .first()
+                                                                                        .ifEmpty { database.recentSongs(80).first() }
+                                                                                history
+                                                                                    .filter { candidate ->
+                                                                                        candidate.artists.none { it.blockedAt != null }
+                                                                                    }.randomOrNull()
+                                                                                    ?: allLocalItems.filterIsInstance<Song>().randomOrNull()
+                                                                            }
+                                                                        if (song == null) {
+                                                                            Toast
+                                                                                .makeText(
+                                                                                    this@MainActivity,
+                                                                                    getString(R.string.navbar_long_press_no_history),
+                                                                                    Toast.LENGTH_SHORT,
+                                                                                ).show()
+                                                                            return@launch
+                                                                        }
+                                                                        playerConnection?.playQueue(
+                                                                            if (song.song.isLocal) {
+                                                                                ListQueue(items = listOf(song.toMediaItem()))
+                                                                            } else {
+                                                                                YouTubeQueue.radio(song.toMediaMetadata())
+                                                                            },
+                                                                        )
+                                                                    }
+                                                                }
+
+                                                                Screens.Search -> navController.navigate(MusicRecognitionRoute)
+
+                                                                else -> Unit
+                                                            }
+                                                        }
+                                                    } else {
+                                                        null
+                                                    },
                                                 onSearchItemDoubleClick = {
                                                     searchSource = SearchSource.ONLINE
                                                     openSearch()
@@ -2972,129 +3014,6 @@ private fun HomeOverflowFab(
                         iconRes = R.drawable.shuffle,
                         contentDescription = stringResource(R.string.shuffle),
                         pureBlack = pureBlack,
-                    )
-                },
-                colors = menuItemColors,
-            )
-        }
-    }
-}
-
-@Composable
-private fun HomeOverflowMenuIcon(
-    @DrawableRes iconRes: Int,
-    contentDescription: String?,
-    pureBlack: Boolean,
-) {
-    Surface(
-        modifier = Modifier.size(HomeOverflowMenuIconSize),
-        shape = CircleShape,
-        color =
-            if (pureBlack) {
-                Color.White.copy(alpha = 0.12f)
-            } else {
-                MaterialTheme.colorScheme.secondaryContainer
-            },
-        contentColor = if (pureBlack) Color.White else MaterialTheme.colorScheme.onSecondaryContainer,
-    ) {
-        Box(contentAlignment = Alignment.Center) {
-            Icon(
-                painter = painterResource(iconRes),
-                contentDescription = contentDescription,
-            )
-        }
-    }
-}
-
-private const val TopAppBarIconButtonContainerAlpha = 0.48f
-
-@Composable
-private fun TranslucentTopAppBarIconButton(
-    onClick: () -> Unit,
-    content: @Composable () -> Unit,
-) {
-    IconButton(
-        onClick = onClick,
-        colors =
-            IconButtonDefaults.iconButtonColors(
-                containerColor =
-                    MaterialTheme.colorScheme.surfaceContainerHighest.copy(
-                        alpha = TopAppBarIconButtonContainerAlpha,
-                    ),
-                contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-            ),
-        content = content,
-    )
-}
-
-@Composable
-private fun OnlineSearchSortMenu(
-    selectedSort: OnlineSearchSort,
-    onSortSelected: (OnlineSearchSort) -> Unit,
-) {
-    var expanded by remember { mutableStateOf(false) }
-    val options =
-        remember {
-            listOf(
-                OnlineSearchSort.DEFAULT,
-                OnlineSearchSort.VIEWS,
-            )
-        }
-
-    Box {
-        IconButton(onClick = { expanded = true }) {
-            Icon(
-                painter = painterResource(R.drawable.filter_alt),
-                contentDescription = null,
-            )
-        }
-
-        DropdownMenu(
-            expanded = expanded,
-            onDismissRequest = { expanded = false },
-        ) {
-            options.forEach { sort ->
-                DropdownMenuItem(
-                    text = {
-                        Text(
-                            text =
-                                stringResource(
-                                    when (sort) {
-                                        OnlineSearchSort.DEFAULT -> R.string.default_style
-                                        OnlineSearchSort.VIEWS -> R.string.views
-                                    },
-                                ),
-                        )
-                    },
-                    onClick = {
-                        expanded = false
-                        onSortSelected(sort)
-                    },
-                    leadingIcon = {
-                        if (sort == selectedSort) {
-                            Icon(
-                                painter = painterResource(R.drawable.done),
-                                contentDescription = null,
-                            )
-                        } else {
-                            Spacer(Modifier.size(24.dp))
-                        }
-                    },
-                )
-            }
-        }
-    }
-}
-
-private fun Context.isTvDevice(): Boolean {
-    val isTelevisionUiMode =
-        (resources.configuration.uiMode and Configuration.UI_MODE_TYPE_MASK) ==
-            Configuration.UI_MODE_TYPE_TELEVISION
-    return isTelevisionUiMode ||
-        packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK) ||
-        packageManager.hasSystemFeature(PackageManager.FEATURE_TELEVISION)
-}
-ck = pureBlack,
                     )
                 },
                 colors = menuItemColors,

--- a/app/src/main/kotlin/dev/citali/lunartune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/constants/PreferenceKeys.kt
@@ -954,6 +954,7 @@ enum class NavigationBarStyle {
 val NavigationBarStyleKey = stringPreferencesKey("navigationBarStyle")
 
 val HideNavigationBarLabelsKey = booleanPreferencesKey("hideNavigationBarLabels")
+val NavBarLongPressActionsKey = booleanPreferencesKey("navBarLongPressActions")
 
 val NavigationBarWidthKey = floatPreferencesKey("navigationBarWidth")
 const val NAVIGATION_BAR_WIDTH_DEFAULT = 0.8f

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/component/FloatingNavigationToolbar.kt
@@ -105,6 +105,7 @@ fun FloatingNavigationToolbar(
     style: NavigationBarStyle = NavigationBarStyle.DEFAULT,
     isSelected: (Screens) -> Boolean,
     onItemClick: (Screens, Boolean) -> Unit,
+    onItemLongClick: ((Screens) -> Unit)? = null,
     onSearchItemDoubleClick: (() -> Unit)? = null,
 ) {
     val isFloating = style == NavigationBarStyle.FLOATING
@@ -293,7 +294,7 @@ fun FloatingNavigationToolbar(
                                                     currentTime - lastClickTime.longValue <= ViewConfiguration.getDoubleTapTimeout()
                                             lastClickTime.longValue = if (isDoubleClick) 0L else currentTime
                                             if (isDoubleClick) {
-                                                onDoubleClick?.invoke()
+                                                onDoubleClick.invoke()
                                             } else {
                                                 onItemClick(screen, selected)
                                             }

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/component/FloatingNavigationToolbar.kt
@@ -12,6 +12,7 @@ package dev.citali.lunartune.ui.component
 import android.os.SystemClock
 import android.view.ViewConfiguration
 import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
@@ -59,6 +60,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalDensity
@@ -278,19 +280,23 @@ fun FloatingNavigationToolbar(
                                     if (screen == Screens.Search) onSearchItemDoubleClick else null
                                 }
                             val lastClickTime = remember(screen) { mutableLongStateOf(0L) }
+                            var ignoreNextClick by remember(screen) { mutableStateOf(false) }
                             val onClick =
                                 remember(screen, selected, onItemClick, onDoubleClick) {
                                     {
-                                        val currentTime = SystemClock.uptimeMillis()
-                                        val isDoubleClick =
-                                            onDoubleClick != null &&
-                                                currentTime - lastClickTime.longValue <= ViewConfiguration.getDoubleTapTimeout()
-                                        lastClickTime.longValue = if (isDoubleClick) 0L else currentTime
-                                        if (isDoubleClick) {
-                                            onDoubleClick?.invoke()
-                                            Unit
+                                        if (ignoreNextClick) {
+                                            ignoreNextClick = false
                                         } else {
-                                            onItemClick(screen, selected)
+                                            val currentTime = SystemClock.uptimeMillis()
+                                            val isDoubleClick =
+                                                onDoubleClick != null &&
+                                                    currentTime - lastClickTime.longValue <= ViewConfiguration.getDoubleTapTimeout()
+                                            lastClickTime.longValue = if (isDoubleClick) 0L else currentTime
+                                            if (isDoubleClick) {
+                                                onDoubleClick?.invoke()
+                                            } else {
+                                                onItemClick(screen, selected)
+                                            }
                                         }
                                     }
                                 }
@@ -299,7 +305,18 @@ fun FloatingNavigationToolbar(
                                 selected = selected,
                                 onClick = onClick,
                                 colors = itemColors,
-                                modifier = Modifier.weight(1f),
+                                modifier =
+                                    Modifier
+                                        .weight(1f)
+                                        .pointerInput(screen, onItemLongClick) {
+                                            if (onItemLongClick == null) return@pointerInput
+                                            detectTapGestures(
+                                                onLongPress = {
+                                                    ignoreNextClick = true
+                                                    onItemLongClick(screen)
+                                                },
+                                            )
+                                        },
                                 icon = {
                                     Box(
                                         modifier =

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/PlayerComponents.kt
@@ -1003,7 +1003,7 @@ fun PlayerPlaybackControls(
                                         },
                                     ),
                                 contentDescription = null,
-                                modifier = Modifier.size(42.dp),
+                                modifier = Modifier.size(30.dp),
                             )
                         }
                     }

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/PlayerComponents.kt
@@ -1029,7 +1029,7 @@ fun PlayerPlaybackControls(
                         Icon(
                             painter = painterResource(R.drawable.skip_next),
                             contentDescription = null,
-                            modifier = Modifier.size(32.dp),
+                            modifier = Modifier.size(26.dp),
                         )
                     }
                 }

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/NavigationBarSettings.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/NavigationBarSettings.kt
@@ -59,6 +59,7 @@ import androidx.navigation.NavController
 import dev.citali.lunartune.LocalPlayerAwareWindowInsets
 import dev.citali.lunartune.R
 import dev.citali.lunartune.constants.HideNavigationBarLabelsKey
+import dev.citali.lunartune.constants.NavBarLongPressActionsKey
 import dev.citali.lunartune.constants.NAVIGATION_BAR_CORNER_RADIUS_DEFAULT
 import dev.citali.lunartune.constants.NAVIGATION_BAR_HEIGHT_DEFAULT
 import dev.citali.lunartune.constants.NAVIGATION_BAR_LABEL_SPACING_DEFAULT
@@ -95,6 +96,8 @@ fun NavigationBarSettings(navController: NavController) {
         )
     val (hideNavigationBarLabels, onHideNavigationBarLabelsChange) =
         rememberPreference(HideNavigationBarLabelsKey, defaultValue = false)
+    val (navBarLongPressActions, onNavBarLongPressActionsChange) =
+        rememberPreference(NavBarLongPressActionsKey, defaultValue = true)
     val (navigationBarWidth, onNavigationBarWidthChange) =
         rememberPreference(NavigationBarWidthKey, defaultValue = NAVIGATION_BAR_WIDTH_DEFAULT)
     val (navigationBarHeight, onNavigationBarHeightChange) =
@@ -178,6 +181,16 @@ fun NavigationBarSettings(navController: NavController) {
                         icon = { Icon(painterResource(R.drawable.nav_bar), null) },
                         checked = hideNavigationBarLabels,
                         onCheckedChange = onHideNavigationBarLabelsChange,
+                    )
+                }
+
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.navbar_long_press_actions)) },
+                        description = stringResource(R.string.navbar_long_press_actions_desc),
+                        icon = { Icon(painterResource(R.drawable.shuffle), null) },
+                        checked = navBarLongPressActions,
+                        onCheckedChange = onNavBarLongPressActionsChange,
                     )
                 }
             }

--- a/app/src/main/res/drawable/pause.xml
+++ b/app/src/main/res/drawable/pause.xml
@@ -1,13 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path
-        android:fillColor="@android:color/white"
-        android:pathData="M2 6C2 4.11438 2 3.17157 2.58579 2.58579C3.17157 2 4.11438 2 6 2C7.88562 2 8.82843 2 9.41421 2.58579C10 3.17157 10 4.11438 10 6V18C10 19.8856 10 20.8284 9.41421 21.4142C8.82843 22 7.88562 22 6 22C4.11438 22 3.17157 22 2.58579 21.4142C2 20.8284 2 19.8856 2 18V6Z" />
-    <path
-        android:fillColor="@android:color/white"
-        android:pathData="M14 6C14 4.11438 14 3.17157 14.5858 2.58579C15.1716 2 16.1144 2 18 2C19.8856 2 20.8284 2 21.4142 2.58579C22 3.17157 22 4.11438 22 6V18C22 19.8856 22 20.8284 21.4142 21.4142C20.8284 22 19.8856 22 18 22C16.1144 22 15.1716 22 14.5858 21.4142C14 20.8284 14 19.8856 14 18V6Z" />
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M640,760Q607,760 583.5,736.5Q560,713 560,680L560,280Q560,247 583.5,223.5Q607,200 640,200L640,200Q673,200 696.5,223.5Q720,247 720,280L720,680Q720,713 696.5,736.5Q673,760 640,760ZM320,760Q287,760 263.5,736.5Q240,713 240,680L240,280Q240,247 263.5,223.5Q287,200 320,200L320,200Q353,200 376.5,223.5Q400,247 400,280L400,680Q400,713 376.5,736.5Q353,760 320,760Z"/>
 </vector>

--- a/app/src/main/res/drawable/play.xml
+++ b/app/src/main/res/drawable/play.xml
@@ -1,10 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path
-        android:fillColor="@android:color/white"
-        android:pathData="M21.4086 9.35258C23.5305 10.5065 23.5305 13.4935 21.4086 14.6474L8.59662 21.6145C6.53435 22.736 4 21.2763 4 18.9671L4 5.0329C4 2.72368 6.53435 1.26402 8.59661 2.38548L21.4086 9.35258Z" />
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M320,687L320,273Q320,256 332,244.5Q344,233 360,233Q365,233 370.5,234.5Q376,236 381,239L707,446Q716,452 720.5,461Q725,470 725,480Q725,490 720.5,499Q716,508 707,514L381,721Q376,724 370.5,725.5Q365,727 360,727Q344,727 332,715.5Q320,704 320,687Z"/>
 </vector>

--- a/app/src/main/res/drawable/replay.xml
+++ b/app/src/main/res/drawable/replay.xml
@@ -1,27 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:width="24.0dip"
+    android:height="24.0dip"
+    android:viewportWidth="960.0"
+    android:viewportHeight="960.0">
     <path
-        android:fillColor="@android:color/transparent"
-        android:pathData="M7.37756 12.5556L7.37756 11.6296C7.37756 9.07276 9.46667 7 12.0437 7C13.4045 7 14.6293 7.57797 15.4822 8.5M6 11L7.37756 12.5556L9 11"
-        android:strokeColor="@android:color/white"
-        android:strokeWidth="1.5"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
-    <path
-        android:fillColor="@android:color/transparent"
-        android:pathData="M16.6188 11.4443V12.3703C16.6188 14.9271 14.5217 16.9999 11.9348 16.9999C10.5777 16.9999 9.35544 16.4295 8.5 15.518M18 12.999L16.6188 11.4443L15 12.999"
-        android:strokeColor="@android:color/white"
-        android:strokeWidth="1.5"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
-    <path
-        android:fillColor="@android:color/transparent"
-        android:pathData="M7 3.33782C8.47087 2.48697 10.1786 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 10.1786 2.48697 8.47087 3.33782 7"
-        android:strokeColor="@android:color/white"
-        android:strokeWidth="1.5"
-        android:strokeLineCap="round" />
+        android:fillColor="@android:color/white"
+        android:pathData="M480,880Q405,880 339.5,851.5Q274,823 225.5,774.5Q177,726 148.5,660.5Q120,595 120,520L200,520Q200,637 281.5,718.5Q363,800 480,800Q597,800 678.5,718.5Q760,637 760,520Q760,403 678.5,321.5Q597,240 480,240L474,240L536,302L480,360L320,200L480,40L536,98L474,160L480,160Q555,160 620.5,188.5Q686,217 734.5,265.5Q783,314 811.5,379.5Q840,445 840,520Q840,595 811.5,660.5Q783,726 734.5,774.5Q686,823 620.5,851.5Q555,880 480,880Z" />
 </vector>

--- a/app/src/main/res/drawable/skip_next.xml
+++ b/app/src/main/res/drawable/skip_next.xml
@@ -1,13 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path
-        android:fillColor="@android:color/white"
-        android:pathData="M16.6598 14.6474C18.4467 13.4935 18.4467 10.5065 16.6598 9.35258L5.87083 2.38548C4.13419 1.26402 2 2.72368 2 5.0329V18.9671C2 21.2763 4.13419 22.736 5.87083 21.6145L16.6598 14.6474Z" />
-    <path
-        android:fillColor="@android:color/white"
-        android:pathData="M22.75 5C22.75 4.58579 22.4142 4.25 22 4.25C21.5858 4.25 21.25 4.58579 21.25 5V19C21.25 19.4142 21.5858 19.75 22 19.75C22.4142 19.75 22.75 19.4142 22.75 19V5Z" />
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M100,645L100,315Q100,297 112,286Q124,275 140,275Q145,275 151,276Q157,277 162,281L410,447Q419,453 423.5,461.5Q428,470 428,480Q428,490 423.5,498.5Q419,507 410,513L162,679Q157,683 151,684Q145,685 140,685Q124,685 112,674Q100,663 100,645ZM500,645L500,315Q500,297 512,286Q524,275 540,275Q545,275 551,276Q557,277 562,281L810,447Q819,453 823.5,461.5Q828,470 828,480Q828,490 823.5,498.5Q819,507 810,513L562,679Q557,683 551,684Q545,685 540,685Q524,685 512,674Q500,663 500,645Z"/>
 </vector>

--- a/app/src/main/res/drawable/skip_previous.xml
+++ b/app/src/main/res/drawable/skip_previous.xml
@@ -1,13 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path
-        android:fillColor="@android:color/white"
-        android:pathData="M8.09015 14.6474C6.30328 13.4935 6.30328 10.5065 8.09015 9.35258L18.8792 2.38548C20.6158 1.26402 22.75 2.72368 22.75 5.0329V18.9671C22.75 21.2763 20.6158 22.736 18.8792 21.6145L8.09015 14.6474Z" />
-    <path
-        android:fillColor="@android:color/white"
-        android:pathData="M2 5C2 4.58579 2.33579 4.25 2.75 4.25C3.16421 4.25 3.5 4.58579 3.5 5V19C3.5 19.4142 3.16421 19.75 2.75 19.75C2.33579 19.75 2 19.4142 2 19V5Z" />
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M798,679L550,513Q541,507 536.5,498.5Q532,490 532,480Q532,470 536.5,461.5Q541,453 550,447L798,281Q803,277 809,276Q815,275 820,275Q836,275 848,286Q860,297 860,315L860,645Q860,663 848,674Q836,685 820,685Q815,685 809,684Q803,683 798,679ZM398,679L150,513Q141,507 136.5,498.5Q132,490 132,480Q132,470 136.5,461.5Q141,453 150,447L398,281Q403,277 409,276Q415,275 420,275Q436,275 448,286Q460,297 460,315L460,645Q460,663 448,674Q436,685 420,685Q415,685 409,684Q403,683 398,679Z"/>
 </vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1116,6 +1116,9 @@
     <string name="navigation_bar_settings_subtitle">Style, labels, and dimensions</string>
     <string name="hide_navigation_bar_labels">Hide labels in navigation bar</string>
     <string name="hide_navigation_bar_labels_desc">Show only icons in the bottom navigation bar</string>
+    <string name="navbar_long_press_actions">Navigation bar long-press</string>
+    <string name="navbar_long_press_actions_desc">Long-press Home to play a random song from listening history, or Search to open music recognition</string>
+    <string name="navbar_long_press_no_history">No listening history yet</string>
     <string name="navigation_bar_dimensions">Dimensions</string>
     <string name="navigation_bar_width">Width</string>
     <string name="navigation_bar_width_desc">Fraction of screen width used by the floating bar</string>


### PR DESCRIPTION
## Summary
- Long-press **Home** on the nav bar plays a random track from listening history (same idea as the old FAB shuffle).
- Long-press **Search** opens music recognition.
- Settings → Navigation bar has a toggle (on by default) for these long-press actions.
- Play / pause / skip / replay icons restored from ArchiveTune; V2 pill glyphs are slightly smaller so they look less thick.

## Test plan
- [ ] Long-press Home with history → a known song starts.
- [ ] Long-press Home with empty history → toast.
- [ ] Long-press Search → music recognition.
- [ ] Disable the nav-bar long-press toggle and confirm long-press does nothing extra.
- [ ] Open the now-playing screen and confirm transport icons match ArchiveTune weight.
