### PR TITLE
fix: keep Discord presence alive during long playback

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/playback/MusicService.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/playback/MusicService.kt
@@ -445,6 +445,7 @@ class MusicService :
     @Volatile
     private var suppressAutoPlayback = false
     private var lastPresenceToken: String? = null
+    private var discordKeepAliveJob: Job? = null
 
     @Volatile
     private var pausedPresenceGate = PausedPresenceGate.FollowPreference
@@ -2192,12 +2193,10 @@ class MusicService :
     }
 
     private fun ensurePresenceManager() {
-        if (DiscordPresenceManager.isRunning() && lastPresenceToken != null) return
-
-        // Launch in scope to avoid blocking
         scope.launch {
-            // Don't start if Discord RPC is disabled in settings
             if (!dataStore.get(EnableDiscordRPCKey, true)) {
+                discordKeepAliveJob?.cancel()
+                discordKeepAliveJob = null
                 if (DiscordPresenceManager.isRunning()) {
                     Timber.tag("MusicService").d("Discord RPC disabled → stopping presence manager")
                     try {
@@ -2211,6 +2210,8 @@ class MusicService :
 
             val key: String = dataStore.get(DiscordTokenKey, "")
             if (key.isNullOrBlank()) {
+                discordKeepAliveJob?.cancel()
+                discordKeepAliveJob = null
                 if (DiscordPresenceManager.isRunning()) {
                     Timber.tag("MusicService").d("No Discord OAuth session -> stopping presence manager")
                     try {
@@ -2222,12 +2223,16 @@ class MusicService :
                 return@launch
             }
 
+            startDiscordKeepAlive()
+
             if (DiscordPresenceManager.isRunning() && lastPresenceToken == key) {
                 return@launch
             }
 
             try {
-                DiscordPresenceManager.stop()
+                if (DiscordPresenceManager.isRunning() && lastPresenceToken != key) {
+                    DiscordPresenceManager.stop()
+                }
                 DiscordPresenceManager.start(
                     context = this@MusicService,
                     token = key,
@@ -2237,6 +2242,7 @@ class MusicService :
                         "transport invalidated reason=%s; requesting forced sync",
                         reason,
                     )
+                    ensurePresenceManager()
                     requestDiscordSync(
                         reason = "transport_invalidated:$reason",
                         force = true,
@@ -2252,6 +2258,28 @@ class MusicService :
                 Timber.tag("MusicService").e(ex, "Failed to start presence manager")
             }
         }
+    }
+
+    private fun startDiscordKeepAlive() {
+        if (discordKeepAliveJob?.isActive == true) return
+        discordKeepAliveJob =
+            scope.launch(SilentHandler) {
+                while (isActive) {
+                    delay(DISCORD_KEEP_ALIVE_MS)
+                    if (discordServiceStopping) return@launch
+                    if (!dataStore.get(EnableDiscordRPCKey, true)) return@launch
+                    if (dataStore.get(DiscordTokenKey, "").isBlank()) return@launch
+                    if (!::player.isInitialized || player.currentMediaItem == null) continue
+                    if (!DiscordPresenceManager.isRunning()) {
+                        Timber.tag(DISCORD_SYNC_TAG).w("keep-alive found manager stopped; restarting")
+                        ensurePresenceManager()
+                    }
+                    requestDiscordSync(
+                        reason = "discord_keep_alive",
+                        force = true,
+                    )
+                }
+            }
     }
 
     private fun setupAudioFocusRequest() {
@@ -8529,6 +8557,8 @@ class MusicService :
     override fun onDestroy() {
         equalizerPlaybackController.detach(this)
         discordServiceStopping = true
+        discordKeepAliveJob?.cancel()
+        discordKeepAliveJob = null
         requestDiscordSync(
             reason = "service_destroy",
             force = true,
@@ -8802,6 +8832,7 @@ class MusicService :
         private const val INFINITE_QUEUE_MAX_BOOTSTRAP_PAGES = 3
         private const val DISCORD_SYNC_TAG = "DiscordSync"
         private const val DISCORD_HOLD_TIMEOUT_MS = 7_000L
+        private const val DISCORD_KEEP_ALIVE_MS = 3 * 60 * 1000L
         const val CHANNEL_ID = "music_channel_01"
         const val ACTION_MEDIA_NOTIFICATION_DISMISSED =
             "dev.citali.lunartune.action.MEDIA_NOTIFICATION_DISMISSED"

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/DebugSettings.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/DebugSettings.kt
@@ -231,7 +231,7 @@ private fun DiscordDebugSection() {
     val lastEndTs: Long? by DiscordPresenceManager.lastRpcEndTimeFlow.collectAsState(initial = null)
     val lastStart: String = lastStartTs?.let { makeTimeString(it) } ?: "—"
     val lastEnd: String = lastEndTs?.let { makeTimeString(it) } ?: "—"
-    val isRunning = DiscordPresenceManager.isRunning()
+    val isRunning by DiscordPresenceManager.isRunningFlow.collectAsState(initial = DiscordPresenceManager.isRunning())
 
     Card(
         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/DiscordPresenceManager.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/DiscordPresenceManager.kt
@@ -263,16 +263,12 @@ object DiscordPresenceManager {
 
     fun stop(clearActivity: Boolean = true) {
         if (!started.getAndSet(false)) return
+        startedState.value = false
 
         DiscordSocialPresenceClient.setOnTransportInvalidated(null)
         updateGeneration.incrementAndGet()
         scope?.cancel()
         scope = null
-
-        lifecycleObserver?.let { observer ->
-            removeLifecycleObserverOnMain(observer)
-        }
-        lifecycleObserver = null
 
         val rpcToClose = rpcInstance
         rpcInstance = null

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/DiscordPresenceManager.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/DiscordPresenceManager.kt
@@ -8,11 +8,6 @@
 package dev.citali.lunartune.ui.screens.settings
 
 import android.content.Context
-import android.os.Handler
-import android.os.Looper
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.ProcessLifecycleOwner
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -40,12 +35,13 @@ object DiscordPresenceManager {
     private const val STOP_TIMEOUT_MS = 5_000L
 
     private val started = AtomicBoolean(false)
+    private val startedState = MutableStateFlow(false)
+    val isRunningFlow = startedState.asStateFlow()
     private val updateGeneration = AtomicLong(0L)
     private val rpcMutex = Mutex()
     private val cleanupScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     private var scope: CoroutineScope? = null
-    private var lifecycleObserver: LifecycleEventObserver? = null
     private var rpcInstance: DiscordRPC? = null
     private var rpcToken: String? = null
 
@@ -65,26 +61,6 @@ object DiscordPresenceManager {
     ) {
         lastRpcStartTimeState.value = start
         lastRpcEndTimeState.value = end
-    }
-
-    private fun addLifecycleObserverOnMain(observer: LifecycleEventObserver) {
-        if (Looper.myLooper() == Looper.getMainLooper()) {
-            ProcessLifecycleOwner.get().lifecycle.addObserver(observer)
-        } else {
-            Handler(Looper.getMainLooper()).post {
-                ProcessLifecycleOwner.get().lifecycle.addObserver(observer)
-            }
-        }
-    }
-
-    private fun removeLifecycleObserverOnMain(observer: LifecycleEventObserver) {
-        if (Looper.myLooper() == Looper.getMainLooper()) {
-            ProcessLifecycleOwner.get().lifecycle.removeObserver(observer)
-        } else {
-            Handler(Looper.getMainLooper()).post {
-                ProcessLifecycleOwner.get().lifecycle.removeObserver(observer)
-            }
-        }
     }
 
     private suspend fun getOrCreateRpc(
@@ -228,13 +204,7 @@ object DiscordPresenceManager {
         if (!started.getAndSet(true)) {
             consecutiveFailures = 0
             scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-            lifecycleObserver =
-                LifecycleEventObserver { _, event ->
-                    if (event == Lifecycle.Event.ON_DESTROY) {
-                        stop()
-                    }
-                }
-            addLifecycleObserverOnMain(lifecycleObserver!!)
+            startedState.value = true
         }
 
         if (token.isNotBlank()) {


### PR DESCRIPTION
## Summary
Discord rich presence could stop after a few hours of listening (same as original ArchiveTune). The manager was torn down by process-lifecycle destroy / a transient NoToken decision, then never restarted until the next song change.

- Do not stop the manager on ProcessLifecycleOwner destroy
- Keep a stored OAuth session from permanently stopping the manager
- Restart + force-sync every 3 minutes while playback is active
- Reconnect when the Discord gateway drops

## Test plan
- [ ] Connect Discord, play for a long session / background the app, confirm Experimental Settings still shows Active / Presence manager running
- [ ] Pause, skip, and resume — presence should come back without re-login
- [ ] Disable Discord RPC and confirm the manager still stops