### PR TITLE
fix: recover streams after HTTP 403 / code 2004

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/utils/YTPlayerUtils.kt
@@ -454,6 +454,14 @@ object YTPlayerUtils {
         return expiresAtMs <= nowMs + STREAM_URL_EXPIRY_SAFETY_MS
     }
 
+    private val androidVrClientKeys =
+        listOf(
+            ANDROID_VR_NO_AUTH,
+            ANDROID_VR_1_65_10,
+            ANDROID_VR_1_61_48,
+            ANDROID_VR_1_43_32,
+        ).map { StreamClientUtils.buildClientKey(it) }
+
     fun markStreamClientFailed(
         videoId: String,
         clientKey: String?,
@@ -463,8 +471,17 @@ object YTPlayerUtils {
         if (httpStatusCode != null && httpStatusCode !in RETRYABLE_STREAM_RESPONSE_CODES) return
         val normalizedClientKey = normalizeStreamClientKey(clientKey)
         if (normalizedClientKey.isEmpty()) return
-        failedStreamClientsUntil[buildFailedClientKey(videoId, normalizedClientKey, authFingerprint)] =
-            System.currentTimeMillis() + FAILED_CLIENT_BACKOFF_MS
+        val until = System.currentTimeMillis() + FAILED_CLIENT_BACKOFF_MS
+        val keysToBlock = linkedSetOf(normalizedClientKey)
+        if (httpStatusCode == 403 && normalizedClientKey.substringBefore("@").startsWith("ANDROID_VR")) {
+            keysToBlock += androidVrClientKeys
+        }
+        for (key in keysToBlock) {
+            failedStreamClientsUntil[buildFailedClientKey(videoId, key, authFingerprint)] = until
+        }
+        if (lastSuccessfulClientKey != null && keysToBlock.contains(lastSuccessfulClientKey)) {
+            lastSuccessfulClientKey = null
+        }
     }
 
     fun markPreferredClientFailed(


### PR DESCRIPTION
## Summary
Playback failed with **No stream available / code 2004 / HTTP 403** after YouTube rotated player.js.

Logs showed:
- `Could not parse deobfuscation function` on WEB_REMIX ciphered formats
- fallback to ANDROID_VR direct URLs that then 403
- retry only blocked one VR version, so the next VR variant was used again

This updates `morideobfuscator` to rukamori `4e1fa93` (signature/n-transform recovery) and, after a 403, backs off the whole Android VR client family so IOS/TV/Android Music can be tried.

## Test plan
- [ ] Play the previously failing track (e.g. IRIS OUT / Kenshi Yonezu) — should start without 2004
- [ ] Skip a few songs, including after backgrounding the app
- [ ] Confirm a logged-in session still plays premium/WEB_REMIX when decipher works