### PR TITLE
feat: nested settings search, nav long-press, lyrics open, taste radio

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/MainActivity.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/MainActivity.kt
@@ -2097,16 +2097,18 @@ class MainActivity : ComponentActivity() {
                                                                                 val from =
                                                                                     System.currentTimeMillis() -
                                                                                         90L * 24 * 60 * 60 * 1000
-                                                                                val history =
+                                                                                val favorites =
                                                                                     database
-                                                                                        .mostPlayedSongs(from, limit = 80)
+                                                                                        .mostPlayedSongs(from, limit = 24)
                                                                                         .first()
-                                                                                        .ifEmpty { database.recentSongs(80).first() }
-                                                                                history
-                                                                                    .filter { candidate ->
-                                                                                        candidate.artists.none { it.blockedAt != null }
-                                                                                    }.randomOrNull()
-                                                                                    ?: allLocalItems.filterIsInstance<Song>().randomOrNull()
+                                                                                        .filter { candidate ->
+                                                                                            candidate.artists.none { it.blockedAt != null }
+                                                                                        }
+                                                                                favorites.randomOrNull()
+                                                                                    ?: database.recentSongs(40).first()
+                                                                                        .filter { candidate ->
+                                                                                            candidate.artists.none { it.blockedAt != null }
+                                                                                        }.randomOrNull()
                                                                             }
                                                                         if (song == null) {
                                                                             Toast
@@ -2121,7 +2123,13 @@ class MainActivity : ComponentActivity() {
                                                                             if (song.song.isLocal) {
                                                                                 ListQueue(items = listOf(song.toMediaItem()))
                                                                             } else {
-                                                                                YouTubeQueue.radio(song.toMediaMetadata())
+                                                                                YouTubeQueue(
+                                                                                    endpoint =
+                                                                                        moe.rukamori.archivetune.innertube.models
+                                                                                            .WatchEndpoint(videoId = song.id),
+                                                                                    preloadItem = null,
+                                                                                    followAutomixPreview = true,
+                                                                                )
                                                                             },
                                                                         )
                                                                     }

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/component/FloatingNavigationToolbar.kt
@@ -12,7 +12,10 @@ package dev.citali.lunartune.ui.component
 import android.os.SystemClock
 import android.view.ViewConfiguration
 import androidx.compose.animation.Crossfade
-import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
+import kotlinx.coroutines.withTimeoutOrNull
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/component/FloatingNavigationToolbar.kt
@@ -314,12 +314,18 @@ fun FloatingNavigationToolbar(
                                         .weight(1f)
                                         .pointerInput(screen, onItemLongClick) {
                                             if (onItemLongClick == null) return@pointerInput
-                                            detectTapGestures(
-                                                onLongPress = {
+                                            awaitEachGesture {
+                                                awaitFirstDown(requireUnconsumed = false)
+                                                val longPressed =
+                                                    withTimeoutOrNull(viewConfiguration.longPressTimeoutMillis.toLong()) {
+                                                        waitForUpOrCancellation()
+                                                        false
+                                                    } == null
+                                                if (longPressed) {
                                                     ignoreNextClick = true
                                                     onItemLongClick(screen)
-                                                },
-                                            )
+                                                }
+                                            }
                                         },
                                 icon = {
                                     Box(

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/Player.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/Player.kt
@@ -1985,9 +1985,9 @@ private fun MikoLyricsTransition(
     val progress by animateFloatAsState(
         targetValue = if (visible) 1f else 0f,
         animationSpec =
-            spring(
-                dampingRatio = 0.82f,
-                stiffness = Spring.StiffnessMediumLow,
+            tween(
+                durationMillis = 320,
+                easing = androidx.compose.animation.core.FastOutSlowInEasing,
             ),
         label = "mikoLyricsTransition",
     )
@@ -1995,28 +1995,23 @@ private fun MikoLyricsTransition(
     val boundedProgress = progress.coerceIn(0f, 1f)
 
     if (visible || boundedProgress > 0.001f) {
-        val scaleX = 0.92f + (0.08f * boundedProgress)
-        val scaleY = 0.78f + (0.22f * boundedProgress)
-        val alpha = (0.2f + (0.8f * boundedProgress)).coerceIn(0f, 1f)
-        val cornerRadius = 32.dp * (1f - boundedProgress)
+        val alpha = boundedProgress
+        val cornerRadius = 20.dp * (1f - boundedProgress)
 
         Box(
             modifier =
                 modifier
                     .fillMaxSize()
                     .graphicsLayer { this.alpha = boundedProgress }
-                    .background(Color.Black.copy(alpha = 0.24f * boundedProgress)),
+                    .background(Color.Black.copy(alpha = 0.28f * boundedProgress)),
         ) {
             Box(
                 modifier =
                     Modifier
                         .fillMaxSize()
                         .graphicsLayer {
-                            transformOrigin = TransformOrigin(0.5f, 1f)
-                            this.scaleX = scaleX
-                            this.scaleY = scaleY
                             this.alpha = alpha
-                            translationY = size.height * 0.16f * (1f - boundedProgress)
+                            translationY = size.height * 0.10f * (1f - boundedProgress)
                         }.clip(RoundedCornerShape(cornerRadius))
                         .background(MaterialTheme.colorScheme.surface),
             ) {

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/SettingsDataBuilders.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/SettingsDataBuilders.kt
@@ -35,6 +35,13 @@ fun buildSettingsGroups(
             title = stringResource(R.string.account),
             subtitle = stringResource(R.string.settings_account_subtitle),
             accentColor = MaterialTheme.colorScheme.primary,
+            keywords =
+                listOf(
+                    stringResource(R.string.login),
+                    stringResource(R.string.account_integrations_summary),
+                    stringResource(R.string.hidden_playlists),
+                    stringResource(R.string.settings_po_token_subtitle),
+                ),
             onClick = { navController.navigate("settings/account") },
         )
     val stats =
@@ -53,6 +60,14 @@ fun buildSettingsGroups(
             title = stringResource(R.string.appearance),
             subtitle = stringResource(R.string.settings_appearance_subtitle),
             accentColor = MaterialTheme.colorScheme.secondary,
+            keywords =
+                listOf(
+                    stringResource(R.string.theme),
+                    stringResource(R.string.dark_theme),
+                    stringResource(R.string.navbar_long_press_actions),
+                    stringResource(R.string.player),
+                    stringResource(R.string.custom_background_subtitle),
+                ),
             onClick = { navController.navigate("settings/appearance") },
         )
     val playback =
@@ -62,6 +77,15 @@ fun buildSettingsGroups(
             title = stringResource(R.string.settings_playback_title),
             subtitle = stringResource(R.string.settings_playback_subtitle),
             accentColor = MaterialTheme.colorScheme.tertiary,
+            keywords =
+                listOf(
+                    stringResource(R.string.audio_quality),
+                    stringResource(R.string.skip_silence),
+                    stringResource(R.string.audio_normalization),
+                    stringResource(R.string.equalizer),
+                    stringResource(R.string.codecs),
+                    stringResource(R.string.download),
+                ),
             onClick = { navController.navigate("settings/player") },
         )
     val lyrics =
@@ -71,6 +95,12 @@ fun buildSettingsGroups(
             title = stringResource(R.string.lyrics),
             subtitle = stringResource(R.string.settings_lyrics_subtitle),
             accentColor = MaterialTheme.colorScheme.secondary,
+            keywords =
+                listOf(
+                    stringResource(R.string.lyrics_mode),
+                    stringResource(R.string.lyrics_animation_style),
+                    stringResource(R.string.search_lyrics),
+                ),
             onClick = { navController.navigate("settings/lyrics") },
         )
     val content =
@@ -98,6 +128,11 @@ fun buildSettingsGroups(
             title = stringResource(R.string.integration),
             subtitle = stringResource(R.string.settings_integration_subtitle),
             accentColor = MaterialTheme.colorScheme.secondary,
+            keywords =
+                listOf(
+                    stringResource(R.string.discord_integration),
+                    stringResource(R.string.discord_login_description),
+                ),
             onClick = { navController.navigate("settings/integration") },
         )
     val aiIntegration =
@@ -116,6 +151,12 @@ fun buildSettingsGroups(
             title = stringResource(R.string.internet),
             subtitle = stringResource(R.string.settings_internet_subtitle),
             accentColor = MaterialTheme.colorScheme.tertiary,
+            keywords =
+                listOf(
+                    stringResource(R.string.enable_proxy),
+                    stringResource(R.string.proxy_host),
+                    stringResource(R.string.proxy_port),
+                ),
             onClick = { navController.navigate("settings/internet") },
         )
     val storage =
@@ -143,6 +184,12 @@ fun buildSettingsGroups(
             title = stringResource(R.string.settings_developer_options_title),
             subtitle = stringResource(R.string.settings_developer_options_subtitle),
             accentColor = MaterialTheme.colorScheme.tertiary,
+            keywords =
+                listOf(
+                    stringResource(R.string.debug_logs),
+                    stringResource(R.string.display_codec_on_player),
+                    stringResource(R.string.experiment_settings),
+                ),
             onClick = { navController.navigate("settings/misc") },
         )
     val defaultLinks =

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/SettingsScreen.kt
@@ -123,11 +123,14 @@ fun SettingsScreen(
                 settingsGroups
             } else {
                 settingsGroups.mapNotNull { group ->
+                    val groupTitleMatches = group.title.lowercase().contains(query)
                     val items =
                         group.items.filter { item ->
-                            item.title.lowercase().contains(query) ||
+                            groupTitleMatches ||
+                                item.title.lowercase().contains(query) ||
                                 item.subtitle.orEmpty().lowercase().contains(query) ||
-                                item.key.lowercase().contains(query)
+                                item.key.lowercase().contains(query) ||
+                                item.keywords.any { keyword -> keyword.lowercase().contains(query) }
                         }
                     if (items.isEmpty()) null else group.copy(items = items)
                 }


### PR DESCRIPTION
## Summary
- Settings search matches **inside** categories (group title + child keywords), like Android Settings
- Nav long-press actually fires (gesture no longer swallowed by the item click)
- Home long-press starts a **related automix** from most-played taste, not a random history replay
- Lyrics page opens with a fade + slide-up

Playback/download 403 is already on main via #25 — install that APK if songs still fail to start.

## Test plan
- [ ] Settings: search `discord`, `equalizer`, `proxy`, `codec` and open the matching category
- [ ] Long-press Home: related mix from listening taste; long-press Search: music recognition
- [ ] Open lyrics from the player: fade/slide-up, back dismisses smoothly