### PR TITLE
fix: stream clients for playback/downloads and CJK lyrics padding

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/playback/DownloadUtil.kt
@@ -37,6 +37,8 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import dev.citali.lunartune.constants.AudioQuality
 import dev.citali.lunartune.constants.AudioQualityKey
+import dev.citali.lunartune.constants.PlayerStreamClient
+import dev.citali.lunartune.constants.PlayerStreamClientKey
 import dev.citali.lunartune.db.MusicDatabase
 import dev.citali.lunartune.db.entities.FormatEntity
 import dev.citali.lunartune.db.entities.SongEntity
@@ -70,6 +72,11 @@ class DownloadUtil
     ) {
         private val connectivityManager = context.getSystemService<ConnectivityManager>()!!
         private val audioQuality by enumPreference(context, AudioQualityKey, AudioQuality.AUTO)
+        private val preferredStreamClient by enumPreference(
+            context,
+            PlayerStreamClientKey,
+            PlayerStreamClient.WEB_REMIX,
+        )
         private val downloadScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         private val songUrlCache = ConcurrentHashMap<String, AuthScopedCacheValue>()
         private val streamResolveMutex = Mutex()
@@ -164,6 +171,7 @@ class DownloadUtil
                                 audioQuality = requestedAudioQuality,
                                 connectivityManager = connectivityManager,
                                 networkMetered = lowDataModeActive,
+                                preferredStreamClient = preferredStreamClient,
                             )
                         }
                     }.getOrThrow()

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/component/LyricsEnhanced.kt
@@ -947,7 +947,7 @@ private fun PlainLyricLineItem(
                 .combinedClickable(
                     onClick = { onLineClicked(line.selectionId) },
                     onLongClick = { onLinePressed(line.selectionId) },
-                ).padding(horizontal = 12.dp, vertical = 8.dp),
+                ).padding(horizontal = 24.dp, vertical = 8.dp),
     )
 }
 

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/component/LyricsV2.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/component/LyricsV2.kt
@@ -591,8 +591,8 @@ fun LyricsV2(
                             Modifier
                                 .fillMaxWidth()
                                 .padding(
-                                    start = 12.dp,
-                                    end = 12.dp,
+                                    start = 24.dp,
+                                    end = 24.dp,
                                     top =
                                         if (index == 0 || (index == 1 && entriesWithWords[0] == HEAD_LYRICS_ENTRY)) {
                                             0.dp
@@ -775,8 +775,8 @@ fun LyricsV2(
                                         },
                                     shape = RoundedCornerShape(8.dp),
                                 ).padding(
-                                    start = if (isAllBackground) 24.dp else 12.dp,
-                                    end = 12.dp,
+                                    start = if (isAllBackground) 28.dp else 24.dp,
+                                    end = 24.dp,
                                     top =
                                         if (index == 0 ||
                                             (index == 1 && entriesWithWords[0] == HEAD_LYRICS_ENTRY)
@@ -1352,10 +1352,16 @@ private fun AnimatedWordV2(
             Modifier
                 .layout { measurable, constraints ->
                     val glowPaddingPx = glowPadding.roundToPx()
+                    val boundedMaxWidth =
+                        if (constraints.hasBoundedWidth) {
+                            constraints.maxWidth
+                        } else {
+                            constraints.maxWidth.coerceAtMost(Int.MAX_VALUE / 8)
+                        }
                     val looseConstraints =
                         constraints.copy(
                             minWidth = 0,
-                            maxWidth = constraints.maxWidth,
+                            maxWidth = boundedMaxWidth,
                             minHeight = 0,
                             maxHeight = Constraints.Infinity,
                         )

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
@@ -820,7 +820,7 @@ private fun AppleMusicLyricsPane(
         modifier =
             modifier
                 .fillMaxSize()
-                .padding(horizontal = 24.dp),
+                .padding(horizontal = 20.dp),
         textColor = foregroundColor,
     )
 }

--- a/app/src/main/kotlin/dev/citali/lunartune/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/utils/YTPlayerUtils.kt
@@ -148,29 +148,29 @@ object YTPlayerUtils {
      */
     private val STREAM_FALLBACK_CLIENTS: Array<YouTubeClient> =
         arrayOf(
+            VISIONOS,
+            IOS,
+            IOS_MUSIC,
+            TVHTML5,
+            TVHTML5_DOWNGRADED,
+            ANDROID_MUSIC,
+            WEB_REMIX,
+            WEB_CREATOR,
+            WEB_EMBEDDED,
+            MWEB,
+            WEB,
+            WEB_PRIMARY,
+            TVHTML5_SIMPLY,
+            MOBILE,
+            IPADOS,
+            ANDROID_CREATOR,
+            ANDROID_TESTSUITE,
+            ANDROID_UNPLUGGED,
+            TVHTML5_SIMPLY_EMBEDDED_PLAYER,
             ANDROID_VR_NO_AUTH,
             ANDROID_VR_1_65_10,
             ANDROID_VR_1_61_48,
             ANDROID_VR_1_43_32,
-            TVHTML5_DOWNGRADED,
-            WEB_EMBEDDED,
-            WEB_CREATOR,
-            WEB_REMIX,
-            MWEB,
-            WEB,
-            WEB_PRIMARY,
-            TVHTML5,
-            TVHTML5_SIMPLY,
-            IOS,
-            MOBILE,
-            ANDROID_MUSIC,
-            IOS_MUSIC,
-            ANDROID_CREATOR,
-            ANDROID_TESTSUITE,
-            ANDROID_UNPLUGGED,
-            IPADOS,
-            VISIONOS,
-            TVHTML5_SIMPLY_EMBEDDED_PLAYER,
         )
 
     private data class CachedStreamUrl(
@@ -523,7 +523,7 @@ object YTPlayerUtils {
     ): YouTubeClient =
         when (preferredStreamClient) {
             PlayerStreamClient.VISION_OS -> {
-                WEB_REMIX
+                VISIONOS
             }
 
             PlayerStreamClient.ANDROID_VR -> {
@@ -772,12 +772,17 @@ object YTPlayerUtils {
         audioQuality: AudioQuality,
         connectivityManager: ConnectivityManager,
         networkMetered: Boolean? = null,
+        preferredStreamClient: PlayerStreamClient = PlayerStreamClient.WEB_REMIX,
     ): Result<PlaybackData> =
         runCatching {
             Timber.tag(logTag).i("Fetching download response for videoId: $videoId, playlistId: $playlistId")
             var lastError: Throwable? = null
 
-            for (preferredStreamClient in downloadPreferredStreamClientAttempts) {
+            val downloadClients =
+                listOf(preferredStreamClient) +
+                    downloadPreferredStreamClientAttempts.filterNot { it == preferredStreamClient }
+
+            for (preferredStreamClient in downloadClients) {
                 val attemptResult =
                     playerResponseForPlayback(
                         videoId = videoId,
@@ -804,11 +809,13 @@ object YTPlayerUtils {
 
     private val downloadPreferredStreamClientAttempts: List<PlayerStreamClient> =
         listOf(
-            PlayerStreamClient.WEB_REMIX,
-            PlayerStreamClient.HI_RES_LOSSLESS,
+            PlayerStreamClient.VISION_OS,
             PlayerStreamClient.IOS,
             PlayerStreamClient.TVHTML5,
+            PlayerStreamClient.WEB_REMIX,
             PlayerStreamClient.ANDROID_MUSIC,
+            PlayerStreamClient.HI_RES_LOSSLESS,
+            PlayerStreamClient.ANDROID_VR,
         )
 
     private suspend fun refreshIpRotationForBotDetection(


### PR DESCRIPTION
## Summary
Playback and downloads stuck at 0% because **visionOS in Stream sources was mapped to WEB_REMIX**, then Android VR URLs 403. Downloads only retried WEB_REMIX.

- Honor **VISIONOS** as the preferred client (Metrolist-style native clients first)
- Fallback order: visionOS → iOS → TVHTML5 → Android Music → WEB_REMIX → Android VR last
- Downloads use the same preferred client, then those fallbacks
- Extra horizontal padding so Japanese lyrics are not clipped

## Test plan
- [ ] With stream order visionOS first, play Heat Waves — should start
- [ ] Download the same song — progress should leave 0 B/s
- [ ] Lyrics page: Japanese lines fully visible, no cut く