### PR TITLE
feat: 5.0.0 downloads, LunarTune URLs, remove in-app updater

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,7 +15,7 @@ body:
       label: Required pre-submission checklist
       description: Reports that skip these checks are difficult to triage and may be closed.
       options:
-        - label: I have tested this bug on the [latest nightly version](https://github.com/cognitiveshadows03/ArchiveTune/actions).
+        - label: I have tested this bug on the [latest nightly version](https://github.com/cognitiveshadows03/LunarTune/actions).
           required: true
         - label: This report describes one specific bug, not multiple unrelated problems.
           required: true

--- a/.github/workflows/notify_telegram.py
+++ b/.github/workflows/notify_telegram.py
@@ -25,7 +25,7 @@ def main():
     commit_author, commit_message, commit_hash, commit_hash_short = get_git_commit_info()
 
     message = (
-        f"A new [commit](https://github.com/cognitiveshadows03/ArchiveTune/commit/{commit_hash}) has been merged to the repository by *{commit_author}*.\n\n"
+        f"A new [commit](https://github.com/cognitiveshadows03/LunarTune/commit/{commit_hash}) has been merged to the repository by *{commit_author}*.\n\n"
         f"*What has changed:*\n>{escape_parentheses(commit_message)}\n\n"
         f"I'm currently building it and will send you the APKs here within ~9 mins if the build is successful.\n\n#{commit_hash_short}"
     )

--- a/.github/workflows/notify_user.yml
+++ b/.github/workflows/notify_user.yml
@@ -33,11 +33,11 @@ jobs:
             const nightlyLinks = [
               {
                 label: "GMS",
-                url: "https://nightly.link/cognitiveshadows03/ArchiveTune/workflows/build/dev/app-gms-mobile-universal-release"
+                url: "https://nightly.link/cognitiveshadows03/LunarTune/workflows/build/dev/app-gms-mobile-universal-release"
               },
               {
                 label: "FOSS",
-                url: "https://nightly.link/cognitiveshadows03/ArchiveTune/workflows/build/dev/app-foss-mobile-universal-release"
+                url: "https://nightly.link/cognitiveshadows03/LunarTune/workflows/build/dev/app-foss-mobile-universal-release"
               }
             ];
             const nightlyUrls = nightlyLinks.map((link) => link.url);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ LunarTune follows a strict **Clean Architecture** approach. This separation of c
 
 1. **Clone the Source:**
 ```bash
-git clone https://github.com/cognitiveshadows03/ArchiveTune.git
+git clone https://github.com/cognitiveshadows03/LunarTune.git
 cd LunarTune
 
 ```

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -113,8 +113,8 @@ This file should be reviewed whenever LunarTune changes its permissions, storage
 
 For questions or corrections, use the project repository and issue tracker.
 
-- Repository: [https://github.com/cognitiveshadows03/ArchiveTune](https://github.com/cognitiveshadows03/ArchiveTune)
-- Issues: [https://github.com/cognitiveshadows03/ArchiveTune/issues](https://github.com/cognitiveshadows03/ArchiveTune/issues)
+- Repository: [https://github.com/cognitiveshadows03/LunarTune](https://github.com/cognitiveshadows03/LunarTune)
+- Issues: [https://github.com/cognitiveshadows03/LunarTune/issues](https://github.com/cognitiveshadows03/LunarTune/issues)
 
 ## Technical Appendix
 

--- a/README.md
+++ b/README.md
@@ -20,15 +20,14 @@
     <a href="#features"><b>Features</b></a> •
     <a href="#download-now"><b>Download</b></a> •
     <a href="#screenshots"><b>Screenshots</b></a> •
-    <a href="https://github.com/cognitiveshadows03/LunarTune
-/issues/new/choose"><b>Support</b></a>
+    <a href="https://github.com/cognitiveshadows03/LunarTune/issues/new/choose"><b>Support</b></a>
   </p>
 
   <div align="center">
-    <img src="https://img.shields.io/github/v/release/cognitiveshadows03/ArchiveTune?style=for-the-badge&color=6366f1&labelColor=1e1e2e&logo=github" alt="Latest Version" />
-    <img src="https://img.shields.io/github/downloads/cognitiveshadows03/ArchiveTune/total?style=for-the-badge&color=6366f1&labelColor=1e1e2e&logo=github" alt="Downloads" />
-    <img src="https://img.shields.io/github/stars/cognitiveshadows03/ArchiveTune?style=for-the-badge&color=6366f1&labelColor=1e1e2e&logo=github" alt="Stars" />
-    <img src="https://img.shields.io/github/license/cognitiveshadows03/ArchiveTune?style=for-the-badge&color=6366f1&labelColor=1e1e2e" alt="License" />
+    <img src="https://img.shields.io/github/v/release/cognitiveshadows03/LunarTune?style=for-the-badge&color=6366f1&labelColor=1e1e2e&logo=github" alt="Latest Version" />
+    <img src="https://img.shields.io/github/downloads/cognitiveshadows03/LunarTune/total?style=for-the-badge&color=6366f1&labelColor=1e1e2e&logo=github" alt="Downloads" />
+    <img src="https://img.shields.io/github/stars/cognitiveshadows03/LunarTune?style=for-the-badge&color=6366f1&labelColor=1e1e2e&logo=github" alt="Stars" />
+    <img src="https://img.shields.io/github/license/cognitiveshadows03/LunarTune?style=for-the-badge&color=6366f1&labelColor=1e1e2e" alt="License" />
     <img src="https://img.shields.io/badge/Architecture-MVVM-6366f1?style=for-the-badge&labelColor=1e1e2e&logo=kotlin" alt="MVVM Architecture" />
     <img src="https://img.shields.io/badge/Language-Kotlin-7f52ff?style=for-the-badge&logo=kotlin&color=6366f1&labelColor=1e1e2e" alt="Kotlin Language" />
     <img src="https://img.shields.io/badge/Toolkit-Jetpack_Compose-4285f4?style=for-the-badge&logo=jetpack-compose&color=6366f1&labelColor=1e1e2e" alt="Jetpack Compose Toolkit" />
@@ -58,24 +57,15 @@
 
 <div align="center">
 
-<img src="https://github.com/cognitiveshadows03/LunarTune
-/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_1.jpg" alt="Browse" width="30%" />
-<img src="https://github.com/cognitiveshadows03/LunarTune
-/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_2.jpg" alt="Live Lyrics" width="30%" />
-<img src="https://github.com/cognitiveshadows03/LunarTune
-/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_3.jpg" alt="Theme Customization" width="30%" />
-<img src="https://github.com/cognitiveshadows03/LunarTune
-/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_4.jpg" alt="Live Statistics" width="30%" />
-<img src="https://github.com/cognitiveshadows03/LunarTune
-/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_5.jpg" alt="Artist" width="30%" />
-<img src="https://github.com/cognitiveshadows03/LunarTune
-/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_6.jpg" alt="Album" width="30%" />
-<img src="https://github.com/cognitiveshadows03/LunarTune
-/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_7.jpg" alt="Player" width="30%" />
-<img src="https://github.com/cognitiveshadows03/LunarTune
-/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_8.jpg" alt="Settings" width="30%" />
-<img src="https://github.com/cognitiveshadows03/LunarTune
-/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_9.jpg" alt="Settings" width="30%" />
+<img src="https://github.com/cognitiveshadows03/LunarTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_1.jpg" alt="Browse" width="30%" />
+<img src="https://github.com/cognitiveshadows03/LunarTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_2.jpg" alt="Live Lyrics" width="30%" />
+<img src="https://github.com/cognitiveshadows03/LunarTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_3.jpg" alt="Theme Customization" width="30%" />
+<img src="https://github.com/cognitiveshadows03/LunarTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_4.jpg" alt="Live Statistics" width="30%" />
+<img src="https://github.com/cognitiveshadows03/LunarTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_5.jpg" alt="Artist" width="30%" />
+<img src="https://github.com/cognitiveshadows03/LunarTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_6.jpg" alt="Album" width="30%" />
+<img src="https://github.com/cognitiveshadows03/LunarTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_7.jpg" alt="Player" width="30%" />
+<img src="https://github.com/cognitiveshadows03/LunarTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_8.jpg" alt="Settings" width="30%" />
+<img src="https://github.com/cognitiveshadows03/LunarTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_9.jpg" alt="Settings" width="30%" />
 
 </div>
 
@@ -180,9 +170,8 @@
   <thead>
     <tr>
       <td align="center" colspan="2">
-        <a href="https://github.com/cognitiveshadows03/LunarTune
-/releases/latest">
-          <img src="https://raw.githubusercontent.com/cognitiveshadows03/ArchiveTune/refs/heads/main/assets/badge_github.png" height="50" alt="Get LunarTune on GitHub">
+        <a href="https://github.com/cognitiveshadows03/LunarTune/releases/latest">
+          <img src="https://raw.githubusercontent.com/cognitiveshadows03/LunarTune/refs/heads/main/assets/badge_github.png" height="50" alt="Get LunarTune on GitHub">
         </a>
       </td>
     </tr>
@@ -197,8 +186,7 @@ Join Our Telegram Channels or Discord Servers for Support and Discussion.
 ---
 
 ### ✨ Project Contributors
-<a href="https://github.com/cognitiveshadows03/LunarTune
-/graphs/contributors">
+<a href="https://github.com/cognitiveshadows03/LunarTune/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=cognitiveshadows03/LunarTune&columns=6" />
 </a>
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-  <img src="https://github.com/cognitiveshadows03/ArchiveTune/blob/main/fastlane/metadata/android/en-US/images/icon.png" width="160" height="160" alt="LunarTune Logo" style="border-radius: 22%">
+  <img src="https://github.com/cognitiveshadows03/LunarTune/blob/main/fastlane/metadata/android/en-US/images/icon.png" width="160" height="160" alt="LunarTune Logo" style="border-radius: 22%">
 
   <h1>LunarTune</h1>
 
@@ -25,7 +25,7 @@
     <a href="https://lunartune.koiiverse.cloud/privacy"><b>プライバシー</b></a> •
     <a href="#download-now"><b>ダウンロード</b></a> •
     <a href="#screenshots"><b>スクリーンショット</b></a> •
-    <a href="https://github.com/cognitiveshadows03/ArchiveTune/issues/new/choose"><b>サポート</b></a>
+    <a href="https://github.com/cognitiveshadows03/LunarTune/issues/new/choose"><b>サポート</b></a>
   </p>
 
   <div align="center">
@@ -64,14 +64,14 @@
 
 <div align="center">
 
-<img src="https://github.com/cognitiveshadows03/ArchiveTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_1.jpg" alt="ブラウズ" width="30%" />
-<img src="https://github.com/cognitiveshadows03/ArchiveTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_2.jpg" alt="ライブ歌詞" width="30%" />
-<img src="https://github.com/cognitiveshadows03/ArchiveTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_3.jpg" alt="テーマカスタマイズ" width="30%" />
-<img src="https://github.com/cognitiveshadows03/ArchiveTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_4.jpg" alt="統計情報" width="30%" />
-<img src="https://github.com/cognitiveshadows03/ArchiveTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_5.jpg" alt="アーティスト" width="30%" />
-<img src="https://github.com/cognitiveshadows03/ArchiveTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_6.jpg" alt="アルバム" width="30%" />
-<img src="https://github.com/cognitiveshadows03/ArchiveTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_7.jpg" alt="プレイヤー" width="30%" />
-<img src="https://github.com/cognitiveshadows03/ArchiveTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_8.jpg" alt="設定" width="30%" />
+<img src="https://github.com/cognitiveshadows03/LunarTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_1.jpg" alt="ブラウズ" width="30%" />
+<img src="https://github.com/cognitiveshadows03/LunarTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_2.jpg" alt="ライブ歌詞" width="30%" />
+<img src="https://github.com/cognitiveshadows03/LunarTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_3.jpg" alt="テーマカスタマイズ" width="30%" />
+<img src="https://github.com/cognitiveshadows03/LunarTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_4.jpg" alt="統計情報" width="30%" />
+<img src="https://github.com/cognitiveshadows03/LunarTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_5.jpg" alt="アーティスト" width="30%" />
+<img src="https://github.com/cognitiveshadows03/LunarTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_6.jpg" alt="アルバム" width="30%" />
+<img src="https://github.com/cognitiveshadows03/LunarTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_7.jpg" alt="プレイヤー" width="30%" />
+<img src="https://github.com/cognitiveshadows03/LunarTune/blob/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot_8.jpg" alt="設定" width="30%" />
 
 </div>
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
     applicationId = "dev.citali.lunartune"
         minSdk = 26
         targetSdk = 37
-        versionCode = 140
-        versionName = "14.1.0"
+        versionCode = 500
+        versionName = "5.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
@@ -112,7 +112,7 @@ android {
                 ).trim()
         buildConfigField("String", "NIGHTLY_BUILD_HASH", "\"$nightlyBuildHash\"")
         buildConfigField("String", "DISTRIBUTION", "\"gms\"")
-        buildConfigField("boolean", "UPDATER_AVAILABLE", "true")
+        buildConfigField("boolean", "UPDATER_AVAILABLE", "false")
     }
 
     flavorDimensions += listOf("distribution", "device", "abi")
@@ -121,7 +121,7 @@ android {
             dimension = "distribution"
             isDefault = true
             buildConfigField("String", "DISTRIBUTION", "\"gms\"")
-            buildConfigField("boolean", "UPDATER_AVAILABLE", "true")
+            buildConfigField("boolean", "UPDATER_AVAILABLE", "false")
             buildConfigField("String", "DISCORD_APPLICATION_ID", "\"$discordApplicationId\"")
             buildConfigField("long", "DISCORD_APPLICATION_ID_LONG", "${discordApplicationIdLong}L")
             buildConfigField("String", "DISCORD_REDIRECT_SCHEME", "\"$discordRedirectScheme\"")
@@ -130,7 +130,7 @@ android {
         create("foss") {
             dimension = "distribution"
             buildConfigField("String", "DISTRIBUTION", "\"foss\"")
-            buildConfigField("boolean", "UPDATER_AVAILABLE", "true")
+            buildConfigField("boolean", "UPDATER_AVAILABLE", "false")
             buildConfigField("String", "DISCORD_APPLICATION_ID", "\"$discordApplicationId\"")
             buildConfigField("long", "DISCORD_APPLICATION_ID_LONG", "${discordApplicationIdLong}L")
             buildConfigField("String", "DISCORD_REDIRECT_SCHEME", "\"$discordRedirectScheme\"")

--- a/app/src/main/kotlin/dev/citali/lunartune/MainActivity.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/MainActivity.kt
@@ -615,26 +615,25 @@ class MainActivity : ComponentActivity() {
                     dev.citali.lunartune.utils.reportException(e)
                 }
 
-                if (
-                    BuildConfig.UPDATER_AVAILABLE &&
-                    System.currentTimeMillis() - Updater.lastCheckTime > 1.days.inWholeMilliseconds
-                ) {
-                    val channelString = withContext(Dispatchers.IO) { dataStore.data.first()[UpdateChannelKey] }
-                    val actualChannel = UpdateChannel.fromStoredName(channelString, defaultUpdateChannel)
-                    val versionResult =
-                        when (actualChannel) {
-                            UpdateChannel.CANARY -> Updater.getLatestCanaryVersionName()
-                            UpdateChannel.STABLE -> Updater.getLatestVersionName()
-                        }
-                    versionResult.onSuccess {
-                        if (Updater.isUpdateAvailable(it, BuildConfig.VERSION_NAME)) {
-                            latestUpdateChannel = actualChannel
-                            latestVersionName = it
+                if (BuildConfig.UPDATER_AVAILABLE) {
+                    if (System.currentTimeMillis() - Updater.lastCheckTime > 1.days.inWholeMilliseconds) {
+                        val channelString = withContext(Dispatchers.IO) { dataStore.data.first()[UpdateChannelKey] }
+                        val actualChannel = UpdateChannel.fromStoredName(channelString, defaultUpdateChannel)
+                        val versionResult =
+                            when (actualChannel) {
+                                UpdateChannel.CANARY -> Updater.getLatestCanaryVersionName()
+                                UpdateChannel.STABLE -> Updater.getLatestVersionName()
+                            }
+                        versionResult.onSuccess {
+                            if (Updater.isUpdateAvailable(it, BuildConfig.VERSION_NAME)) {
+                                latestUpdateChannel = actualChannel
+                                latestVersionName = it
+                            }
                         }
                     }
+                    dev.citali.lunartune.utils.UpdateNotificationManager
+                        .checkForUpdates(this@MainActivity)
                 }
-                dev.citali.lunartune.utils.UpdateNotificationManager
-                    .checkForUpdates(this@MainActivity)
             }
 
             // Use remembered instances so the same state object is used everywhere

--- a/app/src/main/kotlin/dev/citali/lunartune/about/AboutAttributionRepository.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/about/AboutAttributionRepository.kt
@@ -471,9 +471,9 @@ class AboutAttributionRepository
         )
 
         private companion object {
-            const val GitHubCommitsUrl = "https://api.github.com/repos/cognitiveshadows03/ArchiveTune/commits"
+            const val GitHubCommitsUrl = "https://api.github.com/repos/cognitiveshadows03/LunarTune/commits"
             const val GitHubTranslationResourceUrl =
-                "https://api.github.com/repos/cognitiveshadows03/ArchiveTune/contents/app/src/main/res"
+                "https://api.github.com/repos/cognitiveshadows03/LunarTune/contents/app/src/main/res"
             const val TranslationResourceRoot = "app/src/main/res"
             const val TranslationResourcePrefix = "values-"
             const val TranslationCommitMessagePrefix = "Translated using Weblate"

--- a/app/src/main/kotlin/dev/citali/lunartune/about/AboutContributorsRepository.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/about/AboutContributorsRepository.kt
@@ -195,6 +195,6 @@ class AboutContributorsRepository
         private companion object {
             const val ContributorsLimit = 20
             const val GitHubOwner = "cognitiveshadows03"
-            const val GitHubRepo = "ArchiveTune"
+            const val GitHubRepo = "LunarTune"
         }
     }

--- a/app/src/main/kotlin/dev/citali/lunartune/onboarding/OnboardingUseCases.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/onboarding/OnboardingUseCases.kt
@@ -198,7 +198,7 @@ class BuildOnboardingUiStateUseCase
                         titleResId = R.string.support_development_star,
                         descriptionResId = R.string.onboarding_community_github_desc,
                         iconResId = R.drawable.github,
-                        url = "https://github.com/cognitiveshadows03/ArchiveTune",
+                        url = "https://github.com/cognitiveshadows03/LunarTune",
                     ),
                     OnboardingCommunityActionUiModel(
                         id = "telegram",

--- a/app/src/main/kotlin/dev/citali/lunartune/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/playback/DownloadUtil.kt
@@ -16,10 +16,14 @@ import androidx.media3.datasource.ResolvingDataSource
 import androidx.media3.datasource.cache.Cache
 import androidx.media3.datasource.cache.CacheDataSink
 import androidx.media3.datasource.cache.CacheDataSource
+import androidx.media3.datasource.cache.CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR
 import androidx.media3.datasource.okhttp.OkHttpDataSource
+import androidx.media3.exoplayer.offline.DefaultDownloadIndex
+import androidx.media3.exoplayer.offline.DefaultDownloaderFactory
 import androidx.media3.exoplayer.offline.Download
 import androidx.media3.exoplayer.offline.DownloadManager
 import androidx.media3.exoplayer.offline.DownloadNotificationHelper
+import androidx.media3.exoplayer.offline.DownloadProgress
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -31,10 +35,9 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import dev.citali.lunartune.constants.AudioQuality
 import dev.citali.lunartune.constants.AudioQualityKey
 import dev.citali.lunartune.constants.PlayerStreamClient
@@ -79,8 +82,7 @@ class DownloadUtil
         )
         private val downloadScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         private val songUrlCache = ConcurrentHashMap<String, AuthScopedCacheValue>()
-        private val streamResolveMutex = Mutex()
-        private val downloadExecutor = Executors.newFixedThreadPool(MAX_PARALLEL_DOWNLOADS)
+        private val downloadExecutor = Executors.newSingleThreadExecutor()
 
         private val mediaOkHttpClient: OkHttpClient by lazy {
             OkHttpClient
@@ -134,22 +136,9 @@ class DownloadUtil
 
         private val dataSourceFactory =
             ResolvingDataSource.Factory(
-                CacheDataSource
-                    .Factory()
-                    .setCache(playerCache)
-                    .setUpstreamDataSourceFactory(
-                        OkHttpDataSource.Factory(
-                            mediaOkHttpClient,
-                        ),
-                    ).setCacheWriteDataSinkFactory(
-                        CacheDataSink.Factory().setCache(playerCache).setBufferSize(DOWNLOAD_WRITE_BUFFER_SIZE),
-                    ),
+                OkHttpDataSource.Factory(mediaOkHttpClient),
             ) { dataSpec ->
                 val mediaId = dataSpec.key ?: error("No media id")
-                val length = if (dataSpec.length >= 0) dataSpec.length else 1
-                if (playerCache.isCached(mediaId, dataSpec.position, length)) {
-                    return@Factory dataSpec
-                }
                 val lowDataModeActive = context.isLowDataModeActive()
                 val requestedAudioQuality = resolveDownloadAudioQuality(lowDataModeActive)
                 val streamCacheKey = buildSongUrlCacheKey(mediaId, requestedAudioQuality)
@@ -194,14 +183,27 @@ class DownloadUtil
         val downloadManager: DownloadManager =
             DownloadManager(
                 context,
-                databaseProvider,
-                downloadCache,
-                dataSourceFactory,
-                downloadExecutor,
+                DefaultDownloadIndex(databaseProvider),
+                DefaultDownloaderFactory(
+                    CacheDataSource
+                        .Factory()
+                        .setCache(downloadCache)
+                        .setUpstreamDataSourceFactory(dataSourceFactory)
+                        .setCacheWriteDataSinkFactory(
+                            CacheDataSink.Factory()
+                                .setCache(downloadCache)
+                                .setBufferSize(DOWNLOAD_WRITE_BUFFER_SIZE),
+                        ).setFlags(FLAG_IGNORE_CACHE_ON_ERROR),
+                    downloadExecutor,
+                ),
             ).apply {
                 maxParallelDownloads = MAX_PARALLEL_DOWNLOADS
                 addListener(
                     object : DownloadManager.Listener {
+                        override fun onInitialized(downloadManager: DownloadManager) {
+                            refreshActiveDownloadSnapshots()
+                        }
+
                         override fun onDownloadChanged(
                             downloadManager: DownloadManager,
                             download: Download,
@@ -213,7 +215,7 @@ class DownloadUtil
                             }
                             downloads.update { map ->
                                 map.toMutableMap().apply {
-                                    set(download.request.id, download)
+                                    set(download.request.id, download.toProgressSnapshot())
                                 }
                             }
                         }
@@ -231,11 +233,20 @@ class DownloadUtil
         init {
             downloadScope.launch {
                 val result = mutableMapOf<String, Download>()
-                val cursor = downloadManager.downloadIndex.getDownloads()
-                while (cursor.moveToNext()) {
-                    result[cursor.download.request.id] = cursor.download
+                downloadManager.downloadIndex.getDownloads().use { cursor ->
+                    while (cursor.moveToNext()) {
+                        result[cursor.download.request.id] = cursor.download.toProgressSnapshot()
+                    }
                 }
-                downloads.value = result
+                downloads.update { current ->
+                    result.apply { putAll(current) }
+                }
+            }
+            downloadScope.launch {
+                while (isActive) {
+                    delay(DOWNLOAD_PROGRESS_REFRESH_INTERVAL_MS)
+                    refreshActiveDownloadSnapshots()
+                }
             }
             downloadScope.launch {
                 var previousFingerprint: String? = null
@@ -251,15 +262,45 @@ class DownloadUtil
             }
         }
 
-        fun getDownload(songId: String): Flow<Download?> = downloads.map { it[songId] }
+        private fun refreshActiveDownloadSnapshots() {
+            val activeDownloads = downloadManager.currentDownloads
+            if (activeDownloads.isEmpty()) return
+            downloads.update { current ->
+                current.toMutableMap().apply {
+                    activeDownloads.forEach { download ->
+                        set(download.request.id, download.toProgressSnapshot())
+                    }
+                }
+            }
+        }
 
         private fun invalidateResolvedStreamUrl(url: String) {
             songUrlCache.entries.forEach { (cacheKey, cached) ->
                 if (cached.url == url && songUrlCache.remove(cacheKey, cached)) {
-                    YTPlayerUtils.invalidateCachedStreamUrls(cacheKey.substringBefore(':'))
+                    YTPlayerUtils.invalidateCachedStreamUrls(cacheKey.substringBeforeLast(':'))
                 }
             }
         }
+
+        private fun Download.toProgressSnapshot(): Download {
+            val progressSnapshot =
+                DownloadProgress().apply {
+                    bytesDownloaded = this@toProgressSnapshot.bytesDownloaded
+                    percentDownloaded = this@toProgressSnapshot.percentDownloaded
+                }
+            return Download(
+                request,
+                state,
+                startTimeMs,
+                updateTimeMs,
+                contentLength,
+                stopReason,
+                failureReason,
+                progressSnapshot,
+            )
+        }
+
+        fun getDownload(songId: String): Flow<Download?> = downloads.map { it[songId] }
 
         private fun resolveDownloadAudioQuality(lowDataModeActive: Boolean): AudioQuality =
             if (lowDataModeActive) AudioQuality.LOW else audioQuality
@@ -332,12 +373,11 @@ class DownloadUtil
         }
 
         companion object {
-            private const val MAX_PARALLEL_DOWNLOADS = 2
+            private const val MAX_PARALLEL_DOWNLOADS = 1
             private const val MAX_IDLE_DOWNLOAD_CONNECTIONS = 12
-            private const val MAX_DOWNLOAD_HTTP_REQUESTS = 2
+            private const val MAX_DOWNLOAD_HTTP_REQUESTS = 1
             private const val DOWNLOAD_READ_TIMEOUT_SECONDS = 90L
-            private const val DOWNLOAD_STREAM_RESOLVE_ATTEMPTS = 3
-            private const val DOWNLOAD_STREAM_RESOLVE_RETRY_MS = 750L
+            private const val DOWNLOAD_PROGRESS_REFRESH_INTERVAL_MS = 1_000L
             private const val DOWNLOAD_CONNECTION_KEEP_ALIVE_MINUTES = 5L
             private const val DOWNLOAD_WRITE_BUFFER_SIZE = 256 * 1024
             private val STREAM_REFRESH_RESPONSE_CODES = setOf(403, 404, 410, 416)

--- a/app/src/main/kotlin/dev/citali/lunartune/together/TogetherOnlineEndpoint.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/together/TogetherOnlineEndpoint.kt
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit
 
 object TogetherOnlineEndpoint {
     private const val EndpointSourceUrl =
-        "https://raw.githubusercontent.com/cognitiveshadows03/ArchiveTune/refs/heads/dev/ArchiveTuneKoiverseServer.txt"
+        "https://raw.githubusercontent.com/cognitiveshadows03/LunarTune/refs/heads/dev/ArchiveTuneKoiverseServer.txt"
 
     private const val CacheTtlMs: Long = 6 * 60 * 60 * 1000L
 

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/component/StarDialog.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/component/StarDialog.kt
@@ -84,7 +84,7 @@ fun StarDialog(
 
             FilledTonalButton(
                 onClick = {
-                    uriHandler.openUri("https://github.com/cognitiveshadows03/ArchiveTune")
+                    uriHandler.openUri("https://github.com/cognitiveshadows03/LunarTune")
                     onSupport()
                 },
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/DiscordExperimental.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/DiscordExperimental.kt
@@ -88,7 +88,7 @@ fun DiscordExperimental(navController: NavController) {
     val (button2CustomUrl, onButton2CustomUrlChange) =
         rememberPreference(
             key = DiscordActivityButton2CustomUrlKey,
-            defaultValue = "https://github.com/cognitiveshadows03/ArchiveTune",
+            defaultValue = "https://github.com/cognitiveshadows03/LunarTune",
         )
 
     Scaffold { inner ->

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/DiscordSettings.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/DiscordSettings.kt
@@ -346,7 +346,7 @@ fun DiscordSettings(navController: NavController) {
     val (button2CustomUrl) =
         rememberPreference(
             key = DiscordActivityButton2CustomUrlKey,
-            defaultValue = "https://github.com/cognitiveshadows03/ArchiveTune",
+            defaultValue = "https://github.com/cognitiveshadows03/LunarTune",
         )
 
     val (activityType, onActivityTypeChange) =
@@ -1231,7 +1231,7 @@ fun RichPresence(
     button2Label: String = "Go to LunarTune",
     button2Enabled: Boolean = true,
     button2UrlSource: String = "custom",
-    button2CustomUrl: String = "https://github.com/cognitiveshadows03/ArchiveTune",
+    button2CustomUrl: String = "https://github.com/cognitiveshadows03/LunarTune",
     isPlaying: Boolean = false,
 ) {
     val context = LocalContext.current
@@ -1342,7 +1342,7 @@ fun RichPresence(
                                 when (largeImageType.lowercase()) {
                                     "thumbnail" -> song?.song?.thumbnailUrl
                                     "artist" -> song?.artists?.firstOrNull()?.thumbnailUrl
-                                    "appicon" -> "https://raw.githubusercontent.com/cognitiveshadows03/ArchiveTune/main/fastlane/metadata/android/en-US/images/icon.png"
+                                    "appicon" -> "https://raw.githubusercontent.com/cognitiveshadows03/LunarTune/main/fastlane/metadata/android/en-US/images/icon.png"
                                     "custom" -> largeImageCustomUrl.ifBlank { song?.song?.thumbnailUrl }
                                     else -> song?.song?.thumbnailUrl
                                 }
@@ -1372,7 +1372,7 @@ fun RichPresence(
                                 when (smallImageType.lowercase()) {
                                     "thumbnail" -> songThumb
                                     "artist" -> artistThumb
-                                    "appicon" -> "https://raw.githubusercontent.com/cognitiveshadows03/ArchiveTune/main/fastlane/metadata/android/en-US/images/icon.png"
+                                    "appicon" -> "https://raw.githubusercontent.com/cognitiveshadows03/LunarTune/main/fastlane/metadata/android/en-US/images/icon.png"
                                     "custom" -> smallImageCustomUrl.takeIf { it.isNotBlank() } ?: songThumb
                                     "dontshow", "none" -> null
                                     else -> artistThumb

--- a/app/src/main/kotlin/dev/citali/lunartune/utils/DiscordImageResolver.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/utils/DiscordImageResolver.kt
@@ -134,7 +134,7 @@ object DiscordImageResolver {
             }
 
             "appicon" -> {
-                "https://raw.githubusercontent.com/cognitiveshadows03/ArchiveTune/main/fastlane/metadata/android/en-US/images/icon.png"
+                "https://raw.githubusercontent.com/cognitiveshadows03/LunarTune/main/fastlane/metadata/android/en-US/images/icon.png"
             }
 
             "custom" -> {

--- a/app/src/main/kotlin/dev/citali/lunartune/utils/DiscordRPC.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/utils/DiscordRPC.kt
@@ -53,9 +53,9 @@ class DiscordRPC(
 ) {
     companion object {
         private const val PAUSE_IMAGE_URL =
-            "https://raw.githubusercontent.com/cognitiveshadows03/ArchiveTune/main/fastlane/metadata/android/en-US/images/RPC/pause_icon.png"
+            "https://raw.githubusercontent.com/cognitiveshadows03/LunarTune/main/fastlane/metadata/android/en-US/images/RPC/pause_icon.png"
         private const val APP_ICON_URL =
-            "https://raw.githubusercontent.com/cognitiveshadows03/ArchiveTune/main/fastlane/metadata/android/en-US/images/icon.png"
+            "https://raw.githubusercontent.com/cognitiveshadows03/LunarTune/main/fastlane/metadata/android/en-US/images/icon.png"
         private const val TAG = "DiscordRPC"
     }
 
@@ -340,7 +340,7 @@ class DiscordRPC(
         val button2UrlSource = context.dataStore[DiscordActivityButton2UrlSourceKey] ?: "custom"
         val button2CustomUrl =
             context.dataStore[DiscordActivityButton2CustomUrlKey]
-                ?: "https://github.com/cognitiveshadows03/ArchiveTune"
+                ?: "https://github.com/cognitiveshadows03/LunarTune"
 
         return buildList {
             if (button1Enabled) {

--- a/app/src/main/kotlin/dev/citali/lunartune/utils/Updater.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/utils/Updater.kt
@@ -55,11 +55,11 @@ private data class ReleasesNetworkResult(
 object Updater {
     private val client = HttpClient()
     private const val ReleaseCacheCheckIntervalMs: Long = 6 * 60 * 60 * 1000L
-    private const val StableReleaseBaseUrl = "https://github.com/cognitiveshadows03/ArchiveTune/releases"
+    private const val StableReleaseBaseUrl = "https://github.com/cognitiveshadows03/LunarTune/releases"
     private const val CanaryReleaseBaseUrl =
         "https://github.com/cognitiveshadows03/canary/releases"
     private const val CanaryWorkflowRunsUrl =
-        "https://api.github.com/repos/cognitiveshadows03/ArchiveTune/actions/workflows/build.yml/runs" +
+        "https://api.github.com/repos/cognitiveshadows03/LunarTune/actions/workflows/build.yml/runs" +
             "?branch=main&status=success&per_page=1&exclude_pull_requests=true"
     var lastCheckTime = -1L
         private set
@@ -98,7 +98,7 @@ object Updater {
 
     private fun workflowArtifactDownloadUrl(): String {
         val artifactUrl =
-            "https://nightly.link/cognitiveshadows03/ArchiveTune/workflows/build/main/${workflowArtifactName()}"
+            "https://nightly.link/cognitiveshadows03/LunarTune/workflows/build/main/${workflowArtifactName()}"
         return if (canDownloadUpdatesDirectly) "$artifactUrl.zip" else artifactUrl
     }
 
@@ -322,7 +322,7 @@ object Updater {
         cachedEtag: String?,
     ): ReleasesNetworkResult {
         val response: HttpResponse =
-            client.get("https://api.github.com/repos/cognitiveshadows03/ArchiveTune/releases?per_page=$perPage") {
+            client.get("https://api.github.com/repos/cognitiveshadows03/LunarTune/releases?per_page=$perPage") {
                 headers {
                     append("Accept", "application/vnd.github+json")
                     append("User-Agent", "LunarTune")
@@ -394,7 +394,7 @@ object Updater {
 
             val response =
                 client
-                    .get("https://api.github.com/repos/cognitiveshadows03/ArchiveTune/commits?sha=$branch&per_page=$count")
+                    .get("https://api.github.com/repos/cognitiveshadows03/LunarTune/commits?sha=$branch&per_page=$count")
                     .bodyAsText()
             val jsonArray = JSONArray(response)
             val commits = mutableListOf<GitCommit>()

--- a/app/src/main/kotlin/dev/citali/lunartune/viewmodels/AboutViewModel.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/viewmodels/AboutViewModel.kt
@@ -416,7 +416,7 @@ class AboutViewModel
                             id = "github",
                             iconResId = R.drawable.github,
                             labelResId = R.string.about_content_desc_github,
-                            url = "https://github.com/cognitiveshadows03/ArchiveTune",
+                            url = "https://github.com/cognitiveshadows03/LunarTune",
                         ),
                         AboutLinkUiModel(
                             id = "telegram",
@@ -562,6 +562,6 @@ class AboutViewModel
         private companion object {
             const val MaxDisplayedContributors = 20
             const val DebugBuildBadge = "DEBUG"
-            const val ContributorsReadMoreUrl = "https://github.com/cognitiveshadows03/ArchiveTune/graphs/contributors"
+            const val ContributorsReadMoreUrl = "https://github.com/cognitiveshadows03/LunarTune/graphs/contributors"
         }
     }

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -1097,7 +1097,7 @@
     <string name="scheduled_backup_directory_saved">اتحفظ مجلد النسخ الاحتياطي بنجاح</string>
     <string name="scheduled_backup_load_failed">معرفناش نحمل إعدادات النسخ الاحتياطي المجدول</string>
     <string name="scheduled_backup_update_failed">معرفناش نحفظ إعدادات النسخ الاحتياطي المجدول</string>
-    <string name="gatekeeper_connection_blocked">الاتصال اتقفل من LunarTune Remote. معرفناش نتحقق إن النسخة دي رسمية من التطبيق. حمل نسخة رسمية من https://github.com/cognitiveshadows03/ArchiveTune أو https://t.me/LunarTuneGC.</string>
+    <string name="gatekeeper_connection_blocked">الاتصال اتقفل من LunarTune Remote. معرفناش نتحقق إن النسخة دي رسمية من التطبيق. حمل نسخة رسمية من https://github.com/cognitiveshadows03/LunarTune أو https://t.me/LunarTuneGC.</string>
     <string name="remove_from_library_confirm">عايز تشيل \"%1$s\" من المكتبة؟</string>
     <string name="eq_advanced_description">نطاقات دقيقة، تعديل الكسب، التأثيرات، والملفات الشخصية</string>
     <string name="eq_profiles_description">احفظ، استورد، وشارك إعدادات كاملة</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1149,7 +1149,7 @@
     <string name="scheduled_backup_directory_saved">تم حفظ دليل النسخ الاحتياطي</string>
     <string name="scheduled_backup_load_failed">تعذر تحميل إعدادات النسخ الاحتياطي المجدول</string>
     <string name="scheduled_backup_update_failed">تعذر حفظ إعدادات النسخ الاحتياطي المجدول</string>
-    <string name="gatekeeper_connection_blocked">تم حظر الاتصال بواسطة LunarTune Remote. لم يتم التحقق من هذا التطبيق كإصدار رسمي من LunarTune. قم بتثبيت إصدار رسمي من https://github.com/cognitiveshadows03/ArchiveTune أو https://t.me/LunarTuneGC.</string>
+    <string name="gatekeeper_connection_blocked">تم حظر الاتصال بواسطة LunarTune Remote. لم يتم التحقق من هذا التطبيق كإصدار رسمي من LunarTune. قم بتثبيت إصدار رسمي من https://github.com/cognitiveshadows03/LunarTune أو https://t.me/LunarTuneGC.</string>
     <string name="updates_channel_warning_canary_unstable">تُوفر إصدارات Canary للاختبار والوصول المبكر فقط.\nالاستقرار، التوافق، والوظائف غير مضمونة.</string>
     <string name="updates_channel_warning_canary_acknowledgement">ملاحظة: التنزيل مباشرة من GitHub يتجاوز أي فحص إضافي يجريه المتجر الذي ربما ثبّت التطبيق منه سابقًا.\nبالمتابعة، فإنك تقر بأن إصدارات Canary قد تكون غير مستقرة وتتحمل مسؤولية استخدامها.</string>
     <string name="updates_canary_channel_confirmation">التبديل إلى قناة Canary لتلقي إصدارات التطوير.\n\nتُحمل إصدارات Canary تلقائيًا من أحدث فرع تطوير.\nملاحظة: التنزيل مباشرة من GitHub يتجاوز أي فحص إضافي يجريه المتجر الذي ربما ثبّت التطبيق منه سابقًا.</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -1021,7 +1021,7 @@
     <string name="web_client_po_token">Webclient-PO-Token</string>
     <string name="po_token_gvs">PO-Token (GVS)</string>
     <string name="po_token_account_notice_body">Melde dich hier mit demselben Google-Konto an, dass du bereits für YouTube Music in LunarTune benutzt, bevor du ein PO-Token generierst.</string>
-    <string name="gatekeeper_connection_blocked">Verbindung durch LunarTune Remote blockiert. Diese App konnte nicht als offizieller LunarTune-Build verifiziert werden. Installiere einen offiziellen Build von https://github.com/cognitiveshadows03/ArchiveTune oder https://t.me/LunarTuneGC.</string>
+    <string name="gatekeeper_connection_blocked">Verbindung durch LunarTune Remote blockiert. Diese App konnte nicht als offizieller LunarTune-Build verifiziert werden. Installiere einen offiziellen Build von https://github.com/cognitiveshadows03/LunarTune oder https://t.me/LunarTuneGC.</string>
     <string name="scheduled_backup_disabled_description">Automatische Sicherungen sind pausiert.</string>
     <string name="scheduled_backup_enabled_description">Sicherungen laufen automatisch nach dem untenstehenden Plan.</string>
     <string name="po_token_account_notice_same_account">Wenn diese Webansicht ein anderes Konto benutzt, wird das generierte Token nicht richtig funktionieren.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1116,7 +1116,7 @@
     <string name="scheduled_backup_directory_saved">Directorio de copia de seguridad guardado</string>
     <string name="scheduled_backup_load_failed">No se pudieron cargar los ajustes de copia de seguridad programada</string>
     <string name="scheduled_backup_update_failed">No se pudieron guardar los ajustes de copia de seguridad programada</string>
-    <string name="gatekeeper_connection_blocked">Conexión bloqueada por ArchiveTune Remote. Esta aplicación no se ha podido verificar como una compilación oficial de ArchiveTune. Instale una compilación oficial desde https://github.com/cognitiveshadows03/ArchiveTune o https://t.me/LunarTuneGC.</string>
+    <string name="gatekeeper_connection_blocked">Conexión bloqueada por ArchiveTune Remote. Esta aplicación no se ha podido verificar como una compilación oficial de ArchiveTune. Instale una compilación oficial desde https://github.com/cognitiveshadows03/LunarTune o https://t.me/LunarTuneGC.</string>
     <string name="enable_megalobiz_lyrics">Activar las letras de Megalobiz</string>
     <string name="enable_betterlyrics_portato">Activar BetterLyrics Portato</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1116,7 +1116,7 @@
     <string name="scheduled_backup_directory_saved">Répertoire de sauvegarde enregistré</string>
     <string name="scheduled_backup_load_failed">Impossible de charger les paramètres de sauvegarde planifiée</string>
     <string name="scheduled_backup_update_failed">Impossible d\'enregistrer les paramètres de sauvegarde planifiée</string>
-    <string name="gatekeeper_connection_blocked">Connexion bloquée par LunarTune Remote. Il n\'a pas été possible de vérifier que cette application correspondait à une version officielle d\'LunarTune. Installez une version officielle à partir de https://github.com/cognitiveshadows03/ArchiveTune ou https://t.me/LunarTuneGC.</string>
+    <string name="gatekeeper_connection_blocked">Connexion bloquée par LunarTune Remote. Il n\'a pas été possible de vérifier que cette application correspondait à une version officielle d\'LunarTune. Installez une version officielle à partir de https://github.com/cognitiveshadows03/LunarTune ou https://t.me/LunarTuneGC.</string>
     <string name="enable_megalobiz_lyrics">Activer les paroles de Megalobiz</string>
     <string name="enable_betterlyrics_portato">Activer BetterLyrics Portato</string>
 </resources>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -1097,5 +1097,5 @@
     <string name="scheduled_backup_directory_saved">Direktori pencadangan disimpan</string>
     <string name="scheduled_backup_load_failed">Pengaturan pencadangan terjadwal tidak dapat dimuat</string>
     <string name="scheduled_backup_update_failed">Pengaturan pencadangan terjadwal tidak dapat disimpan</string>
-    <string name="gatekeeper_connection_blocked">Koneksi diblokir oleh LunarTune Remote. Aplikasi ini tidak dapat diverifikasi sebagai build LunarTune resmi. Instal build resmi dari https://github.com/cognitiveshadows03/ArchiveTune atau https://t.me/LunarTuneGC.</string>
+    <string name="gatekeeper_connection_blocked">Koneksi diblokir oleh LunarTune Remote. Aplikasi ini tidak dapat diverifikasi sebagai build LunarTune resmi. Instal build resmi dari https://github.com/cognitiveshadows03/LunarTune atau https://t.me/LunarTuneGC.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1119,6 +1119,6 @@
     <string name="scheduled_backup_directory_saved">Diretório de backup salvo</string>
     <string name="scheduled_backup_load_failed">Não foi possível carregar as configurações de backup programado</string>
     <string name="scheduled_backup_update_failed">Não foi possível salvar as configurações do backup programado</string>
-    <string name="gatekeeper_connection_blocked">Conexão bloqueada pelo LunarTune Remote. Não foi possível verificar se este aplicativo é uma versão oficial do LunarTune. Instale uma versão oficial em https://github.com/cognitiveshadows03/ArchiveTune ou https://t.me/LunarTuneGC.</string>
+    <string name="gatekeeper_connection_blocked">Conexão bloqueada pelo LunarTune Remote. Não foi possível verificar se este aplicativo é uma versão oficial do LunarTune. Instale uma versão oficial em https://github.com/cognitiveshadows03/LunarTune ou https://t.me/LunarTuneGC.</string>
     <string name="enable_betterlyrics_portato">Ativar BetterLyrics Portato</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1118,5 +1118,5 @@
     <string name="scheduled_backup_directory_saved">Diretório de cópias de segurança guardado</string>
     <string name="scheduled_backup_load_failed">Não foi possível carregar as configurações de cópia de segurança programadas</string>
     <string name="scheduled_backup_update_failed">Não foi possível guardar as configurações de cópia de segurança programadas</string>
-    <string name="gatekeeper_connection_blocked">Ligação bloqueada pelo LunarTune Remote. Não foi possível verificar se esta aplicação é uma versão oficial do LunarTune. Instala uma versão oficial em https://github.com/cognitiveshadows03/ArchiveTune ou https://t.me/LunarTuneGC.</string>
+    <string name="gatekeeper_connection_blocked">Ligação bloqueada pelo LunarTune Remote. Não foi possível verificar se esta aplicação é uma versão oficial do LunarTune. Instala uma versão oficial em https://github.com/cognitiveshadows03/LunarTune ou https://t.me/LunarTuneGC.</string>
 </resources>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -1108,5 +1108,5 @@
     <string name="scheduled_backup_directory_saved">متبادل کی ڈائریکٹری محفوظ ہوئ</string>
     <string name="scheduled_backup_load_failed">جدول متبادل کی ترتیب لادی نہ جا سکیں</string>
     <string name="scheduled_backup_update_failed">جدول متبادل کی ترتیبات محفوظ نہ ہو سکیں</string>
-    <string name="gatekeeper_connection_blocked">‪‫‪‫LunarTune Remote نے رابطہ مسدود کردیا۔ اس ایپ کی بطور آفیشل LunarTune تعمیر تصدیق نہیں ہو سکی۔ آفیشل تعمیر https://github.com/cognitiveshadows03/ArchiveTune یا https://t.me/LunarTuneGC سے نصب کریں۔</string>
+    <string name="gatekeeper_connection_blocked">‪‫‪‫LunarTune Remote نے رابطہ مسدود کردیا۔ اس ایپ کی بطور آفیشل LunarTune تعمیر تصدیق نہیں ہو سکی۔ آفیشل تعمیر https://github.com/cognitiveshadows03/LunarTune یا https://t.me/LunarTuneGC سے نصب کریں۔</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1091,7 +1091,7 @@
     <string name="scheduled_backup_directory_saved">备份目录已保存</string>
     <string name="scheduled_backup_load_failed">无法加载计划自动备份设置</string>
     <string name="scheduled_backup_update_failed">无法保存计划自动备份设置</string>
-    <string name="gatekeeper_connection_blocked">连接已被 LunarTune Remote 拒绝。当前应用未能通过官方 LunarTune 构建验证。请从 https://github.com/cognitiveshadows03/ArchiveTune 或 https://t.me/LunarTuneGC 获取官方构建版本</string>
+    <string name="gatekeeper_connection_blocked">连接已被 LunarTune Remote 拒绝。当前应用未能通过官方 LunarTune 构建验证。请从 https://github.com/cognitiveshadows03/LunarTune 或 https://t.me/LunarTuneGC 获取官方构建版本</string>
     <plurals name="widget_total_plays">
         <item quantity="other">%d 次播放</item>
     </plurals>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1036,7 +1036,7 @@
     <string name="eq_decibels">%1$+.1f dB</string>
     <string name="eq_percent">%1$d%%</string>
     <string name="eq_frequency_hertz">%1$d Hz</string>
-    <string name="gatekeeper_connection_blocked">連線被 LunarTune Remote 阻止。該應用程式無法被驗證為 LunarTune 官方版本。請從 https://github.com/cognitiveshadows03/ArchiveTune 或 https://t.me/LunarTuneGC 安裝官方版本。</string>
+    <string name="gatekeeper_connection_blocked">連線被 LunarTune Remote 阻止。該應用程式無法被驗證為 LunarTune 官方版本。請從 https://github.com/cognitiveshadows03/LunarTune 或 https://t.me/LunarTuneGC 安裝官方版本。</string>
     <string name="eq_frequency_kilohertz">%1$.1f kHz</string>
     <string name="ai_content_filter">AI 內容過濾器</string>
     <string name="ai_content_filter_hide">隱藏AI生成的內容</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1109,7 +1109,7 @@
     <string name="scheduled_backup_directory_saved">Backup directory saved</string>
     <string name="scheduled_backup_load_failed">Scheduled backup settings could not be loaded</string>
     <string name="scheduled_backup_update_failed">Scheduled backup settings could not be saved</string>
-    <string name="gatekeeper_connection_blocked">Connection blocked by LunarTune Remote. This app could not be verified as an official LunarTune build. Install an official build from https://github.com/cognitiveshadows03/ArchiveTune or https://t.me/LunarTuneGC.</string>
+    <string name="gatekeeper_connection_blocked">Connection blocked by LunarTune Remote. This app could not be verified as an official LunarTune build. Install an official build from https://github.com/cognitiveshadows03/LunarTune or https://t.me/LunarTuneGC.</string>
     <string name="navigation_bar_style">Navigation bar style</string>
     <string name="navigation_bar_style_default">Docked</string>
     <string name="navigation_bar_style_floating">Floating</string>


### PR DESCRIPTION
## Summary
- Port original ArchiveTune download manager: write to the download cache, snapshot progress every second (fixes 0% / 0 B/s UI), serialize to one download at a time.
- Preferred stream client still comes from Stream Sources.
- Bulk multi-download failures are acceptable for 5.0.0.
- All cognitiveshadows03/ArchiveTune GitHub links now point at cognitiveshadows03/LunarTune.
- Version 5.0.0 (versionCode 500).
- In-app updater disabled (UPDATER_AVAILABLE=false); no auto-check or settings Updates row.

## Test
- Download a single song after playback works; percent and speed should move.
- Settings should not show Updates.