### PR TITLE
feat: split Telegram APKs and GitHub logs topics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-          TOPIC_ID: ${{ secrets.TELEGRAM_TOPIC_ID }}
+          TOPIC_ID: ${{ secrets.TELEGRAM_TOPIC_LOGS || secrets.TELEGRAM_TOPIC_ID }}
         run: |
           python ./.github/workflows/notify_telegram.py
         continue-on-error: true
@@ -251,6 +251,7 @@ jobs:
     name: Send APKs to Telegram
     runs-on: ubuntu-latest
     needs: build
+    if: success()
     steps:
       - uses: actions/checkout@v7
         with:
@@ -294,6 +295,48 @@ jobs:
           APK_PATH: app/build/outputs/apk/download/*.apk
         run: |
           python ./.github/workflows/deploy_artifacts.py
+        continue-on-error: true
+
+  notifyTelegramLogs:
+    name: Send GitHub logs to Telegram
+    runs-on: ubuntu-latest
+    needs: [build, aggregateAndSend]
+    if: always() && github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python 3
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Install Dependencies
+        run: pip install requests
+
+      - name: Download this run log
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run view "${{ github.run_id }}" --log > /tmp/actions-run.log || true
+          if [ ! -s /tmp/actions-run.log ]; then
+            echo "No job log available yet. Open ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" > /tmp/actions-run.log
+          fi
+
+      - name: Send status and log to GitHub Logs topic
+        env:
+          BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TOPIC_ID: ${{ secrets.TELEGRAM_TOPIC_LOGS || secrets.TELEGRAM_TOPIC_ID }}
+          BUILD_CONCLUSION: ${{ needs.build.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUN_ID: ${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
+          ACTOR: ${{ github.actor }}
+          BRANCH: ${{ github.ref_name }}
+          JOB_SUMMARY: "build=${{ needs.build.result }} telegram=${{ needs.aggregateAndSend.result }}"
+          LOG_FILE: /tmp/actions-run.log
+        run: python ./.github/workflows/notify_build_status.py
         continue-on-error: true
 
   build_debug:

--- a/.github/workflows/deploy_artifacts.py
+++ b/.github/workflows/deploy_artifacts.py
@@ -107,7 +107,7 @@ async def send_files(file_paths):
     print(f"Sending {len(existing_files)} files to the Telegram group")
     device_names = sorted({extract_device_name(path) for path in existing_files})
     abi_names = sorted({extract_abi_name(path) for path in existing_files})
-    topic_id = os.getenv("TOPIC_ID")
+    topic_id = os.getenv("TOPIC_ID") or os.getenv("ARTIFACTS_TOPIC_ID")
 
     message = (
         f"**Commit by:** {commit_author}\n"

--- a/.github/workflows/notify_build_status.py
+++ b/.github/workflows/notify_build_status.py
@@ -1,0 +1,79 @@
+import os
+import re
+import requests
+
+
+def escape_markdown_v2(text):
+    escape_chars = r'_*[]()~`>#+-=|{}.!'
+    return re.sub(r'([%s])' % re.escape(escape_chars), r'\\\1', text)
+
+
+def main():
+    bot_token = os.environ['BOT_TOKEN']
+    chat_id = os.environ['CHAT_ID']
+    topic_id = os.environ.get('TOPIC_ID') or os.environ.get('LOGS_TOPIC_ID')
+    conclusion = os.environ.get('BUILD_CONCLUSION', 'unknown')
+    run_url = os.environ.get('RUN_URL', '')
+    run_id = os.environ.get('RUN_ID', '')
+    sha = os.environ.get('COMMIT_SHA', '')
+    short_sha = sha[:7] if sha else ''
+    actor = os.environ.get('ACTOR', '')
+    branch = os.environ.get('BRANCH', '')
+    jobs = os.environ.get('JOB_SUMMARY', '')
+
+    status_label = {
+        'success': 'succeeded',
+        'failure': 'failed',
+        'cancelled': 'was cancelled',
+        'skipped': 'was skipped',
+    }.get(conclusion, conclusion)
+
+    lines = [
+        f"Build APKs {status_label} on `{escape_markdown_v2(branch)}` by {escape_markdown_v2(actor)}",
+        f"Commit: `{escape_markdown_v2(short_sha)}`",
+    ]
+    if run_url:
+        lines.append(f"[Open GitHub Actions log]({run_url})")
+    elif run_id:
+        lines.append(f"Run id: `{escape_markdown_v2(run_id)}`")
+    if jobs:
+        lines.append('')
+        lines.append(escape_markdown_v2(jobs))
+
+    payload = {
+        'chat_id': chat_id,
+        'text': '\n'.join(lines),
+        'parse_mode': 'MarkdownV2',
+        'disable_web_page_preview': True,
+    }
+    if topic_id:
+        payload['message_thread_id'] = int(topic_id)
+
+    url = f'https://api.telegram.org/bot{bot_token}/sendMessage'
+    response = requests.post(url, json=payload, timeout=30)
+    if response.status_code != 200:
+        print(f'Failed to send status: {response.status_code} {response.text}')
+    else:
+        print('Build status sent.')
+
+    log_path = os.environ.get('LOG_FILE')
+    if log_path and os.path.isfile(log_path):
+        with open(log_path, 'rb') as handle:
+            data = {'chat_id': chat_id, 'caption': f'Actions log {short_sha}'}
+            if topic_id:
+                data['message_thread_id'] = int(topic_id)
+            doc_url = f'https://api.telegram.org/bot{bot_token}/sendDocument'
+            doc = requests.post(
+                doc_url,
+                data=data,
+                files={'document': handle},
+                timeout=120,
+            )
+        if doc.status_code != 200:
+            print(f'Failed to send log file: {doc.status_code} {doc.text}')
+        else:
+            print('Log file sent.')
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/notify_telegram.py
+++ b/.github/workflows/notify_telegram.py
@@ -20,7 +20,7 @@ def escape_parentheses(text):
 def main():
     bot_token = os.environ['BOT_TOKEN']
     chat_id = os.environ['CHAT_ID']
-    topic_id = os.environ.get('TOPIC_ID')
+    topic_id = os.environ.get('TOPIC_ID') or os.environ.get('LOGS_TOPIC_ID')
 
     commit_author, commit_message, commit_hash, commit_hash_short = get_git_commit_info()
 


### PR DESCRIPTION
Routes CI Telegram posts to the LunarTune forum topics.

- Nightly Artifact: signed APKs (TELEGRAM_TOPIC_ARTIFACTS)
- GitHub Logs: build start, result, Actions URL, and the run log file (TELEGRAM_TOPIC_LOGS)

Falls back to TELEGRAM_TOPIC_ID if the new secrets are missing.