### PR TITLE
fix: Dolby/Dirac EQ selection and stronger presets

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/equalizer/EqualizerRepository.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/equalizer/EqualizerRepository.kt
@@ -93,6 +93,14 @@ class EqualizerRepository
                 it[EqualizerSelectedProfileIdKey] = MANUAL_PROFILE_ID
             }
 
+        suspend fun applyNamedBandPreset(
+            profileId: String,
+            levelsMb: List<Int>,
+        ) = edit {
+            it[EqualizerBandLevelsMbKey] = EqualizerJson.json.encodeToString(levelsMb)
+            it[EqualizerSelectedProfileIdKey] = profileId
+        }
+
         suspend fun setOutputGainEnabled(enabled: Boolean) = editManual { it[EqualizerOutputGainEnabledKey] = enabled }
 
         suspend fun setOutputGainMb(gainMb: Int) = editManual { it[EqualizerOutputGainMbKey] = gainMb.coerceIn(-1500, 1500) }

--- a/app/src/main/kotlin/dev/citali/lunartune/equalizer/EqualizerUseCases.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/equalizer/EqualizerUseCases.kt
@@ -119,6 +119,11 @@ class UpdateEqualizerUseCase
 
         suspend fun updateBandLevels(levelsMb: List<Int>) = repository.updateBandLevels(levelsMb)
 
+        suspend fun applyNamedBandPreset(
+            profileId: String,
+            levelsMb: List<Int>,
+        ) = repository.applyNamedBandPreset(profileId, levelsMb)
+
         suspend fun setOutputGainEnabled(enabled: Boolean) = repository.setOutputGainEnabled(enabled)
 
         suspend fun setOutputGainMb(value: Int) = repository.setOutputGainMb(value)

--- a/app/src/main/kotlin/dev/citali/lunartune/equalizer/ViviEqualizerPresets.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/equalizer/ViviEqualizerPresets.kt
@@ -8,14 +8,15 @@
 package dev.citali.lunartune.equalizer
 
 /**
- * 10-band millibel curves from Vivi Music (vivizzz007/vivi-music).
+ * 10-band millibel curves inspired by Vivi Music Dolby / Dirac profiles.
+ * Centers: 31, 62, 125, 250, 500, 1k, 2k, 4k, 8k, 16k Hz.
  */
 object ViviEqualizerPresets {
     val chips: List<Pair<String, String>> =
         listOf(
             "dolby_open" to "Dolby Open",
             "dolby_rich" to "Dolby Rich",
-            "dolby_focused" to "Dolby Focused",
+            "dolby_focused" to "Dolby Focus",
             "dirac_music" to "Dirac Music",
             "dirac_movie" to "Dirac Movie",
             "dirac_game" to "Dirac Game",
@@ -23,12 +24,18 @@ object ViviEqualizerPresets {
 
     fun levelsMb(id: String): List<Int>? =
         when (id) {
-            "dolby_open" -> listOf(150, 180, 220, 180, 160, 210, 250, 280, 180, 80)
-            "dolby_rich" -> listOf(100, 160, 200, 220, 280, 260, 240, 200, 150, 50)
-            "dolby_focused" -> listOf(-300, -50, 130, 180, 220, 120, 140, 100, -50, -300)
-            "dirac_music" -> listOf(200, 140, 80, 0, 30, 80, 140, 200, 280, 350)
-            "dirac_movie" -> listOf(300, 250, 150, 0, 70, 120, 180, 250, 320, 400)
-            "dirac_game" -> listOf(150, 250, 200, 0, 80, 150, 300, 450, 400, 280)
+            // Wide, airy stage: lifted extremes, open top end.
+            "dolby_open" -> listOf(350, 280, 180, 80, 40, 120, 220, 360, 450, 380)
+            // Warm body: bass + low-mids, soft air.
+            "dolby_rich" -> listOf(480, 400, 280, 180, 220, 160, 80, 140, 220, 120)
+            // Vocal pocket: cut rumble/air, boost presence.
+            "dolby_focused" -> listOf(-450, -180, 80, 260, 380, 280, 220, 80, -120, -380)
+            // Music: gentle bass, rising detail toward treble.
+            "dirac_music" -> listOf(280, 180, 80, 0, 40, 120, 220, 340, 460, 520)
+            // Movie: LFE + dialogue shelf + surround highs.
+            "dirac_movie" -> listOf(520, 400, 220, 20, 140, 200, 280, 400, 520, 480)
+            // Game: punch + footsteps/cues in upper mids and highs.
+            "dirac_game" -> listOf(320, 420, 260, 20, 80, 180, 380, 560, 500, 340)
             else -> null
         }
 }

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/menu/EqualizerDialog.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/menu/EqualizerDialog.kt
@@ -667,6 +667,8 @@ private fun PresetSection(
                                     preset.name.isNullOrBlank() -> stringResource(R.string.eq_preset_number, index)
                                     else -> preset.name.orEmpty()
                                 },
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
                         )
                     },
                     colors = FilterChipDefaults.filterChipColors(selectedContainerColor = MaterialTheme.colorScheme.secondaryContainer),

--- a/app/src/main/kotlin/dev/citali/lunartune/viewmodels/EqualizerViewModel.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/viewmodels/EqualizerViewModel.kt
@@ -249,7 +249,7 @@ class EqualizerViewModel
                 val curve = ViviEqualizerPresets.levelsMb(presetId.removePrefix("vivi:")) ?: return
                 val count = configuration?.capabilities?.bandCount ?: curve.size
                 launchUpdate {
-                    updateEqualizer.updateBandLevels(resampleLevels(curve, count))
+                    updateEqualizer.applyNamedBandPreset(presetId, resampleLevels(curve, count))
                 }
                 return
             }


### PR DESCRIPTION
Advanced EQ chips for Dolby and Dirac never stayed selected because applying those curves marked the profile as manual. That id is now stored, the extra device Flat chip is hidden, and the six Vivi-style curves are stronger 10-band shapes (open / rich / focus, music / movie / game).