### PR TITLE
fix: LunarTune About credits

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/AboutScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/AboutScreen.kt
@@ -732,18 +732,6 @@ private fun AboutSuccessContent(
                 )
             }
         }
-
-        item(key = "contributors", contentType = "about_contributors") {
-            AboutContentContainer {
-                ContributorsSection(
-                    state = model.contributorsState,
-                    readMoreUrl = model.contributorsReadMoreUrl,
-                    onOpenProfile = onOpenUri,
-                    onRetry = onRetryContributors,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
-        }
     }
 }
 

--- a/app/src/main/kotlin/dev/citali/lunartune/viewmodels/AboutViewModel.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/viewmodels/AboutViewModel.kt
@@ -265,7 +265,7 @@ class AboutViewModel
         private var activeDialog = AboutDialog.NONE
 
         init {
-            loadContributors()
+            updateState()
         }
 
         fun retryContributors() {

--- a/app/src/main/res/values-ar-rEG/archivetune_strings.xml
+++ b/app/src/main/res/values-ar-rEG/archivetune_strings.xml
@@ -564,7 +564,7 @@
     <string name="about_license_unknown">ترخيص غير معروف</string>
     <string name="about_position_lead_dev">إيه؟</string>
     <string name="about_position_developers">مطور | فريق</string>
-    <string name="about_position_mo_agamy">إطار العمل الأساسي | Metrolist</string>
+    <string name="about_position_mo_agamy">Playback client fallback</string>
     <string name="about_position_zion_huang">مبتكر InnerTune · الأساس لـ Metrolist و LunarTune والتفرعات التانية</string>
     <string name="about_content_desc_github">GitHub</string>
     <string name="about_content_desc_website">الموقع الإلكتروني</string>

--- a/app/src/main/res/values-ar/archivetune_strings.xml
+++ b/app/src/main/res/values-ar/archivetune_strings.xml
@@ -647,7 +647,7 @@
     <string name="about_position_lead_dev">ماذا؟</string>
     <string name="about_position_developers">مطور | الفريق</string>
     <string name="about_position_yuki">dummy reze | مسؤول</string>
-    <string name="about_position_mo_agamy">الإطار الأساسي | Metrolist</string>
+    <string name="about_position_mo_agamy">Playback client fallback</string>
     <string name="about_position_zion_huang">منشئ InnerTune · الأساس لـ Metrolist و LunarTune والتفرعات الأخرى</string>
     <string name="about_content_desc_github">GitHub</string>
     <string name="about_content_desc_website">الموقع الإلكتروني</string>

--- a/app/src/main/res/values-de-rDE/archivetune_strings.xml
+++ b/app/src/main/res/values-de-rDE/archivetune_strings.xml
@@ -497,7 +497,7 @@
     <string name="about_content_desc_discord">Discord</string>
     <string name="about_content_desc_github">GitHub</string>
     <string name="about_content_desc_website">Webseite</string>
-    <string name="about_position_mo_agamy">Basis-Framework | Metrolist</string>
+    <string name="about_position_mo_agamy">Playback client fallback</string>
     <string name="about_license_unknown">Unbekannte Lizenz</string>
     <string name="about_contributor_translation">Beitragende Übersetzung</string>
     <string name="about_lead_developer">Leitender Entwickler</string>

--- a/app/src/main/res/values-es/archivetune_strings.xml
+++ b/app/src/main/res/values-es/archivetune_strings.xml
@@ -540,7 +540,7 @@
     <string name="about_respecter">Cumplir</string>
     <string name="about_contributors">Colaboradores</string>
     <string name="about_position_lead_dev">¿Eh?</string>
-    <string name="about_position_mo_agamy">Estructura básica | Metrolist</string>
+    <string name="about_position_mo_agamy">Playback client fallback</string>
     <string name="about_position_zion_huang">Creador de InnerTune · Fundador de Metrolist, LunarTune y otras bifurcaciones</string>
     <string name="about_content_desc_github">GitHub</string>
     <string name="about_content_desc_website">Página web</string>

--- a/app/src/main/res/values-fr/archivetune_strings.xml
+++ b/app/src/main/res/values-fr/archivetune_strings.xml
@@ -348,7 +348,7 @@
     <string name="ai_provider">Fournisseur d\'IA</string>
     <string name="aod_shape_circle">Cercle</string>
     <string name="aod_customize_visibility">Visibilité</string>
-    <string name="about_position_mo_agamy">Cadre de base | Metrolist</string>
+    <string name="about_position_mo_agamy">Playback client fallback</string>
     <string name="aod_background_tonal_edge">Contraste de tons</string>
     <string name="about_content_desc_donate">Faire un don</string>
     <string name="aod_customize_sample_duration">3:48</string>

--- a/app/src/main/res/values-in-rID/archivetune_strings.xml
+++ b/app/src/main/res/values-in-rID/archivetune_strings.xml
@@ -628,7 +628,7 @@
     <string name="about_position_lead_dev">Eh?</string>
     <string name="about_position_developers">Pengembang | Tim</string>
     <string name="about_position_yuki">dummy reze | Admin</string>
-    <string name="about_position_mo_agamy">Base dari | Metrolist</string>
+    <string name="about_position_mo_agamy">Playback client fallback</string>
     <string name="about_position_zion_huang">Pencipta InnerTune · Fondasi untuk Metrolist, LunarTune, dan fork lainnya</string>
     <string name="about_content_desc_github">GitHub</string>
     <string name="about_content_desc_website">Situs Web</string>

--- a/app/src/main/res/values-ja/archivetune_strings.xml
+++ b/app/src/main/res/values-ja/archivetune_strings.xml
@@ -565,7 +565,7 @@
     <string name="about_position_lead_dev">え？</string>
     <string name="about_position_developers">開発者 | チーム</string>
     <string name="about_position_yuki">見た目担当 😂 | 管理者</string>
-    <string name="about_position_mo_agamy">ベースフレームワーク | Metrolist</string>
+    <string name="about_position_mo_agamy">Playback client fallback</string>
     <string name="about_position_zion_huang">InnerTuneの作成者 · Metrolist、LunarTune、その他フォークの基盤</string>
     <string name="about_content_desc_github">GitHub</string>
     <string name="about_content_desc_website">ウェブサイト</string>

--- a/app/src/main/res/values-ko/archivetune_strings.xml
+++ b/app/src/main/res/values-ko/archivetune_strings.xml
@@ -399,7 +399,7 @@
     <string name="aod_customize_subtitle">모양, 레이아웃, 컨트롤 및 앰비언트 스타일 설정</string>
     <string name="aod_shape_circle">원형</string>
     <string name="aod_customize_visibility">표시 설정</string>
-    <string name="about_position_mo_agamy">기초 프레임워크 설계 | Metrolist</string>
+    <string name="about_position_mo_agamy">Playback client fallback</string>
     <string name="aod_background_tonal_edge">톤 엣지</string>
     <string name="about_content_desc_donate">후원</string>
     <string name="aod_customize_sample_duration">3:48</string>

--- a/app/src/main/res/values-pt-rBR/archivetune_strings.xml
+++ b/app/src/main/res/values-pt-rBR/archivetune_strings.xml
@@ -565,7 +565,7 @@
     <string name="about_position_lead_dev">Eh?</string>
     <string name="about_position_developers">Desenvolvedor | Equipe</string>
     <string name="about_position_yuki">reze idiota | Admin</string>
-    <string name="about_position_mo_agamy">Framework base | Metrolist</string>
+    <string name="about_position_mo_agamy">Playback client fallback</string>
     <string name="about_position_zion_huang">Criador do InnerTune · Fundação do Metrolist, LunarTune e outros forks</string>
     <string name="about_content_desc_github">GitHub</string>
     <string name="about_content_desc_website">Site</string>

--- a/app/src/main/res/values-ru/archivetune_strings.xml
+++ b/app/src/main/res/values-ru/archivetune_strings.xml
@@ -283,7 +283,7 @@
     <string name="crossfade_gapless_title">Кроссфейд без пробелов</string>
     <string name="crossfade_gapless_description">Затухание и появление без перекрываний звука.</string>
     <string name="about_position_yuki">Чисто для показа 😂 | Админ</string>
-    <string name="about_position_mo_agamy">Базовая структура | Metrolist</string>
+    <string name="about_position_mo_agamy">Playback client fallback</string>
     <string name="about_position_zion_huang">Создатель InnerTune · Основатель проектов Metrolist, LunarTune и других форков</string>
     <string name="about_content_desc_github">GitHub</string>
     <string name="about_content_desc_website">Веб-сайт</string>

--- a/app/src/main/res/values-vi/archivetune_strings.xml
+++ b/app/src/main/res/values-vi/archivetune_strings.xml
@@ -536,7 +536,7 @@
     <string name="about_respecter">Tôn kính</string>
     <string name="about_contributors">Người đóng góp</string>
     <string name="about_position_lead_dev">Hả?</string>
-    <string name="about_position_mo_agamy">Khung cơ bản | Metrolist</string>
+    <string name="about_position_mo_agamy">Playback client fallback</string>
     <string name="about_position_zion_huang">Người tạo InnerTune · Nền tảng cho Metrolist, LunarTune và các fork khác</string>
     <string name="about_content_desc_github">GitHub</string>
     <string name="about_content_desc_website">Trang web</string>

--- a/app/src/main/res/values-zh-rTW/archivetune_strings.xml
+++ b/app/src/main/res/values-zh-rTW/archivetune_strings.xml
@@ -573,7 +573,7 @@
     <string name="about_position_lead_dev">Eh?</string>
     <string name="about_position_developers">開發者 | 團隊</string>
     <string name="about_position_yuki">純屬擺拍 😂 | 管理員</string>
-    <string name="about_position_mo_agamy">基礎架構 | Metrolist</string>
+    <string name="about_position_mo_agamy">Playback client fallback</string>
     <string name="about_position_zion_huang">InnerTune 創作者 · Metrolist、LunarTune 及其他衍生版本的奠基人</string>
     <string name="about_content_desc_github">GitHub</string>
     <string name="about_content_desc_website">網站</string>

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -733,11 +733,11 @@
     <string name="about_license">LICENSE</string>
     <string name="about_license_unknown">Unknown license</string>
     <string name="about_position_lead_dev">Lead developer of LunarTune</string>
-    <string name="about_position_original">Original ArchiveTune by rukamori</string>
+    <string name="about_position_original">Base framework</string>
     <string name="about_position_bot_contributor">Contributor</string>
     <string name="about_position_developers">Developer | Team</string>
     <string name="about_position_yuki">dummy reze | Admin</string>
-    <string name="about_position_mo_agamy">Playback client</string>
+    <string name="about_position_mo_agamy">Playback client fallback</string>
     <string name="about_position_vivi">Dolby and Dirac equalizer presets</string>
     <string name="about_position_zion_huang">Creator of InnerTune · Foundation for Metrolist, LunarTune, and other forks</string>
     <string name="about_content_desc_github">GitHub</string>


### PR DESCRIPTION
Respecter: ArchiveTune is base framework, MO AGAMY is playback client fallback, Vivi Music unchanged. Remove the Contributors list (rukamori, mikooochi, Windowstechtips) that was still fetched from the ArchiveTune-era About page.