### PR TITLE
fix: Quick Picks corners and Discord icon

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/HomeScreenComponents.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/HomeScreenComponents.kt
@@ -307,7 +307,7 @@ fun QuickPicksSection(
                         modifier =
                             Modifier
                                 .fillMaxSize()
-                                .clip(MaterialTheme.shapes.extraLarge)
+                                .maskClip(MaterialTheme.shapes.extraLarge)
                                 .border(
                                     BorderStroke(
                                         1.dp,

--- a/app/src/main/res/drawable/discord.xml
+++ b/app/src/main/res/drawable/discord.xml
@@ -1,32 +1,31 @@
-<?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
+    android:tint="#ffffff"
     android:viewportWidth="24"
     android:viewportHeight="24">
+
     <path
-        android:fillColor="@android:color/transparent"
-        android:pathData="M17.8206 9C18 9.86938 18 11.0385 18 12.8V13.6C18 15.4638 18 16.3957 17.6955 17.1308C17.2895 18.1109 16.5108 18.8896 15.5307 19.2956C15.0652 19.4884 14.5207 19.5591 13.7106 19.585C12.8467 19.6126 12.4147 19.6264 12.0836 19.8223C11.7524 20.0182 11.5445 20.3695 11.1287 21.0719L10.8693 21.5102C10.4828 22.1633 9.51714 22.1633 9.13061 21.5102L8.87117 21.0719C8.4554 20.3695 8.24749 20.0182 7.91634 19.8223C7.58517 19.6264 7.1532 19.6126 6.28927 19.585C5.47919 19.5591 4.93475 19.4884 4.46923 19.2956C3.48912 18.8896 2.71042 18.1109 2.30444 17.1308"
-        android:strokeColor="@android:color/white"
-        android:strokeWidth="1.5"
-        android:strokeLineCap="round" />
+        android:pathData="M15.5008,17.75 L16.7942,19.5205 C16.9156,19.7127 17.1489,19.7985 17.3619,19.7224 C18.1657,19.4353 20.158,18.6572 21.7984,17.4725 C21.9263,17.3801 22.0002,17.2261 21.9992,17.0673 C21.9992,8.25 19.5008,5.75 19.5008,5.75 C19.5008,5.75 17.5008,4.60213 15.3547,4.25602 C15.1436,4.22196 14.9368,4.33509 14.8429,4.52891 L14.3979,5.44677 C14.3979,5.44677 13.2853,5.21397 12,5.21397 C10.7147,5.21397 9.6021,5.44677 9.6021,5.44677 L9.15711,4.52891 C9.06314,4.33509 8.85644,4.22196 8.64529,4.25602 C6.50079,4.60187 4.50079,5.75 4.50079,5.75 C4.50079,5.75 2.0008,8.25 2.0008,17.0673 C1.9998,17.2261 2.07365,17.3801 2.20159,17.4725 C3.84196,18.6572 5.8343,19.4353 6.63806,19.7224 C6.85105,19.7985 7.08437,19.7127 7.20582,19.5205 L8.50079,17.75"
+        android:strokeWidth="2.0"
+        android:strokeColor="#ffffff"
+        android:strokeLineCap="butt"
+        android:strokeLineJoin="miter" />
+
     <path
-        android:fillColor="@android:color/transparent"
-        android:pathData="M2 12.8C2 10.1813 2 8.87189 2.58944 7.91001C2.91926 7.37179 3.37178 6.91927 3.91001 6.58944C4.87188 6 6.18126 6 8.8 6H11.2C12.9615 6 14.1306 6 15 6.17941"
-        android:strokeColor="@android:color/white"
-        android:strokeWidth="1.5"
-        android:strokeLineCap="round" />
+        android:pathData="M17.5008,16.75 C17.5008,16.75 15.2057,18.25 12.0008,18.25 C8.79587,18.25 6.50079,16.75 6.50079,16.75"
+        android:strokeWidth="2.0"
+        android:strokeColor="#ffffff"
+        android:strokeLineCap="butt"
+        android:strokeLineJoin="miter" />
+
     <path
-        android:fillColor="@android:color/transparent"
-        android:pathData="M7.0332 6C7.08481 5.00787 7.2165 4.33902 7.55255 3.79064C7.86176 3.28605 8.28599 2.86181 8.79058 2.5526C9.69234 2 10.9199 2 13.3749 2H15.6249C17.153 2 18.2056 2 19 2.13325M18 14.7352C18.7477 14.7104 19.2527 14.6437 19.685 14.4646C20.6039 14.084 21.3339 13.354 21.7145 12.4351C21.9999 11.746 21.9999 10.8723 21.9999 9.12503V8.37503C21.9999 6.84695 21.9999 5.79442 21.8667 5"
-        android:strokeColor="@android:color/white"
-        android:strokeWidth="1.5"
-        android:strokeLineCap="round" />
+        android:pathData="M17.2508,12.25 C17.2508,13.3546 16.4673,14.25 15.5008,14.25 C14.5343,14.25 13.7508,13.3546 13.7508,12.25 C13.7508,11.1454 14.5343,10.25 15.5008,10.25 C16.4673,10.25 17.2508,11.1454 17.2508,12.25Z"
+        android:strokeWidth="2.0"
+        android:strokeColor="#ffffff" />
+
     <path
-        android:fillColor="@android:color/transparent"
-        android:pathData="M6.50928 13H6.51828M10 13H10.009M13.491 13H13.5"
-        android:strokeColor="@android:color/white"
-        android:strokeWidth="1.5"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round" />
+        android:pathData="M10.2508,12.25 C10.2508,13.3546 9.46729,14.25 8.50079,14.25 C7.5343,14.25 6.75079,13.3546 6.75079,12.25 C6.75079,11.1454 7.5343,10.25 8.50079,10.25 C9.46729,10.25 10.2508,11.1454 10.2508,12.25Z"
+        android:strokeWidth="2.0"
+        android:strokeColor="#ffffff" />
 </vector>

--- a/app/src/main/res/values-ar-rEG/archivetune_strings.xml
+++ b/app/src/main/res/values-ar-rEG/archivetune_strings.xml
@@ -564,7 +564,7 @@
     <string name="about_license_unknown">ترخيص غير معروف</string>
     <string name="about_position_lead_dev">إيه؟</string>
     <string name="about_position_developers">مطور | فريق</string>
-    <string name="about_position_mo_agamy">Playback client fallback</string>
+    <string name="about_position_mo_agamy">إطار العمل الأساسي | Metrolist</string>
     <string name="about_position_zion_huang">مبتكر InnerTune · الأساس لـ Metrolist و LunarTune والتفرعات التانية</string>
     <string name="about_content_desc_github">GitHub</string>
     <string name="about_content_desc_website">الموقع الإلكتروني</string>

--- a/app/src/main/res/values-ar/archivetune_strings.xml
+++ b/app/src/main/res/values-ar/archivetune_strings.xml
@@ -647,7 +647,7 @@
     <string name="about_position_lead_dev">ماذا؟</string>
     <string name="about_position_developers">مطور | الفريق</string>
     <string name="about_position_yuki">dummy reze | مسؤول</string>
-    <string name="about_position_mo_agamy">Playback client fallback</string>
+    <string name="about_position_mo_agamy">الإطار الأساسي | Metrolist</string>
     <string name="about_position_zion_huang">منشئ InnerTune · الأساس لـ Metrolist و LunarTune والتفرعات الأخرى</string>
     <string name="about_content_desc_github">GitHub</string>
     <string name="about_content_desc_website">الموقع الإلكتروني</string>

--- a/app/src/main/res/values-de-rDE/archivetune_strings.xml
+++ b/app/src/main/res/values-de-rDE/archivetune_strings.xml
@@ -497,7 +497,7 @@
     <string name="about_content_desc_discord">Discord</string>
     <string name="about_content_desc_github">GitHub</string>
     <string name="about_content_desc_website">Webseite</string>
-    <string name="about_position_mo_agamy">Playback client fallback</string>
+    <string name="about_position_mo_agamy">Basis-Framework | Metrolist</string>
     <string name="about_license_unknown">Unbekannte Lizenz</string>
     <string name="about_contributor_translation">Beitragende Übersetzung</string>
     <string name="about_lead_developer">Leitender Entwickler</string>

--- a/app/src/main/res/values-es/archivetune_strings.xml
+++ b/app/src/main/res/values-es/archivetune_strings.xml
@@ -540,7 +540,7 @@
     <string name="about_respecter">Cumplir</string>
     <string name="about_contributors">Colaboradores</string>
     <string name="about_position_lead_dev">¿Eh?</string>
-    <string name="about_position_mo_agamy">Playback client fallback</string>
+    <string name="about_position_mo_agamy">Estructura básica | Metrolist</string>
     <string name="about_position_zion_huang">Creador de InnerTune · Fundador de Metrolist, LunarTune y otras bifurcaciones</string>
     <string name="about_content_desc_github">GitHub</string>
     <string name="about_content_desc_website">Página web</string>

--- a/app/src/main/res/values-fr/archivetune_strings.xml
+++ b/app/src/main/res/values-fr/archivetune_strings.xml
@@ -348,7 +348,7 @@
     <string name="ai_provider">Fournisseur d\'IA</string>
     <string name="aod_shape_circle">Cercle</string>
     <string name="aod_customize_visibility">Visibilité</string>
-    <string name="about_position_mo_agamy">Playback client fallback</string>
+    <string name="about_position_mo_agamy">Cadre de base | Metrolist</string>
     <string name="aod_background_tonal_edge">Contraste de tons</string>
     <string name="about_content_desc_donate">Faire un don</string>
     <string name="aod_customize_sample_duration">3:48</string>

--- a/app/src/main/res/values-in-rID/archivetune_strings.xml
+++ b/app/src/main/res/values-in-rID/archivetune_strings.xml
@@ -628,7 +628,7 @@
     <string name="about_position_lead_dev">Eh?</string>
     <string name="about_position_developers">Pengembang | Tim</string>
     <string name="about_position_yuki">dummy reze | Admin</string>
-    <string name="about_position_mo_agamy">Playback client fallback</string>
+    <string name="about_position_mo_agamy">Base dari | Metrolist</string>
     <string name="about_position_zion_huang">Pencipta InnerTune · Fondasi untuk Metrolist, LunarTune, dan fork lainnya</string>
     <string name="about_content_desc_github">GitHub</string>
     <string name="about_content_desc_website">Situs Web</string>

--- a/app/src/main/res/values-ja/archivetune_strings.xml
+++ b/app/src/main/res/values-ja/archivetune_strings.xml
@@ -565,7 +565,7 @@
     <string name="about_position_lead_dev">え？</string>
     <string name="about_position_developers">開発者 | チーム</string>
     <string name="about_position_yuki">見た目担当 😂 | 管理者</string>
-    <string name="about_position_mo_agamy">Playback client fallback</string>
+    <string name="about_position_mo_agamy">ベースフレームワーク | Metrolist</string>
     <string name="about_position_zion_huang">InnerTuneの作成者 · Metrolist、LunarTune、その他フォークの基盤</string>
     <string name="about_content_desc_github">GitHub</string>
     <string name="about_content_desc_website">ウェブサイト</string>

--- a/app/src/main/res/values-ko/archivetune_strings.xml
+++ b/app/src/main/res/values-ko/archivetune_strings.xml
@@ -399,7 +399,7 @@
     <string name="aod_customize_subtitle">모양, 레이아웃, 컨트롤 및 앰비언트 스타일 설정</string>
     <string name="aod_shape_circle">원형</string>
     <string name="aod_customize_visibility">표시 설정</string>
-    <string name="about_position_mo_agamy">Playback client fallback</string>
+    <string name="about_position_mo_agamy">기초 프레임워크 설계 | Metrolist</string>
     <string name="aod_background_tonal_edge">톤 엣지</string>
     <string name="about_content_desc_donate">후원</string>
     <string name="aod_customize_sample_duration">3:48</string>

--- a/app/src/main/res/values-pt-rBR/archivetune_strings.xml
+++ b/app/src/main/res/values-pt-rBR/archivetune_strings.xml
@@ -565,7 +565,7 @@
     <string name="about_position_lead_dev">Eh?</string>
     <string name="about_position_developers">Desenvolvedor | Equipe</string>
     <string name="about_position_yuki">reze idiota | Admin</string>
-    <string name="about_position_mo_agamy">Playback client fallback</string>
+    <string name="about_position_mo_agamy">Framework base | Metrolist</string>
     <string name="about_position_zion_huang">Criador do InnerTune · Fundação do Metrolist, LunarTune e outros forks</string>
     <string name="about_content_desc_github">GitHub</string>
     <string name="about_content_desc_website">Site</string>

--- a/app/src/main/res/values-ru/archivetune_strings.xml
+++ b/app/src/main/res/values-ru/archivetune_strings.xml
@@ -283,7 +283,7 @@
     <string name="crossfade_gapless_title">Кроссфейд без пробелов</string>
     <string name="crossfade_gapless_description">Затухание и появление без перекрываний звука.</string>
     <string name="about_position_yuki">Чисто для показа 😂 | Админ</string>
-    <string name="about_position_mo_agamy">Playback client fallback</string>
+    <string name="about_position_mo_agamy">Базовая структура | Metrolist</string>
     <string name="about_position_zion_huang">Создатель InnerTune · Основатель проектов Metrolist, LunarTune и других форков</string>
     <string name="about_content_desc_github">GitHub</string>
     <string name="about_content_desc_website">Веб-сайт</string>

--- a/app/src/main/res/values-vi/archivetune_strings.xml
+++ b/app/src/main/res/values-vi/archivetune_strings.xml
@@ -536,7 +536,7 @@
     <string name="about_respecter">Tôn kính</string>
     <string name="about_contributors">Người đóng góp</string>
     <string name="about_position_lead_dev">Hả?</string>
-    <string name="about_position_mo_agamy">Playback client fallback</string>
+    <string name="about_position_mo_agamy">Khung cơ bản | Metrolist</string>
     <string name="about_position_zion_huang">Người tạo InnerTune · Nền tảng cho Metrolist, LunarTune và các fork khác</string>
     <string name="about_content_desc_github">GitHub</string>
     <string name="about_content_desc_website">Trang web</string>

--- a/app/src/main/res/values-zh-rTW/archivetune_strings.xml
+++ b/app/src/main/res/values-zh-rTW/archivetune_strings.xml
@@ -573,7 +573,7 @@
     <string name="about_position_lead_dev">Eh?</string>
     <string name="about_position_developers">開發者 | 團隊</string>
     <string name="about_position_yuki">純屬擺拍 😂 | 管理員</string>
-    <string name="about_position_mo_agamy">Playback client fallback</string>
+    <string name="about_position_mo_agamy">基礎架構 | Metrolist</string>
     <string name="about_position_zion_huang">InnerTune 創作者 · Metrolist、LunarTune 及其他衍生版本的奠基人</string>
     <string name="about_content_desc_github">GitHub</string>
     <string name="about_content_desc_website">網站</string>


### PR DESCRIPTION
Collapsed Quick Picks cards now use the carousel maskClip with extraLarge corners so peeking neighbors are not square. Discord Integration uses the Discord logo again instead of the chat-bubble Solar icon.