### PR TITLE
fix: first release notes too long for GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,20 +359,24 @@ jobs:
           LAST_TAG="$(git describe --tags --abbrev=0 --match "v*" 2>/dev/null || true)"
           if [ -n "$LAST_TAG" ]; then
             FROM_REF="$LAST_TAG"
+            echo "has_previous_tag=true" >> "$GITHUB_OUTPUT"
           else
             FROM_REF="$(git rev-list --max-parents=0 HEAD | tail -n 1)"
+            echo "has_previous_tag=false" >> "$GITHUB_OUTPUT"
           fi
 
           echo "from_ref=$FROM_REF" >> "$GITHUB_OUTPUT"
           echo "to_ref=${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Build Changelog
+        if: steps.changelog_range.outputs.has_previous_tag == 'true'
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v6
         with:
           mode: "COMMIT"
           fromTag: ${{ steps.changelog_range.outputs.from_ref }}
           toTag: ${{ steps.changelog_range.outputs.to_ref }}
+          outputFile: generated_changelog.md
           configurationJson: |
             {
               "template": "# Changelog\n\n#{{CHANGELOG}}\n\n<details>\n<summary>Other changes</summary>\n\n#{{UNCATEGORIZED}}\n</details>\n",
@@ -399,17 +403,44 @@ jobs:
       - name: Create Release
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          RELEASE_VERSION: ${{ needs.check-version.outputs.new_version }}
+          RELEASE_SHA: ${{ github.sha }}
+          HAS_PREVIOUS_TAG: ${{ steps.changelog_range.outputs.has_previous_tag }}
         run: |
+          set -euo pipefail
           MOBILE_UNIVERSAL_APK=$(find downloaded_artifacts/app-gms-mobile-universal-release -name "*.apk" | head -n 1)
-          OTHER_APKS=$(find downloaded_artifacts -path "*/app-*-release/*.apk" ! -path "*/app-gms-mobile-universal-release/*")
+          mapfile -t OTHER_APKS < <(find downloaded_artifacts -path "*/app-*-release/*.apk" ! -path "*/app-gms-mobile-universal-release/*" | sort)
 
-          cat > release_notes.md <<EOF
-          ${{ steps.build_changelog.outputs.changelog }}
-          EOF
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
 
-          gh release create "v${{ needs.check-version.outputs.new_version }}" \
-            --target "${{ github.sha }}" \
-            --title "${{ needs.check-version.outputs.new_version }}" \
+          limit = 120_000
+          has_previous = os.environ.get("HAS_PREVIOUS_TAG") == "true"
+          generated = Path("generated_changelog.md")
+          if has_previous and generated.is_file():
+              notes = generated.read_text(encoding="utf-8")
+          else:
+              notes = """# LunarTune 5.0.0
+
+          First stable LunarTune release.
+
+          - Playback and download pipeline
+          - Last.fm via official API keys
+          - Dolby / Dirac equalizer presets
+          - Settings search limited to LunarTune
+          - Updates open the GitHub release page
+
+          See the repository history for the full commit list.
+          """
+          if len(notes) > limit:
+              notes = notes[:limit].rstrip() + "\n\n…truncated. Full history is in git.\n"
+          Path("release_notes.md").write_text(notes, encoding="utf-8")
+          PY
+
+          gh release create "v${RELEASE_VERSION}" \
+            --target "${RELEASE_SHA}" \
+            --title "${RELEASE_VERSION}" \
             --notes-file release_notes.md \
             "$MOBILE_UNIVERSAL_APK" \
-            $OTHER_APKS
+            "${OTHER_APKS[@]}"


### PR DESCRIPTION
create-release failed with HTTP 422 body is too long. PAT and APKs were fine. First tag now ships a short 5.0.0 note instead of the entire ArchiveTune history.