### PR TITLE
feat: nightly APKs as GitHub pre-releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -291,7 +291,7 @@ jobs:
           API_HASH: ${{ secrets.TELEGRAM_API_HASH }}
           BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-          TOPIC_ID: ${{ secrets.TELEGRAM_TOPIC_ID }}
+          TOPIC_ID: ${{ secrets.TELEGRAM_TOPIC_ARTIFACTS || secrets.TELEGRAM_TOPIC_ID }}
           APK_PATH: app/build/outputs/apk/download/*.apk
         run: |
           python ./.github/workflows/deploy_artifacts.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -339,6 +339,73 @@ jobs:
         run: python ./.github/workflows/notify_build_status.py
         continue-on-error: true
 
+  publishNightlyPrerelease:
+    name: Publish nightly pre-release
+    runs-on: ubuntu-latest
+    needs: build
+    if: success() && github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download signed APKs
+        uses: actions/download-artifact@v8
+        with:
+          pattern: app-*-release
+          path: downloaded_artifacts/
+
+      - name: Create nightly pre-release
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || github.token }}
+        run: |
+          set -euo pipefail
+          TS="$(date -u +'%Y%m%d%H%M')"
+          TAG="N${TS}"
+          SHORT_SHA="$(git rev-parse --short HEAD)"
+          SUBJECT="$(git log -1 --pretty=format:'%s')"
+          {
+            echo "# LunarTune nightly"
+            echo
+            echo "Automated pre-release from \`${GITHUB_REF_NAME}\` (\`${SHORT_SHA}\`)."
+            echo "Not the stable channel. GitHub Latest stays on the last stable tag."
+            echo
+            echo "**Commit:** ${SUBJECT}"
+          } > nightly_notes.md
+
+          mapfile -t APKS < <(find downloaded_artifacts -type f -name '*.apk' | sort)
+          if [ "${#APKS[@]}" -eq 0 ]; then
+            echo "No APKs to publish"
+            exit 1
+          fi
+
+          gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "Nightly ${GITHUB_REF_NAME} ${SHORT_SHA} (${TS})" \
+            --notes-file nightly_notes.md \
+            --prerelease \
+            "${APKS[@]}"
+
+      - name: Keep only the 5 newest nightlies
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || github.token }}
+        run: |
+          set -euo pipefail
+          mapfile -t OLD < <(
+            gh release list --repo "$GITHUB_REPOSITORY" --limit 200 --json tagName,createdAt \
+              --jq '[.[] | select(.tagName | test("^N[0-9]+"))] | sort_by(.createdAt) | reverse | .[5:] | .[].tagName'
+          )
+          for tag in "${OLD[@]:-}"; do
+            [ -z "$tag" ] && continue
+            echo "Deleting old nightly: $tag"
+            gh release delete "$tag" --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes || true
+          done
+
   build_debug:
     if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Same idea as 4nx3b: every successful Build APKs run publishes a pre-release tagged NYYYYMMDDHHMM with the signed APKs. The Latest release stays v5.0.0. Older nightlies are pruned after five.