### PR TITLE
fix: keep player blur after expand

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -291,7 +291,7 @@ jobs:
           API_HASH: ${{ secrets.TELEGRAM_API_HASH }}
           BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-          TOPIC_ID: ${{ secrets.TELEGRAM_TOPIC_ID }}
+          TOPIC_ID: ${{ secrets.TELEGRAM_TOPIC_ARTIFACTS || secrets.TELEGRAM_TOPIC_ID }}
           APK_PATH: app/build/outputs/apk/download/*.apk
         run: |
           python ./.github/workflows/deploy_artifacts.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -339,6 +339,73 @@ jobs:
         run: python ./.github/workflows/notify_build_status.py
         continue-on-error: true
 
+  publishNightlyPrerelease:
+    name: Publish nightly pre-release
+    runs-on: ubuntu-latest
+    needs: build
+    if: success() && github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download signed APKs
+        uses: actions/download-artifact@v8
+        with:
+          pattern: app-*-release
+          path: downloaded_artifacts/
+
+      - name: Create nightly pre-release
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || github.token }}
+        run: |
+          set -euo pipefail
+          TS="$(date -u +'%Y%m%d%H%M')"
+          TAG="N${TS}"
+          SHORT_SHA="$(git rev-parse --short HEAD)"
+          SUBJECT="$(git log -1 --pretty=format:'%s')"
+          {
+            echo "# LunarTune nightly"
+            echo
+            echo "Automated pre-release from \`${GITHUB_REF_NAME}\` (\`${SHORT_SHA}\`)."
+            echo "Not the stable channel. GitHub Latest stays on the last stable tag."
+            echo
+            echo "**Commit:** ${SUBJECT}"
+          } > nightly_notes.md
+
+          mapfile -t APKS < <(find downloaded_artifacts -type f -name '*.apk' | sort)
+          if [ "${#APKS[@]}" -eq 0 ]; then
+            echo "No APKs to publish"
+            exit 1
+          fi
+
+          gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "Nightly ${GITHUB_REF_NAME} ${SHORT_SHA} (${TS})" \
+            --notes-file nightly_notes.md \
+            --prerelease \
+            "${APKS[@]}"
+
+      - name: Keep only the 5 newest nightlies
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || github.token }}
+        run: |
+          set -euo pipefail
+          mapfile -t OLD < <(
+            gh release list --repo "$GITHUB_REPOSITORY" --limit 200 --json tagName,createdAt \
+              --jq '[.[] | select(.tagName | test("^N[0-9]+"))] | sort_by(.createdAt) | reverse | .[5:] | .[].tagName'
+          )
+          for tag in "${OLD[@]:-}"; do
+            [ -z "$tag" ] && continue
+            echo "Deleting old nightly: $tag"
+            gh release delete "$tag" --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes || true
+          done
+
   build_debug:
     if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
     runs-on: ubuntu-latest

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/Player.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/Player.kt
@@ -2056,27 +2056,7 @@ private fun V8PlayerBackdrop(
     ) {
         if (currentUrl != null) {
             val backdropHasBlur = backdropBlurAmount > 0
-            if (backdropHasBlur && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                AsyncImage(
-                    model = backdropRequest,
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
-                    modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .then(if (blurRadiusDp > 0.dp) Modifier.blur(blurRadiusDp) else Modifier)
-                            .graphicsLayer {
-                                scaleX = 1.16f
-                                scaleY = 1.16f
-                                alpha = 0.66f
-                            },
-                    onState = { state ->
-                        if (state is coil3.compose.AsyncImagePainter.State.Error) {
-                            getNextFallbackUrl(currentUrl)?.let { currentUrl = it }
-                        }
-                    },
-                )
-            } else if (backdropHasBlur) {
+            if (backdropHasBlur) {
                 BackdropBlurApi30(
                     model = currentUrl,
                     blurAmount = backdropBlurAmount,
@@ -2333,10 +2313,9 @@ private fun V7PlayerBackdrop(
                     arrayOf(
                         0f to Color.Transparent,
                         V7SharpStageBottomScrimStartFraction to Color.Transparent,
-                        0.60f to blendColor.copy(alpha = 0.18f),
-                        0.76f to blendColor.copy(alpha = 0.52f),
-                        0.88f to blendColor.copy(alpha = 0.82f),
-                        1f to blendColor,
+                        0.68f to blendColor.copy(alpha = 0.10f),
+                        0.84f to blendColor.copy(alpha = 0.28f),
+                        1f to blendColor.copy(alpha = 0.40f),
                     ),
             )
         }
@@ -2345,9 +2324,10 @@ private fun V7PlayerBackdrop(
             Brush.verticalGradient(
                 colorStops =
                     arrayOf(
-                        0f to backdropPalette.bottom,
-                        V7BackdropFloorBlackStartFraction to backdropPalette.bottom,
-                        1f to backdropPalette.bottom,
+                        0f to backdropPalette.bottom.copy(alpha = 0.12f),
+                        0.55f to backdropPalette.bottom.copy(alpha = 0.28f),
+                        V7BackdropFloorBlackStartFraction to backdropPalette.bottom.copy(alpha = 0.42f),
+                        1f to backdropPalette.bottom.copy(alpha = 0.55f),
                     ),
             )
         }
@@ -2397,19 +2377,7 @@ private fun V7PlayerBackdrop(
                     .background(backdropPalette.bottom),
         ) {
             if (backdropArtworkModel != null) {
-                if (needsBlur && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                    AsyncImage(
-                        model = backdropArtworkRequest,
-                        contentDescription = null,
-                        contentScale = ContentScale.Crop,
-                        modifier = backdropImageModifier.blur(backdropBlurRadius),
-                        onState = { state ->
-                            if (state is coil3.compose.AsyncImagePainter.State.Error) {
-                                getNextFallbackUrl(backdropArtworkModel)?.let { backdropArtworkModel = it }
-                            }
-                        },
-                    )
-                } else if (needsBlur) {
+                if (needsBlur) {
                     BackdropBlurApi30(
                         model = backdropArtworkModel,
                         blurAmount = backdropBlurAmount,
@@ -2897,6 +2865,30 @@ private fun Modifier.littlePlayerOverlayGestures(
                                         android.view.HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING,
                                     )
                                 }
+                                onSkipPrevious()
+                            }
+                        } else {
+                            if (canSkipNext) {
+                                if (enableHapticFeedback) {
+                                    view.performHapticFeedback(
+                                        android.view.HapticFeedbackConstants.CONTEXT_CLICK,
+                                        android.view.HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING,
+                                    )
+                                }
+                                onSkipNext()
+                            }
+                        }
+                        lastTapUptimeMs = 0L
+                        lastTapPosition = null
+                    } else {
+                        lastTapUptimeMs = now
+                        lastTapPosition = upPosition
+                    }
+                }
+            }
+        }
+    }
+           }
                                 onSkipPrevious()
                             }
                         } else {

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/Player.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/Player.kt
@@ -2888,27 +2888,3 @@ private fun Modifier.littlePlayerOverlayGestures(
             }
         }
     }
-           }
-                                onSkipPrevious()
-                            }
-                        } else {
-                            if (canSkipNext) {
-                                if (enableHapticFeedback) {
-                                    view.performHapticFeedback(
-                                        android.view.HapticFeedbackConstants.CONTEXT_CLICK,
-                                        android.view.HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING,
-                                    )
-                                }
-                                onSkipNext()
-                            }
-                        }
-                        lastTapUptimeMs = 0L
-                        lastTapPosition = null
-                    } else {
-                        lastTapUptimeMs = now
-                        lastTapPosition = upPosition
-                    }
-                }
-            }
-        }
-    }


### PR DESCRIPTION
Expanding from Home showed frost for a second, then a solid palette wash. Same ArchiveTune bug: live Compose blur dies after the sheet animation, and V7 then covered the art with an opaque color. Nightlies now use a bitmap blur plus a light tint.