### PR TITLE
fix: 4nx3b V7 backdrop instead of Apple Music frost

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/Player.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/Player.kt
@@ -2056,7 +2056,27 @@ private fun V8PlayerBackdrop(
     ) {
         if (currentUrl != null) {
             val backdropHasBlur = backdropBlurAmount > 0
-            if (backdropHasBlur) {
+            if (backdropHasBlur && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                AsyncImage(
+                    model = backdropRequest,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .then(if (blurRadiusDp > 0.dp) Modifier.blur(blurRadiusDp) else Modifier)
+                            .graphicsLayer {
+                                scaleX = 1.16f
+                                scaleY = 1.16f
+                                alpha = 0.66f
+                            },
+                    onState = { state ->
+                        if (state is coil3.compose.AsyncImagePainter.State.Error) {
+                            getNextFallbackUrl(currentUrl)?.let { currentUrl = it }
+                        }
+                    },
+                )
+            } else if (backdropHasBlur) {
                 BackdropBlurApi30(
                     model = currentUrl,
                     blurAmount = backdropBlurAmount,
@@ -2313,9 +2333,10 @@ private fun V7PlayerBackdrop(
                     arrayOf(
                         0f to Color.Transparent,
                         V7SharpStageBottomScrimStartFraction to Color.Transparent,
-                        0.68f to blendColor.copy(alpha = 0.10f),
-                        0.84f to blendColor.copy(alpha = 0.28f),
-                        1f to blendColor.copy(alpha = 0.40f),
+                        0.60f to blendColor.copy(alpha = 0.18f),
+                        0.76f to blendColor.copy(alpha = 0.52f),
+                        0.88f to blendColor.copy(alpha = 0.82f),
+                        1f to blendColor,
                     ),
             )
         }
@@ -2324,10 +2345,9 @@ private fun V7PlayerBackdrop(
             Brush.verticalGradient(
                 colorStops =
                     arrayOf(
-                        0f to backdropPalette.bottom.copy(alpha = 0.12f),
-                        0.55f to backdropPalette.bottom.copy(alpha = 0.28f),
-                        V7BackdropFloorBlackStartFraction to backdropPalette.bottom.copy(alpha = 0.42f),
-                        1f to backdropPalette.bottom.copy(alpha = 0.55f),
+                        0f to backdropPalette.bottom,
+                        V7BackdropFloorBlackStartFraction to backdropPalette.bottom,
+                        1f to backdropPalette.bottom,
                     ),
             )
         }
@@ -2377,7 +2397,19 @@ private fun V7PlayerBackdrop(
                     .background(backdropPalette.bottom),
         ) {
             if (backdropArtworkModel != null) {
-                if (needsBlur) {
+                if (needsBlur && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    AsyncImage(
+                        model = backdropArtworkRequest,
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = backdropImageModifier.blur(backdropBlurRadius),
+                        onState = { state ->
+                            if (state is coil3.compose.AsyncImagePainter.State.Error) {
+                                getNextFallbackUrl(backdropArtworkModel)?.let { backdropArtworkModel = it }
+                            }
+                        },
+                    )
+                } else if (needsBlur) {
                     BackdropBlurApi30(
                         model = backdropArtworkModel,
                         blurAmount = backdropBlurAmount,


### PR DESCRIPTION
The lower player should match 4nx3b: sharp artwork on top and a blended color wash from the cover under the controls. Not the Apple Music frosted-art style from #36.