### PR TITLE
fix: Immersive Legacy portrait + keep 14.1.0 Immersive

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/Player.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/Player.kt
@@ -1438,36 +1438,6 @@ fun BottomSheetPlayer(
                             Spacer(Modifier.height(16.dp))
                         }
                     }
-                } else if (playerDesignStyle == PlayerDesignStyle.V7_LEGACY) {
-                    Box(modifier = Modifier.fillMaxSize()) {
-                        val swap =
-                            rememberThumbnailSwapState(
-                                videoId = mediaMetadata?.id,
-                                ytmUrl = mediaMetadata?.thumbnailUrl,
-                                lowDataMode = lowDataModeActive,
-                                isMusicVideo = mediaMetadata?.isMusicVideo ?: false,
-                            )
-                        LegacyImmersiveBackdrop(
-                            thumbnailUrl = swap.displayUrl,
-                            canvasPrimaryUrl = v7CanvasArtwork?.animatedVertical,
-                            canvasFallbackUrl = v7CanvasArtwork?.videoUrlVertical,
-                            isPlaying = isPlaying,
-                            disableBlur = disableBlur,
-                            label = "legacyV7Portrait",
-                        )
-                        Column(
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            modifier =
-                                Modifier
-                                    .align(Alignment.BottomCenter)
-                                    .padding(bottom = queueSheetState.collapsedBound)
-                                    .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Horizontal))
-                                    .nestedScroll(state.preUpPostDownNestedScrollConnection),
-                        ) {
-                            enrichedMetadata?.let { controlsContent(it) }
-                            Spacer(Modifier.height(24.dp))
-                        }
-                    }
                 } else if (playerDesignStyle == PlayerDesignStyle.V7) {
                     Box(
                         modifier =
@@ -1744,6 +1714,36 @@ fun BottomSheetPlayer(
                                     )
                                 }
                             }
+                        }
+                    }
+                } else if (playerDesignStyle == PlayerDesignStyle.V7_LEGACY) {
+                    Box(modifier = Modifier.fillMaxSize()) {
+                        val swap =
+                            rememberThumbnailSwapState(
+                                videoId = mediaMetadata?.id,
+                                ytmUrl = mediaMetadata?.thumbnailUrl,
+                                lowDataMode = lowDataModeActive,
+                                isMusicVideo = mediaMetadata?.isMusicVideo ?: false,
+                            )
+                        LegacyImmersiveBackdrop(
+                            thumbnailUrl = swap.displayUrl,
+                            canvasPrimaryUrl = v7CanvasArtwork?.animatedVertical,
+                            canvasFallbackUrl = v7CanvasArtwork?.videoUrlVertical,
+                            isPlaying = isPlaying,
+                            disableBlur = disableBlur,
+                            label = "legacyV7Portrait",
+                        )
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            modifier =
+                                Modifier
+                                    .align(Alignment.BottomCenter)
+                                    .padding(bottom = queueSheetState.collapsedBound)
+                                    .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Horizontal))
+                                    .nestedScroll(state.preUpPostDownNestedScrollConnection),
+                        ) {
+                            enrichedMetadata?.let { controlsContent(it) }
+                            Spacer(Modifier.height(24.dp))
                         }
                     }
                 } else if (playerDesignStyle == PlayerDesignStyle.V7) {


### PR DESCRIPTION
## What
- **Immersive Legacy** (ArchiveTune 13.4.0): portrait now uses the same full-bleed frosted art as landscape. #38 only wired landscape, so phones showed boxed Daisy art on black.
- **Immersive** (V7): left as ArchiveTune **14.1.0** (`V7PlayerBackdrop` + `V8PlayerControlsContent`). Compared to rukamori `v14.1.0` — backdrop is identical. Not replaced by Legacy.

## Test
- Appearance → Immersive Legacy: edge-to-edge cover, frost on lower controls, heart + …, remaining time, codec chip.
- Appearance → Immersive: sharp art stage + palette wash like ArchiveTune 14.1.0 / 4nx3b current V7.