### PR TITLE
fix: hide status bar on Immersive Legacy

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/MainActivity.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/MainActivity.kt
@@ -1157,7 +1157,13 @@ class MainActivity : ComponentActivity() {
 
                     val shouldHideStatusBars =
                         isYearInMusicScreen ||
-                            (playerBottomSheetState.isExpandedOrExpanding && playerDesignStyle == PlayerDesignStyle.V7)
+                            (
+                                playerBottomSheetState.isExpandedOrExpanding &&
+                                    (
+                                        playerDesignStyle == PlayerDesignStyle.V7 ||
+                                            playerDesignStyle == PlayerDesignStyle.V7_LEGACY
+                                    )
+                            )
 
                     LaunchedEffect(shouldHideStatusBars, aodModeEnabled) {
                         if (aodModeEnabled) return@LaunchedEffect

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/menu/PlayerMenu.kt
@@ -482,7 +482,9 @@ fun PlayerMenu(
                                                 when (
                                                     playerConnection.refetchCanvasArtwork(
                                                         metadata = mediaMetadata,
-                                                        requireVertical = playerDesignStyle == PlayerDesignStyle.V7,
+                                                        requireVertical =
+                                                            playerDesignStyle == PlayerDesignStyle.V7 ||
+                                                                playerDesignStyle == PlayerDesignStyle.V7_LEGACY,
                                                     )
                                                 ) {
                                                     CanvasArtworkRefetchResult.Success -> onDismiss()


### PR DESCRIPTION
Immersive Legacy now hides the status bar when the player is expanded, same as Immersive (V7). Swipe-to-change-song and square thumbnails stay as you set them in Appearance.