### PR TITLE
fix: enable 13.4.0 button and slider settings on Immersive Legacy

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/Player.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/Player.kt
@@ -701,7 +701,7 @@ fun BottomSheetPlayer(
                 }
             }
         }.let { (tb, ib) ->
-            if (playerDesignStyle == PlayerDesignStyle.V7 || playerDesignStyle == PlayerDesignStyle.V7_LEGACY || playerDesignStyle == PlayerDesignStyle.V8) {
+            if (playerDesignStyle == PlayerDesignStyle.V7 || playerDesignStyle == PlayerDesignStyle.V8) {
                 Pair(Color.White, Color.Black)
             } else if (playerDesignStyle == PlayerDesignStyle.V9) {
                 Pair(dynamicAccentColor, dynamicIconButtonColor)

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/AppearanceSettings.kt
@@ -364,7 +364,7 @@ fun AppearanceSettings(navController: NavController) {
             )
         }
     val lyricsBackground = configuredLyricsBackground.resolveFor(playerBackground)
-    val isPlayerStyleCustomizationEnabled =
+    val isPlayerBackgroundCustomizationEnabled =
         when (playerDesignStyle) {
             PlayerDesignStyle.V7,
             PlayerDesignStyle.V7_LEGACY,
@@ -374,6 +374,9 @@ fun AppearanceSettings(navController: NavController) {
 
             else -> true
         }
+    // ArchiveTune 13.4.0 Immersive kept button colors + slider style available.
+    val isPlayerControlsCustomizationEnabled =
+        playerDesignStyle == PlayerDesignStyle.V7_LEGACY || isPlayerBackgroundCustomizationEnabled
     val isVolumeBarSupported =
         playerDesignStyle == PlayerDesignStyle.V7 ||
             playerDesignStyle == PlayerDesignStyle.V8
@@ -409,19 +412,19 @@ fun AppearanceSettings(navController: NavController) {
         mutableStateOf(false)
     }
 
-    LaunchedEffect(isPlayerStyleCustomizationEnabled, playerBackground) {
-        if (!isPlayerStyleCustomizationEnabled && playerBackground != PlayerBackgroundStyle.DEFAULT) {
+    LaunchedEffect(isPlayerBackgroundCustomizationEnabled, playerBackground) {
+        if (!isPlayerBackgroundCustomizationEnabled && playerBackground != PlayerBackgroundStyle.DEFAULT) {
             onPlayerBackgroundChange(PlayerBackgroundStyle.DEFAULT)
         }
     }
 
-    LaunchedEffect(isPlayerStyleCustomizationEnabled) {
-        if (!isPlayerStyleCustomizationEnabled) {
+    LaunchedEffect(isPlayerControlsCustomizationEnabled) {
+        if (!isPlayerControlsCustomizationEnabled) {
             showSliderOptionDialog = false
         }
     }
 
-    if (showSliderOptionDialog && isPlayerStyleCustomizationEnabled) {
+    if (showSliderOptionDialog && isPlayerControlsCustomizationEnabled) {
         val sliderStyles =
             remember {
                 listOf(
@@ -749,7 +752,7 @@ fun AppearanceSettings(navController: NavController) {
                     EnumListPreference(
                         title = { Text(stringResource(R.string.player_background_style)) },
                         description =
-                            if (isPlayerStyleCustomizationEnabled) {
+                            if (isPlayerBackgroundCustomizationEnabled) {
                                 null
                             } else {
                                 stringResource(R.string.player_background_style_v8_v9_desc)
@@ -768,7 +771,7 @@ fun AppearanceSettings(navController: NavController) {
                                 }
                             }
                         },
-                        isEnabled = isPlayerStyleCustomizationEnabled,
+                        isEnabled = isPlayerBackgroundCustomizationEnabled,
                         valueText = {
                             when (it) {
                                 PlayerBackgroundStyle.DEFAULT -> stringResource(R.string.follow_theme)
@@ -902,7 +905,7 @@ fun AppearanceSettings(navController: NavController) {
                         onClick = {
                             showSliderOptionDialog = true
                         },
-                        isEnabled = isPlayerStyleCustomizationEnabled,
+                        isEnabled = isPlayerControlsCustomizationEnabled,
                     )
                 }
 

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/AppearanceSettings.kt
@@ -879,7 +879,7 @@ fun AppearanceSettings(navController: NavController) {
                     EnumListPreference(
                         title = { Text(stringResource(R.string.player_buttons_style)) },
                         description =
-                            if (isPlayerStyleCustomizationEnabled) {
+                            if (isPlayerControlsCustomizationEnabled) {
                                 null
                             } else {
                                 stringResource(R.string.player_background_style_v8_v9_desc)
@@ -887,7 +887,7 @@ fun AppearanceSettings(navController: NavController) {
                         icon = { Icon(painterResource(R.drawable.palette), null) },
                         selectedValue = playerButtonsStyle,
                         onValueSelected = onPlayerButtonsStyleChange,
-                        isEnabled = isPlayerStyleCustomizationEnabled,
+                        isEnabled = isPlayerControlsCustomizationEnabled,
                         valueText = {
                             when (it) {
                                 PlayerButtonsStyle.DEFAULT -> stringResource(R.string.default_style)


### PR DESCRIPTION
Immersive Legacy was lumped in with V7/V8/V9, which greys out **Player button colors** and **Player slider style**. Those were available on ArchiveTune 13.4.0 Immersive.\n\n- Unlock those two for Immersive Legacy only.\n- Player background style stays locked (Legacy still uses its own full-bleed art).\n- Current Immersive / Extended / Material Extended unchanged.