### PR TITLE
revert: high-res artwork probe, brighten Immersive Legacy

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/Player.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/Player.kt
@@ -2239,22 +2239,6 @@ private fun LegacyImmersiveBackdrop(
                 }
             }
         }
-        Box(Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.08f)))
-        Box(
-            Modifier
-                .fillMaxSize()
-                .background(
-                    Brush.verticalGradient(
-                        colorStops =
-                            arrayOf(
-                                0f to Color.Black.copy(alpha = 0.18f),
-                                0.34f to Color.Transparent,
-                                0.64f to Color.Black.copy(alpha = 0.22f),
-                                1f to Color.Black.copy(alpha = 0.82f),
-                            ),
-                    ),
-                ),
-        )
         Box(
             Modifier
                 .fillMaxSize()
@@ -2263,9 +2247,9 @@ private fun LegacyImmersiveBackdrop(
                         colorStops =
                             arrayOf(
                                 0f to Color.Transparent,
-                                0.56f to Color.Transparent,
-                                0.8f to surfaceTint.copy(alpha = 0.16f),
-                                1f to surfaceTint.copy(alpha = 0.3f),
+                                0.52f to Color.Transparent,
+                                0.72f to Color.Black.copy(alpha = 0.12f),
+                                1f to Color.Black.copy(alpha = 0.58f),
                             ),
                     ),
                 ),

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/ThumbnailSwapState.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/ThumbnailSwapState.kt
@@ -20,16 +20,12 @@ import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
 import coil3.request.allowHardware
-import coil3.toBitmap
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import dev.citali.lunartune.ui.utils.YTThumbQuality
 import dev.citali.lunartune.ui.utils.buildYTThumbnailUrl
-import dev.citali.lunartune.ui.utils.resize
 import timber.log.Timber
-
-private const val HighResMinEdgePx = 480
 
 @Immutable
 data class ThumbnailSwapState(
@@ -46,24 +42,23 @@ fun rememberThumbnailSwapState(
     isMusicVideo: Boolean = false,
 ): ThumbnailSwapState {
     val context = LocalContext.current
-    val shouldAttemptHighRes = videoId != null && !lowDataMode
+    val shouldAttemptYT = videoId != null && !lowDataMode && isMusicVideo
 
     var displayUrl by remember { mutableStateOf(ytmUrl) }
     var isYTReady by remember { mutableStateOf(false) }
     var ytUrl by remember { mutableStateOf<String?>(null) }
 
-    LaunchedEffect(videoId, ytmUrl, shouldAttemptHighRes, isMusicVideo) {
+    LaunchedEffect(videoId, ytmUrl, shouldAttemptYT) {
         displayUrl = ytmUrl
         isYTReady = false
         ytUrl = null
 
-        if (!shouldAttemptHighRes || videoId == null) return@LaunchedEffect
+        if (!shouldAttemptYT || videoId == null) return@LaunchedEffect
 
         val imageLoader = context.imageLoader
-        val candidates = buildHighResArtworkCandidates(videoId, ytmUrl)
 
-        for (url in candidates) {
-            if (url.isBlank() || url == ytmUrl) continue
+        for (quality in YTThumbQuality.entries) {
+            val url = buildYTThumbnailUrl(videoId, quality)
             try {
                 val request =
                     ImageRequest
@@ -81,8 +76,6 @@ fun rememberThumbnailSwapState(
                         imageLoader.execute(request)
                     }
                 if (result is SuccessResult) {
-                    val bitmap = result.image.toBitmap()
-                    if (minOf(bitmap.width, bitmap.height) < HighResMinEdgePx) continue
                     ytUrl = url
                     displayUrl = url
                     isYTReady = true
@@ -91,30 +84,11 @@ fun rememberThumbnailSwapState(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                Timber.tag("ThumbnailSwap").d(e, "High-res artwork failed: %s", url)
+                Timber.tag("ThumbnailSwap").e(e, "YT thumbnail quality=%s failed for videoId=%s", quality.value, videoId)
                 continue
             }
         }
-        displayUrl = ytmUrl
     }
 
     return ThumbnailSwapState(displayUrl, isYTReady, ytUrl)
-}
-
-internal fun buildHighResArtworkCandidates(
-    videoId: String,
-    ytmUrl: String?,
-): List<String> {
-    val urls = linkedSetOf<String>()
-    urls += buildYTThumbnailUrl(videoId, YTThumbQuality.MAXRES)
-    urls += "https://i.ytimg.com/vi_webp/$videoId/maxresdefault.webp"
-    urls += buildYTThumbnailUrl(videoId, YTThumbQuality.HQ720)
-    urls += "https://i.ytimg.com/vi_webp/$videoId/hq720.webp"
-    val upscaledYtm =
-        ytmUrl
-            ?.takeIf { it.isNotBlank() }
-            ?.resize(width = 2048, height = 2048, maxresAllowed = true)
-    if (!upscaledYtm.isNullOrBlank()) urls += upscaledYtm
-    urls += buildYTThumbnailUrl(videoId, YTThumbQuality.HQ)
-    return urls.toList()
 }


### PR DESCRIPTION
Reverts the #42 maxres/webp probe that made the player slow and flicker on expand. Artwork is back to YouTube Music / Innertube thumbnails (plus the old music-video ytimg path).\n\nAlso removes the extra full-screen black wash on Immersive Legacy so the cover is brighter; frost stays on the control band only.