### PR TITLE
fix: sharper Quick Picks and mini player artwork

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/MiniPlayerComponents.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/MiniPlayerComponents.kt
@@ -82,6 +82,7 @@ import dev.citali.lunartune.extensions.togglePlayPause
 import dev.citali.lunartune.models.MediaMetadata
 import dev.citali.lunartune.playback.PlayerConnection
 import dev.citali.lunartune.together.isConnectedToSession
+import dev.citali.lunartune.ui.utils.displayArtworkUrl
 import dev.citali.lunartune.utils.rememberLowDataModeActive
 import dev.citali.lunartune.utils.rememberPreference
 import kotlin.math.absoluteValue

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/HomeScreenComponents.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/HomeScreenComponents.kt
@@ -89,6 +89,7 @@ import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import coil3.size.Size
+import dev.citali.lunartune.ui.utils.displayArtworkUrl
 import kotlinx.coroutines.CoroutineScope
 import dev.citali.lunartune.R
 import dev.citali.lunartune.constants.GridThumbnailHeight
@@ -293,11 +294,18 @@ fun QuickPicksSection(
                     val song = distinctQuickPicks[index]
                     val isActive = song.id == mediaMetadata?.id
                     val context = LocalContext.current
-                    val imageRequest =
+                    val artworkUrl =
                         remember(song.song.thumbnailUrl, requestWidthPx, requestHeightPx) {
+                            song.song.thumbnailUrl?.displayArtworkUrl(
+                                width = requestWidthPx,
+                                height = requestHeightPx,
+                            )
+                        }
+                    val imageRequest =
+                        remember(artworkUrl, requestWidthPx, requestHeightPx) {
                             ImageRequest
                                 .Builder(context)
-                                .data(song.song.thumbnailUrl)
+                                .data(artworkUrl)
                                 .size(Size(requestWidthPx, requestHeightPx))
                                 .crossfade(true)
                                 .build()

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/utils/YouTubeUtils.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/utils/YouTubeUtils.kt
@@ -159,6 +159,18 @@ fun String.highRes(): String =
         ytimgResizePolicy = YtimgResizePolicy.PreserveOriginal,
     )
 
+/** Upsize a stored YTM/ytimg thumb for large list cards and the mini player. */
+fun String.displayArtworkUrl(
+    width: Int,
+    height: Int = width,
+): String =
+    resize(
+        width = width.coerceAtLeast(1),
+        height = height.coerceAtLeast(1),
+        maxresAllowed = maxOf(width, height) >= 480,
+        ytimgResizePolicy = YtimgResizePolicy.AllowAnyAspect,
+    )
+
 fun getMusicVideoYTThumbnail(
     videoId: String?,
     ytmUrl: String?,


### PR DESCRIPTION
Quick Picks cards and the mini player were loading the stored browse thumbnail (often a small music-video still). The expanded player already upsizes that URL.\n\nUse the same resize helper so list/mini-player art matches the player.