### PR TITLE
perf: smoother UI without changing animations

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/App.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/App.kt
@@ -9,6 +9,7 @@ package dev.citali.lunartune
 
 import android.app.ActivityManager
 import android.app.Application
+import android.content.ComponentCallbacks2
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
@@ -19,6 +20,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import coil3.ImageLoader
 import coil3.PlatformContext
 import coil3.SingletonImageLoader
+import coil3.imageLoader
 import coil3.disk.DiskCache
 import coil3.disk.directory
 import coil3.memory.MemoryCache
@@ -120,7 +122,9 @@ class App :
         runBlocking {
             PreferenceStore.awaitReady()
         }
-        Timber.plant(Timber.DebugTree())
+        if (BuildConfig.DEBUG) {
+            Timber.plant(Timber.DebugTree())
+        }
         try {
             Timber.plant(
                 dev.citali.lunartune.utils
@@ -150,7 +154,9 @@ class App :
 
     override fun onTrimMemory(level: Int) {
         super.onTrimMemory(level)
-        // WebView cleanup happens automatically on process death
+        if (level >= ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW) {
+            runCatching { imageLoader.memoryCache?.clear() }
+        }
     }
 
     private fun initializeCriticalSync() {

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/Player.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/Player.kt
@@ -9,16 +9,15 @@
 
 package dev.citali.lunartune.ui.player
 
+import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.content.res.Configuration
-import android.database.ContentObserver
 import android.graphics.Bitmap
 import android.media.AudioManager
 import android.os.Build
-import android.os.Handler
-import android.os.Looper
 import android.os.SystemClock
-import android.provider.Settings
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
@@ -294,17 +293,26 @@ internal fun rememberDeviceMusicVolumeController(): DeviceMusicVolumeController 
         }
 
     DisposableEffect(context, controller) {
-        val observer =
-            object : ContentObserver(Handler(Looper.getMainLooper())) {
-                override fun onChange(selfChange: Boolean) {
+        val appContext = context.applicationContext
+        val receiver =
+            object : BroadcastReceiver() {
+                override fun onReceive(
+                    ctx: Context?,
+                    intent: Intent?,
+                ) {
                     controller.refresh()
                 }
             }
-        val contentResolver = context.applicationContext.contentResolver
-        contentResolver.registerContentObserver(Settings.System.CONTENT_URI, true, observer)
+        val filter = IntentFilter("android.media.VOLUME_CHANGED_ACTION")
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            appContext.registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
+        } else {
+            @Suppress("UnspecifiedRegisterReceiverFlag")
+            appContext.registerReceiver(receiver, filter)
+        }
         controller.refresh()
         onDispose {
-            contentResolver.unregisterContentObserver(observer)
+            runCatching { appContext.unregisterReceiver(receiver) }
         }
     }
 
@@ -828,11 +836,17 @@ fun BottomSheetPlayer(
         mutableStateOf(false)
     }
 
-    LaunchedEffect(mediaMetadata?.id, playbackState, aodModeEnabled) {
+    LaunchedEffect(mediaMetadata?.id, playbackState, aodModeEnabled, state.isExpanded) {
         val startTime = SystemClock.elapsedRealtime()
         if (playbackState == STATE_READY) {
             while (isActive) {
-                delay(if (aodModeEnabled) 500L else 100L)
+                delay(
+                    when {
+                        aodModeEnabled -> 500L
+                        !state.isExpanded -> 400L
+                        else -> 100L
+                    },
+                )
                 val isTransitioning = playerConnection.player.currentMediaItem?.mediaId != mediaMetadata?.id
                 val currentPlayerPosition = playerConnection.player.currentPosition
                 val currentPlayerDuration = playerConnection.player.duration

--- a/app/src/main/kotlin/dev/citali/lunartune/utils/ComposeToImage.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/utils/ComposeToImage.kt
@@ -30,7 +30,7 @@ import androidx.core.graphics.drawable.toBitmap
 import androidx.core.graphics.withClip
 import androidx.core.graphics.withTranslation
 import androidx.core.view.drawToBitmap
-import coil3.ImageLoader
+import coil3.imageLoader
 import coil3.request.ImageRequest
 import coil3.request.allowHardware
 import coil3.toBitmap

--- a/app/src/main/kotlin/dev/citali/lunartune/utils/ComposeToImage.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/utils/ComposeToImage.kt
@@ -224,7 +224,7 @@ object ComposeToImage {
             var coverArtBitmap: Bitmap? = null
             if (coverArtUrl != null) {
                 try {
-                    val imageLoader = ImageLoader(context)
+                    val imageLoader = context.imageLoader
                     val request =
                         ImageRequest
                             .Builder(context)


### PR DESCRIPTION
Does not change animation specs.

- Release builds no longer plant Timber.DebugTree (less main-thread log spam)
- Volume UI listens to VOLUME_CHANGED instead of every Settings.System change
- Mini-player progress ticks at 400ms when collapsed (100ms when expanded)
- Trim Coil memory under memory pressure
- Lyrics image export reuses the app ImageLoader