### PR TITLE
fix: revert laggy perf PR and stop lyrics black flash

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/App.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/App.kt
@@ -9,7 +9,6 @@ package dev.citali.lunartune
 
 import android.app.ActivityManager
 import android.app.Application
-import android.content.ComponentCallbacks2
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
@@ -20,7 +19,6 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import coil3.ImageLoader
 import coil3.PlatformContext
 import coil3.SingletonImageLoader
-import coil3.imageLoader
 import coil3.disk.DiskCache
 import coil3.disk.directory
 import coil3.memory.MemoryCache
@@ -122,9 +120,7 @@ class App :
         runBlocking {
             PreferenceStore.awaitReady()
         }
-        if (BuildConfig.DEBUG) {
-            Timber.plant(Timber.DebugTree())
-        }
+        Timber.plant(Timber.DebugTree())
         try {
             Timber.plant(
                 dev.citali.lunartune.utils
@@ -154,9 +150,7 @@ class App :
 
     override fun onTrimMemory(level: Int) {
         super.onTrimMemory(level)
-        if (level >= ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW) {
-            runCatching { imageLoader.memoryCache?.clear() }
-        }
+        // WebView cleanup happens automatically on process death
     }
 
     private fun initializeCriticalSync() {

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
@@ -115,7 +115,6 @@ import dev.citali.lunartune.ui.component.LyricsV2
 import dev.citali.lunartune.ui.component.PlayerSliderTrack
 import dev.citali.lunartune.ui.menu.LyricsMenu
 import dev.citali.lunartune.ui.theme.PlayerColorExtractor
-import dev.citali.lunartune.utils.ImageBlurUtils
 import dev.citali.lunartune.utils.makeTimeString
 import dev.citali.lunartune.utils.rememberEnumPreference
 import dev.citali.lunartune.utils.rememberPreference

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
@@ -14,11 +14,6 @@ import android.graphics.Bitmap
 import android.os.Build
 import android.view.HapticFeedbackConstants
 import androidx.activity.compose.BackHandler
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -568,69 +563,67 @@ private fun AppleMusicBackground(
                 .fillMaxSize()
                 .background(Color.Black),
     ) {
-        AnimatedContent(
-            targetState = mediaMetadata.thumbnailUrl,
-            transitionSpec = { fadeIn(tween(700)) togetherWith fadeOut(tween(700)) },
-            label = "lyrics-lockscreen-background",
-        ) { thumbnailUrl ->
-            if (thumbnailUrl != null) {
-                val context = LocalContext.current
-                val isPreS = Build.VERSION.SDK_INT < Build.VERSION_CODES.S
-                if (isPreS) {
-                    val imageLoader = context.imageLoader
-                    val blurredBitmap by produceState<Bitmap?>(null, thumbnailUrl) {
-                        value =
-                            withContext(Dispatchers.IO) {
-                                runCatching {
-                                    val request =
-                                        ImageRequest
-                                            .Builder(context)
-                                            .data(thumbnailUrl)
-                                            .allowHardware(false)
-                                            .size(Size(720, 720))
-                                            .build()
-                                    val image = imageLoader.execute(request).image ?: return@runCatching null
-                                    val bitmap = image.toBitmap().copy(Bitmap.Config.ARGB_8888, true)
-                                    val density = context.resources.displayMetrics.density
-                                    ImageBlurUtils.blur(bitmap, 72f * density)
-                                }.getOrNull()
-                            }
+        val thumbnailUrl = mediaMetadata.thumbnailUrl
+        if (thumbnailUrl != null) {
+            val context = LocalContext.current
+            val isPreS = Build.VERSION.SDK_INT < Build.VERSION_CODES.S
+            val artModifier =
+                Modifier
+                    .fillMaxSize()
+                    .graphicsLayer {
+                        scaleX = 1.12f
+                        scaleY = 1.12f
                     }
-                    blurredBitmap?.let { bitmap ->
-                        Image(
-                            bitmap = bitmap.asImageBitmap(),
-                            contentDescription = null,
-                            contentScale = ContentScale.Crop,
-                            modifier =
-                                Modifier
-                                    .fillMaxSize()
-                                    .graphicsLayer {
-                                        scaleX = 1.12f
-                                        scaleY = 1.12f
-                                    },
-                        )
-                    }
-                } else {
-                    AsyncImage(
-                        model = thumbnailUrl,
+            // Show crop art immediately so Android 11 and below never flash black
+            // while RenderScript / software blur is still working.
+            AsyncImage(
+                model = thumbnailUrl,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = artModifier,
+            )
+            if (isPreS) {
+                val imageLoader = context.imageLoader
+                val blurredBitmap by produceState<Bitmap?>(null, thumbnailUrl) {
+                    value =
+                        withContext(Dispatchers.IO) {
+                            runCatching {
+                                val request =
+                                    ImageRequest
+                                        .Builder(context)
+                                        .data(thumbnailUrl)
+                                        .allowHardware(false)
+                                        .size(Size(720, 720))
+                                        .build()
+                                val image = imageLoader.execute(request).image ?: return@runCatching null
+                                val bitmap = image.toBitmap().copy(Bitmap.Config.ARGB_8888, true)
+                                val density = context.resources.displayMetrics.density
+                                ImageBlurUtils.blur(bitmap, 72f * density)
+                            }.getOrNull()
+                        }
+                }
+                blurredBitmap?.let { bitmap ->
+                    Image(
+                        bitmap = bitmap.asImageBitmap(),
                         contentDescription = null,
                         contentScale = ContentScale.Crop,
-                        modifier =
-                            Modifier
-                                .fillMaxSize()
-                                .graphicsLayer {
-                                    scaleX = 1.12f
-                                    scaleY = 1.12f
-                                }.blur(64.dp),
+                        modifier = artModifier,
                     )
                 }
+            } else {
+                AsyncImage(
+                    model = thumbnailUrl,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = artModifier.blur(64.dp),
+                )
             }
         }
         Box(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.28f)),
+                    .background(Color.Black.copy(alpha = 0.46f)),
         )
     }
 }

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/Player.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/Player.kt
@@ -9,15 +9,16 @@
 
 package dev.citali.lunartune.ui.player
 
-import android.content.BroadcastReceiver
 import android.content.Context
-import android.content.Intent
-import android.content.IntentFilter
 import android.content.res.Configuration
+import android.database.ContentObserver
 import android.graphics.Bitmap
 import android.media.AudioManager
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.os.SystemClock
+import android.provider.Settings
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
@@ -293,26 +294,17 @@ internal fun rememberDeviceMusicVolumeController(): DeviceMusicVolumeController 
         }
 
     DisposableEffect(context, controller) {
-        val appContext = context.applicationContext
-        val receiver =
-            object : BroadcastReceiver() {
-                override fun onReceive(
-                    ctx: Context?,
-                    intent: Intent?,
-                ) {
+        val observer =
+            object : ContentObserver(Handler(Looper.getMainLooper())) {
+                override fun onChange(selfChange: Boolean) {
                     controller.refresh()
                 }
             }
-        val filter = IntentFilter("android.media.VOLUME_CHANGED_ACTION")
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            appContext.registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
-        } else {
-            @Suppress("UnspecifiedRegisterReceiverFlag")
-            appContext.registerReceiver(receiver, filter)
-        }
+        val contentResolver = context.applicationContext.contentResolver
+        contentResolver.registerContentObserver(Settings.System.CONTENT_URI, true, observer)
         controller.refresh()
         onDispose {
-            runCatching { appContext.unregisterReceiver(receiver) }
+            contentResolver.unregisterContentObserver(observer)
         }
     }
 
@@ -836,17 +828,11 @@ fun BottomSheetPlayer(
         mutableStateOf(false)
     }
 
-    LaunchedEffect(mediaMetadata?.id, playbackState, aodModeEnabled, state.isExpanded) {
+    LaunchedEffect(mediaMetadata?.id, playbackState, aodModeEnabled) {
         val startTime = SystemClock.elapsedRealtime()
         if (playbackState == STATE_READY) {
             while (isActive) {
-                delay(
-                    when {
-                        aodModeEnabled -> 500L
-                        !state.isExpanded -> 400L
-                        else -> 100L
-                    },
-                )
+                delay(if (aodModeEnabled) 500L else 100L)
                 val isTransitioning = playerConnection.player.currentMediaItem?.mediaId != mediaMetadata?.id
                 val currentPlayerPosition = playerConnection.player.currentPosition
                 val currentPlayerDuration = playerConnection.player.duration

--- a/app/src/main/kotlin/dev/citali/lunartune/utils/ComposeToImage.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/utils/ComposeToImage.kt
@@ -30,7 +30,7 @@ import androidx.core.graphics.drawable.toBitmap
 import androidx.core.graphics.withClip
 import androidx.core.graphics.withTranslation
 import androidx.core.view.drawToBitmap
-import coil3.imageLoader
+import coil3.ImageLoader
 import coil3.request.ImageRequest
 import coil3.request.allowHardware
 import coil3.toBitmap
@@ -224,7 +224,7 @@ object ComposeToImage {
             var coverArtBitmap: Bitmap? = null
             if (coverArtUrl != null) {
                 try {
-                    val imageLoader = context.imageLoader
+                    val imageLoader = ImageLoader(context)
                     val request =
                         ImageRequest
                             .Builder(context)


### PR DESCRIPTION
Reverts #48. Those observer/seek-tick changes made motion feel laggy, so the player is back to the previous observers and 100ms ticks without touching animation specs.

Lyrics page on Android 11 and below no longer opens on a black screen while software blur runs: album art is shown immediately, then replaced with the lockscreen-style blur. Overlay dim is 0.46 so lyrics and glow stay readable.