### PR TITLE
fix: prefetch lyrics blur when a song starts

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
@@ -10,9 +10,9 @@
 package dev.citali.lunartune.ui.player
 
 import android.content.res.Configuration
-import android.os.Build
 import android.view.HapticFeedbackConstants
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -58,6 +58,7 @@ import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
@@ -72,6 +73,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.collectAsState
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.media3.common.C
 import androidx.media3.common.Player.STATE_BUFFERING
@@ -115,6 +117,7 @@ import dev.citali.lunartune.ui.component.LyricsV2
 import dev.citali.lunartune.ui.component.PlayerSliderTrack
 import dev.citali.lunartune.ui.menu.LyricsMenu
 import dev.citali.lunartune.ui.theme.PlayerColorExtractor
+import dev.citali.lunartune.utils.LyricsArtBlurCache
 import dev.citali.lunartune.utils.makeTimeString
 import dev.citali.lunartune.utils.rememberEnumPreference
 import dev.citali.lunartune.utils.rememberPreference
@@ -395,8 +398,7 @@ fun LyricsScreen(
                     )
 
                     Column(
-                        modifier =
-                            Modifier
+                Modifier
                                 .weight(0.85f)
                                 .widthIn(max = 420.dp),
                         verticalArrangement = Arrangement.Center,
@@ -554,28 +556,25 @@ private fun AppleMusicBackground(
 ) {
     val context = LocalContext.current
     val thumbnailUrl = mediaMetadata.thumbnailUrl
-    val isPreS = Build.VERSION.SDK_INT < Build.VERSION_CODES.S
-    // Tiny decode + stretch (and GPU blur on S+) is instant and lockscreen-like.
-    // Skip RenderScript so Android 11 never waits on a 720px software blur.
-    val blurRequest =
-        remember(thumbnailUrl, context) {
-            thumbnailUrl?.let { url ->
-                ImageRequest
-                    .Builder(context)
-                    .data(url)
-                    .size(Size(48, 48))
-                    .build()
-            }
+    val cacheRevision by LyricsArtBlurCache.updates.collectAsState()
+    val blurredArt =
+        remember(thumbnailUrl, cacheRevision) {
+            LyricsArtBlurCache.peek(thumbnailUrl)
         }
+
+    LaunchedEffect(thumbnailUrl) {
+        LyricsArtBlurCache.prefetch(context, thumbnailUrl)
+    }
+
     Box(
         modifier =
             modifier
                 .fillMaxSize()
                 .background(Color.Black),
     ) {
-        if (blurRequest != null) {
-            AsyncImage(
-                model = blurRequest,
+        if (blurredArt != null) {
+            Image(
+                bitmap = blurredArt.asImageBitmap(),
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
                 modifier =
@@ -584,14 +583,14 @@ private fun AppleMusicBackground(
                         .graphicsLayer {
                             scaleX = 1.12f
                             scaleY = 1.12f
-                        }.then(if (isPreS) Modifier else Modifier.blur(64.dp)),
+                        },
             )
         }
         Box(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.48f)),
+                    .background(Color.Black.copy(alpha = 0.62f)),
         )
     }
 }

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/Player.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/Player.kt
@@ -208,6 +208,7 @@ import dev.citali.lunartune.ui.utils.YtimgResizePolicy
 import dev.citali.lunartune.ui.utils.getNextFallbackUrl
 import dev.citali.lunartune.ui.utils.resize
 import dev.citali.lunartune.utils.ImageBlurUtils
+import dev.citali.lunartune.utils.LyricsArtBlurCache
 import dev.citali.lunartune.utils.makeTimeString
 import dev.citali.lunartune.utils.parseTabMap
 import dev.citali.lunartune.utils.rememberEnumPreference
@@ -536,6 +537,10 @@ fun BottomSheetPlayer(
             previousThumbnailUrl = currentThumbnail
             previousGradientColors = gradientColors
         }
+    }
+
+    LaunchedEffect(mediaMetadata?.thumbnailUrl) {
+        LyricsArtBlurCache.prefetch(context, mediaMetadata?.thumbnailUrl)
     }
 
     LaunchedEffect(mediaMetadata?.id, mediaMetadata?.thumbnailUrl, playerBackground, playerDesignStyle) {

--- a/app/src/main/kotlin/dev/citali/lunartune/utils/LyricsArtBlurCache.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/utils/LyricsArtBlurCache.kt
@@ -1,0 +1,93 @@
+/*
+ * LunarTune (2026)
+ * © cognitiveshadows03 — github.com/cognitiveshadows03
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package dev.citali.lunartune.utils
+
+import android.content.Context
+import android.graphics.Bitmap
+import coil3.imageLoader
+import coil3.request.ImageRequest
+import coil3.request.allowHardware
+import coil3.size.Size
+import coil3.toBitmap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+/**
+ * Pre-blurs the playing track's cover on a background thread so the lyrics
+ * page can open on an already-blurred bitmap instead of a sharp cover.
+ */
+object LyricsArtBlurCache {
+    private const val DecodeSizePx = 160
+    private const val BlurRadius = 24f
+    private const val MaxEntries = 8
+
+    private val mutex = Mutex()
+    private val bitmaps =
+        object : LinkedHashMap<String, Bitmap>(MaxEntries, 0.75f, true) {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Bitmap>): Boolean =
+                size > MaxEntries
+        }
+    private val inFlight = mutableSetOf<String>()
+    private val revision = MutableStateFlow(0)
+
+    val updates: StateFlow<Int> = revision.asStateFlow()
+
+    fun peek(url: String?): Bitmap? {
+        if (url.isNullOrBlank()) return null
+        synchronized(bitmaps) {
+            return bitmaps[url]
+        }
+    }
+
+    suspend fun prefetch(
+        context: Context,
+        url: String?,
+    ) {
+        if (url.isNullOrBlank()) return
+        if (peek(url) != null) return
+
+        val shouldLoad =
+            mutex.withLock {
+                if (url in inFlight || peek(url) != null) {
+                    false
+                } else {
+                    inFlight.add(url)
+                    true
+                }
+            }
+        if (!shouldLoad) return
+
+        try {
+            val blurred =
+                withContext(Dispatchers.IO) {
+                    val request =
+                        ImageRequest
+                            .Builder(context.applicationContext)
+                            .data(url)
+                            .size(Size(DecodeSizePx, DecodeSizePx))
+                            .allowHardware(false)
+                            .build()
+                    val image = context.applicationContext.imageLoader.execute(request).image ?: return@withContext null
+                    val bitmap = image.toBitmap().copy(Bitmap.Config.ARGB_8888, true)
+                    ImageBlurUtils.blur(bitmap, BlurRadius)
+                } ?: return
+
+            synchronized(bitmaps) {
+                bitmaps[url] = blurred
+            }
+            revision.value = revision.value + 1
+        } finally {
+            mutex.withLock { inFlight.remove(url) }
+        }
+    }
+}


### PR DESCRIPTION
#50 already merged. This is the leftover lyrics work:

- Blur the playing cover in the background as soon as playback metadata is ready.
- Lyrics page uses that cached bitmap so it does not wait on a sharp cover or RenderScript.
- Dim overlay is 0.62 so lyrics and glow stay readable.