### PR TITLE
feat: smart playlists, reliable crossfade, and multi-select

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/playback/CrossfadeHandoffPolicy.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/playback/CrossfadeHandoffPolicy.kt
@@ -31,6 +31,11 @@ internal fun hasPlaybackPositionAdvanced(
     currentPositionMs: Long,
 ): Boolean = currentPositionMs > positionAfterSeekMs
 
+internal fun requiredCrossfadeStartBufferMs(durationMs: Long): Long =
+    durationMs
+        .coerceAtLeast(750L)
+        .coerceAtMost(3_000L)
+
 internal fun equalPowerGains(progress: Float): EqualPowerGains {
     val clampedProgress = progress.coerceIn(0f, 1f)
     val radians = clampedProgress.toDouble() * (PI / 2.0)

--- a/app/src/main/kotlin/dev/citali/lunartune/playback/MusicService.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/playback/MusicService.kt
@@ -3047,11 +3047,6 @@ class MusicService :
         return false
     }
 
-    private fun requiredCrossfadeStartBufferMs(durationMs: Long): Long =
-        (durationMs + CROSSFADE_HANDOFF_BUFFER_MS)
-            .coerceAtLeast(CROSSFADE_MIN_BUFFER_BEFORE_START_MS)
-            .coerceAtMost(CROSSFADE_MAX_BUFFER_BEFORE_START_MS)
-
     private fun hasBufferedForSmoothStart(
         targetPlayer: ExoPlayer,
         minimumBufferedMs: Long,
@@ -8882,7 +8877,7 @@ class MusicService :
         const val MIN_CROSSFADE_DURATION_MS = 500L
         const val CROSSFADE_END_GUARD_MS = 150L
         const val CROSSFADE_PREPARE_AHEAD_MS = 30_000L
-        const val CROSSFADE_READY_TIMEOUT_MS = 5_000L
+        const val CROSSFADE_READY_TIMEOUT_MS = 12_000L
         const val CROSSFADE_HANDOFF_READY_TIMEOUT_MS = 5_000L
         const val CROSSFADE_HANDOFF_BUFFER_MS = 5_000L
         const val CROSSFADE_HANDOFF_SEEK_GUARD_MS = 750L

--- a/app/src/main/kotlin/dev/citali/lunartune/playback/SleepTimer.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/playback/SleepTimer.kt
@@ -15,6 +15,7 @@ import androidx.media3.common.Player
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.minutes
 
@@ -37,10 +38,22 @@ class SleepTimer(
         if (minute == -1) {
             pauseWhenSongEnd = true
         } else {
-            triggerTime = System.currentTimeMillis() + minute.minutes.inWholeMilliseconds
+            val durationMs = minute.minutes.inWholeMilliseconds
+            triggerTime = System.currentTimeMillis() + durationMs
             sleepTimerJob =
                 scope.launch {
-                    delay(minute.minutes)
+                    val fadeMs = FADE_MS.coerceAtMost(durationMs)
+                    val waitMs = (durationMs - fadeMs).coerceAtLeast(0L)
+                    delay(waitMs)
+                    val startVolume = player.volume
+                    val startedAt = android.os.SystemClock.elapsedRealtime()
+                    while (isActive) {
+                        val elapsed = android.os.SystemClock.elapsedRealtime() - startedAt
+                        val progress = (elapsed.toFloat() / fadeMs.toFloat()).coerceIn(0f, 1f)
+                        player.volume = (startVolume * (1f - progress)).coerceAtLeast(0f)
+                        if (progress >= 1f) break
+                        delay(32L)
+                    }
                     service.pauseFromSleepTimer()
                 }
         }
@@ -68,5 +81,9 @@ class SleepTimer(
         if (playbackState == Player.STATE_ENDED && pauseWhenSongEnd) {
             service.pauseFromSleepTimer()
         }
+    }
+
+    companion object {
+        private const val FADE_MS = 30_000L
     }
 }

--- a/app/src/main/kotlin/dev/citali/lunartune/playlist/SmartPlaylists.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/playlist/SmartPlaylists.kt
@@ -1,0 +1,18 @@
+/*
+ * LunarTune (2026)
+ * © cognitiveshadows03 — github.com/cognitiveshadows03
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package dev.citali.lunartune.playlist
+
+object SmartPlaylists {
+    const val ON_REPEAT = "on_repeat"
+    const val FORGOTTEN = "forgotten"
+    const val RECENT = "recent"
+
+    val ids = listOf(ON_REPEAT, FORGOTTEN, RECENT)
+
+    fun isSmartPlaylist(id: String): Boolean = id in ids
+}

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/artist/ArtistSongsScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/artist/ArtistSongsScreen.kt
@@ -7,6 +7,7 @@
 
 package dev.citali.lunartune.ui.screens.artist
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
@@ -27,8 +28,14 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -55,7 +62,9 @@ import dev.citali.lunartune.ui.component.IconButton
 import dev.citali.lunartune.ui.component.LocalMenuState
 import dev.citali.lunartune.ui.component.SongListItem
 import dev.citali.lunartune.ui.component.SortHeader
+import dev.citali.lunartune.ui.menu.SelectionSongMenu
 import dev.citali.lunartune.ui.menu.SongMenu
+import dev.citali.lunartune.ui.utils.ItemWrapper
 import dev.citali.lunartune.ui.utils.backToMain
 import dev.citali.lunartune.utils.rememberEnumPreference
 import dev.citali.lunartune.utils.rememberPreference
@@ -89,6 +98,18 @@ fun ArtistSongsScreen(
     val artist by viewModel.artist.collectAsState()
     val songs by viewModel.songs.collectAsState()
     val lazyListState = rememberLazyListState()
+    val wrappedSongs = remember(songs) { songs.map { ItemWrapper(it) }.toMutableStateList() }
+    var selection by remember { mutableStateOf(false) }
+    val selectedCount by remember { derivedStateOf { wrappedSongs.count { it.isSelected } } }
+    LaunchedEffect(selection, selectedCount) {
+        if (selection && selectedCount == 0) selection = false
+    }
+    if (selection) {
+        BackHandler {
+            selection = false
+            wrappedSongs.forEach { it.isSelected = false }
+        }
+    }
 
     Box(
         modifier = Modifier.fillMaxSize(),
@@ -130,12 +151,14 @@ fun ArtistSongsScreen(
             }
 
             itemsIndexed(
-                items = songs,
-                key = { _, item -> item.id },
-            ) { index, song ->
+                items = wrappedSongs,
+                key = { _, item -> item.item.id },
+            ) { index, songWrapper ->
+                val song = songWrapper.item
                 SongListItem(
                     song = song,
                     showInLibraryIcon = true,
+                    isSelected = selection && songWrapper.isSelected,
                     isActive = song.id == mediaMetadata?.id,
                     isPlaying = isPlaying,
                     trailingContent = {
@@ -161,7 +184,9 @@ fun ArtistSongsScreen(
                             .fillMaxWidth()
                             .combinedClickable(
                                 onClick = {
-                                    if (song.id == mediaMetadata?.id) {
+                                    if (selection) {
+                                        songWrapper.isSelected = !songWrapper.isSelected
+                                    } else if (song.id == mediaMetadata?.id) {
                                         playerConnection.player.togglePlayPause()
                                     } else {
                                         playerConnection.playQueue(
@@ -175,12 +200,12 @@ fun ArtistSongsScreen(
                                 },
                                 onLongClick = {
                                     haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                    menuState.show {
-                                        SongMenu(
-                                            originalSong = song,
-                                            navController = navController,
-                                            onDismiss = menuState::dismiss,
-                                        )
+                                    if (!selection) {
+                                        selection = true
+                                        wrappedSongs.forEach { it.isSelected = false }
+                                        songWrapper.isSelected = true
+                                    } else {
+                                        songWrapper.isSelected = !songWrapper.isSelected
                                     }
                                 },
                             ).animateItem(),

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/library/LibraryMixScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/library/LibraryMixScreen.kt
@@ -296,7 +296,40 @@ fun LibraryMixScreen(
                                 onClick = { navController.navigate("top_playlist/$topSize") },
                             )
 
-                            Spacer(modifier = Modifier.weight(1f))
+                            ShortcutCard(
+                                title = stringResource(R.string.smart_playlist_on_repeat),
+                                countText = stringResource(R.string.smart_playlist_on_repeat_desc),
+                                iconRes = R.drawable.replay,
+                                containerColor = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.6f),
+                                iconColor = MaterialTheme.colorScheme.tertiary,
+                                modifier = Modifier.weight(1f),
+                                onClick = { navController.navigate("auto_playlist/on_repeat") },
+                            )
+                        }
+
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            ShortcutCard(
+                                title = stringResource(R.string.smart_playlist_forgotten),
+                                countText = stringResource(R.string.smart_playlist_forgotten_desc),
+                                iconRes = R.drawable.history,
+                                containerColor = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.45f),
+                                iconColor = MaterialTheme.colorScheme.error,
+                                modifier = Modifier.weight(1f),
+                                onClick = { navController.navigate("auto_playlist/forgotten") },
+                            )
+
+                            ShortcutCard(
+                                title = stringResource(R.string.smart_playlist_recent),
+                                countText = stringResource(R.string.smart_playlist_recent_desc),
+                                iconRes = R.drawable.history,
+                                containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.45f),
+                                iconColor = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.weight(1f),
+                                onClick = { navController.navigate("auto_playlist/recent") },
+                            )
                         }
                     }
                 }

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/library/LibrarySongsScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/library/LibrarySongsScreen.kt
@@ -7,6 +7,7 @@
 
 package dev.citali.lunartune.ui.screens.library
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -44,12 +45,15 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -59,6 +63,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -82,6 +87,7 @@ import dev.citali.lunartune.playback.queues.ListQueue
 import dev.citali.lunartune.ui.component.ExpressivePullToRefreshBox
 import dev.citali.lunartune.ui.component.ItemThumbnail
 import dev.citali.lunartune.ui.component.LocalMenuState
+import dev.citali.lunartune.ui.menu.SelectionSongMenu
 import dev.citali.lunartune.ui.menu.SongMenu
 import dev.citali.lunartune.ui.screens.library.rememberArtworkGradient
 import dev.citali.lunartune.ui.utils.ItemWrapper
@@ -128,7 +134,19 @@ fun LibrarySongsScreen(
             .asPaddingValues()
             .calculateBottomPadding() + 12.dp
 
-    val wrappedSongs = remember(songs) { songs.map { item -> ItemWrapper(item) }.toMutableList() }
+    val wrappedSongs = remember(songs) { songs.map { item -> ItemWrapper(item) }.toMutableStateList() }
+
+    var selection by remember { mutableStateOf(false) }
+    val selectedCount by remember { derivedStateOf { wrappedSongs.count { it.isSelected } } }
+    LaunchedEffect(selection, selectedCount) {
+        if (selection && selectedCount == 0) selection = false
+    }
+    if (selection) {
+        BackHandler {
+            selection = false
+            wrappedSongs.forEach { it.isSelected = false }
+        }
+    }
 
     val filteredSongs =
         remember(wrappedSongs, hideExplicit) {
@@ -316,6 +334,60 @@ fun LibrarySongsScreen(
 
             Spacer(modifier = Modifier.height(12.dp))
 
+            if (selection) {
+                Row(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 24.dp, vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Text(
+                        text = pluralStringResource(R.plurals.n_song, selectedCount, selectedCount),
+                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                    )
+                    Row {
+                        IconButton(
+                            onClick = {
+                                if (selectedCount == wrappedSongs.size) {
+                                    wrappedSongs.forEach { it.isSelected = false }
+                                } else {
+                                    wrappedSongs.forEach { it.isSelected = true }
+                                }
+                            },
+                        ) {
+                            Icon(
+                                painter =
+                                    painterResource(
+                                        if (selectedCount == wrappedSongs.size) R.drawable.deselect else R.drawable.select_all,
+                                    ),
+                                contentDescription = null,
+                            )
+                        }
+                        IconButton(
+                            onClick = {
+                                menuState.show {
+                                    SelectionSongMenu(
+                                        songSelection = wrappedSongs.filter { it.isSelected }.map { it.item },
+                                        onDismiss = menuState::dismiss,
+                                        clearAction = {
+                                            selection = false
+                                            wrappedSongs.forEach { it.isSelected = false }
+                                        },
+                                    )
+                                }
+                            },
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.more_vert),
+                                contentDescription = null,
+                            )
+                        }
+                    }
+                }
+            }
+
             LazyColumn(
                 state = lazyListState,
                 // Issue 2: use player-aware window insets for bottom padding
@@ -481,6 +553,7 @@ fun LibrarySongsScreen(
                             thumbnailUrl = song.song.thumbnailUrl,
                             isActive = isActive,
                             isPlaying = isPlaying,
+                            isSelected = selection && songWrapper.isSelected,
                             shape = RoundedCornerShape(thumbCorner),
                             contentScale = ContentScale.Crop,
                             showPlaceholder = true,

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -126,7 +126,13 @@ fun AutoPlaylistScreen(
     val isPlaying by playerConnection.isPlaying.collectAsStateWithLifecycle()
     val mediaMetadata by playerConnection.mediaMetadata.collectAsStateWithLifecycle()
     val playlist =
-        if (viewModel.playlist == "liked") stringResource(R.string.liked) else stringResource(R.string.offline)
+        when (viewModel.playlist) {
+            "liked" -> stringResource(R.string.liked)
+            "on_repeat" -> stringResource(R.string.smart_playlist_on_repeat)
+            "forgotten" -> stringResource(R.string.smart_playlist_forgotten)
+            "recent" -> stringResource(R.string.smart_playlist_recent)
+            else -> stringResource(R.string.offline)
+        }
 
     val songs by viewModel.likedSongs.collectAsStateWithLifecycle()
 

--- a/app/src/main/kotlin/dev/citali/lunartune/viewmodels/AutoPlaylistViewModel.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/viewmodels/AutoPlaylistViewModel.kt
@@ -82,6 +82,22 @@ class AutoPlaylistViewModel
                             database.likedSongs(songSortType, descending, hideVideo).map { it.filterExplicit(hideExplicit) }
                         }
 
+                        "on_repeat" -> {
+                            database
+                                .mostPlayedSongs(
+                                    fromTimeStamp = System.currentTimeMillis() - 30L * 24 * 60 * 60 * 1000,
+                                    limit = 50,
+                                ).map { it.filterExplicit(hideExplicit) }
+                        }
+
+                        "forgotten" -> {
+                            database.forgottenFavorites().map { it.filterExplicit(hideExplicit) }
+                        }
+
+                        "recent" -> {
+                            database.recentSongs(80).map { it.filterExplicit(hideExplicit) }
+                        }
+
                         else -> {
                             MutableStateFlow(emptyList())
                         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,6 +106,12 @@
     <string name="featured_album_badge">FEATURED ALBUM</string>
     <string name="other_versions">Other versions</string>
     <string name="liked_songs">Liked songs</string>
+    <string name="smart_playlist_on_repeat">On repeat</string>
+    <string name="smart_playlist_on_repeat_desc">Most played this month</string>
+    <string name="smart_playlist_forgotten">Forgotten favorites</string>
+    <string name="smart_playlist_forgotten_desc">Loved songs you left behind</string>
+    <string name="smart_playlist_recent">Recently played</string>
+    <string name="smart_playlist_recent_desc">Your latest listens</string>
     <string name="downloaded_songs">Downloaded songs</string>
     <string name="playlist_is_empty">The playlist is empty</string>
     <string name="remove_download_playlist_confirm">Do you really want to remove all \"%s\" playlist songs from the Downloaded Songs storage?</string>

--- a/app/src/test/kotlin/dev/citali/lunartune/playback/CrossfadeHandoffPolicyTest.kt
+++ b/app/src/test/kotlin/dev/citali/lunartune/playback/CrossfadeHandoffPolicyTest.kt
@@ -45,6 +45,13 @@ class CrossfadeHandoffPolicyTest {
     }
 
     @Test
+    fun startBuffer_isShortEnoughToBeatTheReadyTimeout() {
+        assertEquals(750L, requiredCrossfadeStartBufferMs(200L))
+        assertEquals(2_000L, requiredCrossfadeStartBufferMs(2_000L))
+        assertEquals(3_000L, requiredCrossfadeStartBufferMs(8_000L))
+    }
+
+    @Test
     fun equalPowerHandoff_preservesPowerAtEndpointsAndMidpoint() {
         val start = equalPowerGains(0f)
         val midpoint = equalPowerGains(0.5f)

--- a/app/src/test/kotlin/dev/citali/lunartune/playlist/SmartPlaylistsTest.kt
+++ b/app/src/test/kotlin/dev/citali/lunartune/playlist/SmartPlaylistsTest.kt
@@ -1,0 +1,22 @@
+/*
+ * LunarTune (2026)
+ * © cognitiveshadows03 — github.com/cognitiveshadows03
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package dev.citali.lunartune.playlist
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SmartPlaylistsTest {
+    @Test
+    fun knownSmartPlaylists_areRecognized() {
+        assertTrue(SmartPlaylists.isSmartPlaylist("on_repeat"))
+        assertTrue(SmartPlaylists.isSmartPlaylist("forgotten"))
+        assertTrue(SmartPlaylists.isSmartPlaylist("recent"))
+        assertFalse(SmartPlaylists.isSmartPlaylist("liked"))
+    }
+}


### PR DESCRIPTION
## How smart playlists work
They are live lists, not saved copies. Opening **On repeat** rebuilds from the last 30 days of plays (top 50). **Forgotten favorites** are songs you used to play a lot but barely touched this month. **Recently played** is your last 80 unique listens. They sit on Library Mix next to Liked / Offline.

## Crossfade
The next track was waiting for 5–12 seconds of buffer inside a 5 second timeout, so mixes often aborted. Start buffer is now 0.75–3s with a 12s ready window. Player seek *adjustments* no longer cancel an in-progress fade.

## Multi-select
Long-press a song in **Library → Songs** or an **artist song list** to select many, then add to playlist / queue / download from the same menu albums already use.

## Extra
Sleep timer now **fades volume over the last 30 seconds** instead of a hard cut.
