### PR TITLE
feat: bump version to 5.1.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
     applicationId = "dev.citali.lunartune"
         minSdk = 26
         targetSdk = 37
-        versionCode = 500
-        versionName = "5.0.0"
+        versionCode = 510
+        versionName = "5.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
Bumps the app to 5.1.0 (versionCode 510), the first release after the 5.0.0 stable line — covers the merged player blur/crossfade work, Library card toggles and the #61 cleanup.

versionCode follows the 5.0.0 → 500 scheme: major*100 + minor*10 + patch, leaving room for 5.1.x patches.