### PR TITLE
perf: force max refresh rate app-wide, on by default

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/MainActivity.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/MainActivity.kt
@@ -197,6 +197,7 @@ import dev.citali.lunartune.constants.CustomThemeColorKey
 import dev.citali.lunartune.constants.DarkModeKey
 import dev.citali.lunartune.constants.DefaultOpenTabKey
 import dev.citali.lunartune.constants.DisableAnimationsKey
+import dev.citali.lunartune.constants.ForceHighRefreshRateKey
 import dev.citali.lunartune.constants.DisableScreenshotKey
 import dev.citali.lunartune.constants.DynamicThemeKey
 import dev.citali.lunartune.constants.EnableHapticFeedbackKey
@@ -288,6 +289,7 @@ import dev.citali.lunartune.ui.screens.search.OnlineSearchResultRoutePrefix
 import dev.citali.lunartune.ui.screens.search.OnlineSearchScreen
 import dev.citali.lunartune.ui.screens.search.decodeOnlineSearchQuery
 import dev.citali.lunartune.ui.screens.search.onlineSearchResultRoute
+import dev.citali.lunartune.ui.screens.settings.ApplyForcedRefreshRate
 import dev.citali.lunartune.ui.screens.settings.DarkMode
 import dev.citali.lunartune.ui.screens.settings.NavigationTab
 import dev.citali.lunartune.ui.theme.LunarTuneTheme
@@ -750,6 +752,11 @@ class MainActivity : ComponentActivity() {
                 DisableAnimationsKey,
                 defaultValue = defaultDisableAnimations,
             )
+            val forceHighRefreshRate by rememberPreference(
+                ForceHighRefreshRateKey,
+                defaultValue = true,
+            )
+            ApplyForcedRefreshRate(enabled = forceHighRefreshRate)
             val fontPreference by rememberEnumPreference(FontPreferenceKey, defaultValue = AppFontPreference.DEFAULT)
             val customFontUri by rememberPreference(CustomFontUriKey, defaultValue = "")
             val legacyUseSystemFont by rememberPreference(UseSystemFontKey, defaultValue = false)

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/AppearanceSettings.kt
@@ -225,7 +225,7 @@ fun AppearanceSettings(navController: NavController) {
     val (forceHighRefreshRate, onForceHighRefreshRateChange) =
         rememberPreference(
             ForceHighRefreshRateKey,
-            defaultValue = false,
+            defaultValue = true,
         )
     val (blurRadius, onBlurRadiusChange) = rememberPreference(BlurRadiusKey, defaultValue = 48f)
     val (backdropEnabled, onBackdropEnabledChange) = rememberPreference(BackdropEnabledKey, defaultValue = true)
@@ -408,11 +408,6 @@ fun AppearanceSettings(navController: NavController) {
         )
     val supportedHighestFps = rememberSupportedHighestFps()
     val isHighRefreshRateSupported = supportedHighestFps > HIGH_REFRESH_RATE_THRESHOLD_FPS
-
-    ApplyRefreshRate(
-        isEnabled = forceHighRefreshRate && isHighRefreshRateSupported,
-        targetFps = supportedHighestFps,
-    )
 
     var showSliderOptionDialog by rememberSaveable {
         mutableStateOf(false)
@@ -1204,7 +1199,16 @@ fun ApplyRefreshRate(
 }
 
 @Composable
-private fun rememberSupportedHighestFps(): Float {
+internal fun ApplyForcedRefreshRate(enabled: Boolean) {
+    val supportedHighestFps = rememberSupportedHighestFps()
+    ApplyRefreshRate(
+        isEnabled = enabled && supportedHighestFps > HIGH_REFRESH_RATE_THRESHOLD_FPS,
+        targetFps = supportedHighestFps,
+    )
+}
+
+@Composable
+internal fun rememberSupportedHighestFps(): Float {
     val view = LocalView.current
 
     return remember(view) {
@@ -1224,13 +1228,24 @@ private fun applyRefreshRate(
 ) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
         view.setRequestedFrameRate(requestedFps)
-        return
     }
 
     activity?.window?.let { window ->
         val attributes = window.attributes
-        if (attributes.preferredRefreshRate != requestedFps) {
-            attributes.preferredRefreshRate = requestedFps
+        val targetModeId =
+            if (requestedFps <= 0f) {
+                0
+            } else {
+                view.display
+                    ?.supportedModes
+                    ?.filter { it.refreshRate >= requestedFps - 0.01f }
+                    ?.minByOrNull { it.refreshRate }
+                    ?.modeId
+                    ?: view.display?.supportedModes?.maxByOrNull { it.refreshRate }?.modeId
+                    ?: 0
+            }
+        if (attributes.preferredDisplayModeId != targetModeId) {
+            attributes.preferredDisplayModeId = targetModeId
             window.attributes = attributes
         }
     }


### PR DESCRIPTION
Examined the lag: the existing Force high refresh rate feature was scoped to the Appearance settings screen only — `ApplyRefreshRate` ran there and its `onDispose` reset the window back to the default rate the moment you left the screen — and it defaulted to off. So the app effectively always ran at the system-default (often 60 Hz) mode, which reads as lag on 90/120 Hz displays.

Fixes:

- the refresh-rate request now lives in `MainActivity`, so it applies to the whole app for as long as it is visible
- default flipped to **on**; the existing Appearance toggle still controls it (and stays disabled on 60 Hz-only displays)
- the request now sets `WindowManager.LayoutParams.preferredDisplayModeId` to the highest supported mode (the reliable force path across OEMs) instead of only `preferredRefreshRate`, keeping the `setRequestedFrameRate` hint on API 35+

Blur paths were audited too: artwork blurs run off the main thread (`Dispatchers.IO`) and Compose `Modifier.blur` is GPU-backed on API 31+, so no main-thread blur jank remains.