### PR TITLE
fix: make home category chips show their content

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/home/HomeModels.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/home/HomeModels.kt
@@ -53,6 +53,7 @@ data class HomeUiState(
     val showTonalBackdrop: Boolean,
     val isRefreshing: Boolean,
     val isLoadingMore: Boolean,
+    val isChipLoading: Boolean,
 )
 
 sealed interface HomeAction {
@@ -61,6 +62,8 @@ sealed interface HomeAction {
     data class SelectChip(
         val chip: HomePage.Chip?,
     ) : HomeAction
+
+    data object RetryChip : HomeAction
 
     data class LoadMore(
         val continuation: String?,

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/HomeScreen.kt
@@ -11,6 +11,7 @@ import androidx.activity.compose.BackHandler
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -23,6 +24,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -70,6 +72,7 @@ import dev.citali.lunartune.ui.component.LocalMenuState
 import dev.citali.lunartune.ui.component.MenuState
 import dev.citali.lunartune.ui.utils.SnapLayoutInfoProvider
 import dev.citali.lunartune.viewmodels.HomeViewModel
+import moe.rukamori.archivetune.innertube.pages.HomePage
 
 private val HomeFeedMaxWidth = 1_200.dp
 private val HomeSectionSpacing = 18.dp
@@ -126,6 +129,14 @@ fun HomeScreen(
     LaunchedEffect(uiState?.forgottenFavorites) {
         if (uiState != null) {
             forgottenFavoritesGridState.scrollToItem(0)
+        }
+    }
+
+    // A category is its own feed, so start it from the top instead of leaving the
+    // scroll position of the personalised home.
+    LaunchedEffect(selectedChip) {
+        if (selectedChip != null) {
+            lazyListState.scrollToItem(0)
         }
     }
 
@@ -338,124 +349,39 @@ private fun HomeContent(
                         }
                     }
 
-                    if (remoteQuickPicks?.items?.isNotEmpty() == true) {
-                        item(
-                            key = "home_remote_quick_picks_header",
-                            contentType = "section_header",
-                        ) {
-                            HomeSectionHeader(
-                                title = remoteQuickPicks.title,
-                            )
-                        }
-                        item(
-                            key = "home_remote_quick_picks",
-                            contentType = "media_shelf",
-                        ) {
-                            HomePageSectionContent(
-                                section = remoteQuickPicks,
-                                mediaMetadata = mediaMetadata,
-                                isPlaying = isPlaying,
-                                navController = navController,
-                                playerConnection = playerConnection,
-                                menuState = menuState,
-                                haptic = haptic,
-                                scope = scope,
-                            )
-                        }
-                    } else if (uiState.quickPicks.isNotEmpty()) {
-                        item(
-                            key = "home_quick_picks_header",
-                            contentType = "section_header",
-                        ) {
-                            HomeSectionHeader(
-                                title = stringResource(R.string.quick_picks),
-                            )
-                        }
-                        item(
-                            key = "home_quick_picks",
-                            contentType = "quick_picks",
-                        ) {
-                            QuickPicksSection(
-                                quickPicks = uiState.quickPicks,
-                                mediaMetadata = mediaMetadata,
-                                isPlaying = isPlaying,
-                                displayMode = uiState.quickPicksDisplayMode,
-                                navController = navController,
-                                playerConnection = playerConnection,
-                                menuState = menuState,
-                                haptic = haptic,
-                            )
-                        }
-                    }
-
-                    if (uiState.speedDialItems.isNotEmpty()) {
-                        sectionSpacer("speed_dial")
-                        item(
-                            key = "home_speed_dial_header",
-                            contentType = "section_header",
-                        ) {
-                            HomeSectionHeader(
-                                title = stringResource(R.string.speed_dial),
-                            )
-                        }
-                        item(
-                            key = "home_speed_dial",
-                            contentType = "speed_dial",
-                        ) {
-                            SpeedDialSection(
-                                speedDialItems = uiState.speedDialItems,
-                                mediaMetadata = mediaMetadata,
-                                isPlaying = isPlaying,
-                                navController = navController,
-                                playerConnection = playerConnection,
-                                menuState = menuState,
-                                haptic = haptic,
-                                scope = scope,
-                            )
-                        }
-                    }
-
-                    if (uiState.keepListening.isNotEmpty()) {
-                        sectionSpacer("keep_listening")
-                        item(
-                            key = "home_keep_listening_header",
-                            contentType = "section_header",
-                        ) {
-                            HomeSectionHeader(
-                                title = stringResource(R.string.keep_listening),
-                            )
-                        }
-                        item(
-                            key = "home_keep_listening",
-                            contentType = "media_shelf",
-                        ) {
-                            KeepListeningSection(
-                                keepListening = uiState.keepListening,
-                                mediaMetadata = mediaMetadata,
-                                isPlaying = isPlaying,
-                                navController = navController,
-                                playerConnection = playerConnection,
-                                menuState = menuState,
-                                haptic = haptic,
-                                scope = scope,
-                            )
-                        }
-                    }
-
-                    if (uiState.accountPlaylists.isNotEmpty()) {
-                        sectionSpacer("account_playlists")
-                        item(
-                            key = "home_account_playlists",
-                            contentType = "media_shelf",
-                        ) {
-                            Column {
-                                AccountPlaylistsTitle(
-                                    accountName = uiState.accountName,
-                                    accountImageUrl = uiState.accountImageUrl,
-                                    onClick = { navController.navigate("account") },
-                                )
-                                AccountPlaylistsSection(
-                                    accountPlaylists = uiState.accountPlaylists,
+                    val chipSelected = uiState.selectedChip != null
+                    if (chipSelected) {
+                        // A category replaces the personalised feed: only its own
+                        // shelves are shown, right under the chip row.
+                        if (uiState.isChipLoading) {
+                            item(
+                                key = "home_chip_loading",
+                                contentType = "loading",
+                            ) {
+                                Box(
+                                    contentAlignment = Alignment.Center,
+                                    modifier =
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .padding(vertical = 64.dp),
+                                ) {
+                                    LoadingIndicator()
+                                }
+                            }
+                        } else {
+                            val chipSections = uiState.homePage?.sections.orEmpty()
+                            if (chipSections.isEmpty()) {
+                                item(
+                                    key = "home_chip_empty",
+                                    contentType = "chip_empty",
+                                ) {
+                                    HomeChipEmptyState(
+                                        onRetry = { onAction(HomeAction.RetryChip) },
+                                    )
+                                }
+                            } else {
+                                homePageSections(
+                                    sections = chipSections,
                                     mediaMetadata = mediaMetadata,
                                     isPlaying = isPlaying,
                                     navController = navController,
@@ -466,94 +392,206 @@ private fun HomeContent(
                                 )
                             }
                         }
-                    }
+                    } else {
+                        if (remoteQuickPicks?.items?.isNotEmpty() == true) {
+                            item(
+                                key = "home_remote_quick_picks_header",
+                                contentType = "section_header",
+                            ) {
+                                HomeSectionHeader(
+                                    title = remoteQuickPicks.title,
+                                )
+                            }
+                            item(
+                                key = "home_remote_quick_picks",
+                                contentType = "media_shelf",
+                            ) {
+                                HomePageSectionContent(
+                                    section = remoteQuickPicks,
+                                    mediaMetadata = mediaMetadata,
+                                    isPlaying = isPlaying,
+                                    navController = navController,
+                                    playerConnection = playerConnection,
+                                    menuState = menuState,
+                                    haptic = haptic,
+                                    scope = scope,
+                                )
+                            }
+                        } else if (uiState.quickPicks.isNotEmpty()) {
+                            item(
+                                key = "home_quick_picks_header",
+                                contentType = "section_header",
+                            ) {
+                                HomeSectionHeader(
+                                    title = stringResource(R.string.quick_picks),
+                                )
+                            }
+                            item(
+                                key = "home_quick_picks",
+                                contentType = "quick_picks",
+                            ) {
+                                QuickPicksSection(
+                                    quickPicks = uiState.quickPicks,
+                                    mediaMetadata = mediaMetadata,
+                                    isPlaying = isPlaying,
+                                    displayMode = uiState.quickPicksDisplayMode,
+                                    navController = navController,
+                                    playerConnection = playerConnection,
+                                    menuState = menuState,
+                                    haptic = haptic,
+                                )
+                            }
+                        }
 
-                    if (uiState.forgottenFavorites.isNotEmpty()) {
-                        sectionSpacer("forgotten_favorites")
-                        item(
-                            key = "home_forgotten_favorites_header",
-                            contentType = "section_header",
-                        ) {
-                            HomeSectionHeader(
-                                title = stringResource(R.string.forgotten_favorites),
-                            )
+                        if (uiState.speedDialItems.isNotEmpty()) {
+                            sectionSpacer("speed_dial")
+                            item(
+                                key = "home_speed_dial_header",
+                                contentType = "section_header",
+                            ) {
+                                HomeSectionHeader(
+                                    title = stringResource(R.string.speed_dial),
+                                )
+                            }
+                            item(
+                                key = "home_speed_dial",
+                                contentType = "speed_dial",
+                            ) {
+                                SpeedDialSection(
+                                    speedDialItems = uiState.speedDialItems,
+                                    mediaMetadata = mediaMetadata,
+                                    isPlaying = isPlaying,
+                                    navController = navController,
+                                    playerConnection = playerConnection,
+                                    menuState = menuState,
+                                    haptic = haptic,
+                                    scope = scope,
+                                )
+                            }
                         }
-                        item(
-                            key = "home_forgotten_favorites",
-                            contentType = "song_shelf",
-                        ) {
-                            ForgottenFavoritesSection(
-                                forgottenFavorites = uiState.forgottenFavorites,
-                                mediaMetadata = mediaMetadata,
-                                isPlaying = isPlaying,
-                                horizontalLazyGridItemWidth = forgottenItemWidth,
-                                lazyGridState = forgottenFavoritesGridState,
-                                snapLayoutInfoProvider = forgottenSnapLayoutInfoProvider,
-                                navController = navController,
-                                playerConnection = playerConnection,
-                                menuState = menuState,
-                                haptic = haptic,
-                            )
-                        }
-                    }
 
-                    uiState.similarRecommendations.forEach { recommendation ->
-                        sectionSpacer("similar_${recommendation.title.id}")
-                        item(
-                            key = "home_similar_header_${recommendation.title.id}",
-                            contentType = "section_header",
-                        ) {
-                            SimilarRecommendationsTitle(
-                                recommendation = recommendation,
-                                navController = navController,
-                            )
+                        if (uiState.keepListening.isNotEmpty()) {
+                            sectionSpacer("keep_listening")
+                            item(
+                                key = "home_keep_listening_header",
+                                contentType = "section_header",
+                            ) {
+                                HomeSectionHeader(
+                                    title = stringResource(R.string.keep_listening),
+                                )
+                            }
+                            item(
+                                key = "home_keep_listening",
+                                contentType = "media_shelf",
+                            ) {
+                                KeepListeningSection(
+                                    keepListening = uiState.keepListening,
+                                    mediaMetadata = mediaMetadata,
+                                    isPlaying = isPlaying,
+                                    navController = navController,
+                                    playerConnection = playerConnection,
+                                    menuState = menuState,
+                                    haptic = haptic,
+                                    scope = scope,
+                                )
+                            }
                         }
-                        item(
-                            key = "home_similar_${recommendation.title.id}",
-                            contentType = "media_shelf",
-                        ) {
-                            SimilarRecommendationsSection(
-                                recommendation = recommendation,
-                                mediaMetadata = mediaMetadata,
-                                isPlaying = isPlaying,
-                                navController = navController,
-                                playerConnection = playerConnection,
-                                menuState = menuState,
-                                haptic = haptic,
-                                scope = scope,
-                            )
-                        }
-                    }
 
-                    uiState.homePage?.sections.orEmpty().forEachIndexed { index, section ->
-                        val sectionKey = "${section.endpoint?.browseId ?: section.title}_$index"
-                        sectionSpacer("remote_$sectionKey")
-                        item(
-                            key = "home_remote_header_$sectionKey",
-                            contentType = "section_header",
-                        ) {
-                            HomePageSectionTitle(
-                                section = section,
-                                navController = navController,
-                            )
+                        if (uiState.accountPlaylists.isNotEmpty()) {
+                            sectionSpacer("account_playlists")
+                            item(
+                                key = "home_account_playlists",
+                                contentType = "media_shelf",
+                            ) {
+                                Column {
+                                    AccountPlaylistsTitle(
+                                        accountName = uiState.accountName,
+                                        accountImageUrl = uiState.accountImageUrl,
+                                        onClick = { navController.navigate("account") },
+                                    )
+                                    AccountPlaylistsSection(
+                                        accountPlaylists = uiState.accountPlaylists,
+                                        mediaMetadata = mediaMetadata,
+                                        isPlaying = isPlaying,
+                                        navController = navController,
+                                        playerConnection = playerConnection,
+                                        menuState = menuState,
+                                        haptic = haptic,
+                                        scope = scope,
+                                    )
+                                }
+                            }
                         }
-                        item(
-                            key = "home_remote_$sectionKey",
-                            contentType = "media_shelf",
-                        ) {
-                            HomePageSectionContent(
-                                section = section,
-                                mediaMetadata = mediaMetadata,
-                                isPlaying = isPlaying,
-                                navController = navController,
-                                playerConnection = playerConnection,
-                                menuState = menuState,
-                                haptic = haptic,
-                                scope = scope,
-                            )
-                        }
-                    }
 
+                        if (uiState.forgottenFavorites.isNotEmpty()) {
+                            sectionSpacer("forgotten_favorites")
+                            item(
+                                key = "home_forgotten_favorites_header",
+                                contentType = "section_header",
+                            ) {
+                                HomeSectionHeader(
+                                    title = stringResource(R.string.forgotten_favorites),
+                                )
+                            }
+                            item(
+                                key = "home_forgotten_favorites",
+                                contentType = "song_shelf",
+                            ) {
+                                ForgottenFavoritesSection(
+                                    forgottenFavorites = uiState.forgottenFavorites,
+                                    mediaMetadata = mediaMetadata,
+                                    isPlaying = isPlaying,
+                                    horizontalLazyGridItemWidth = forgottenItemWidth,
+                                    lazyGridState = forgottenFavoritesGridState,
+                                    snapLayoutInfoProvider = forgottenSnapLayoutInfoProvider,
+                                    navController = navController,
+                                    playerConnection = playerConnection,
+                                    menuState = menuState,
+                                    haptic = haptic,
+                                )
+                            }
+                        }
+
+                        uiState.similarRecommendations.forEach { recommendation ->
+                            sectionSpacer("similar_${recommendation.title.id}")
+                            item(
+                                key = "home_similar_header_${recommendation.title.id}",
+                                contentType = "section_header",
+                            ) {
+                                SimilarRecommendationsTitle(
+                                    recommendation = recommendation,
+                                    navController = navController,
+                                )
+                            }
+                            item(
+                                key = "home_similar_${recommendation.title.id}",
+                                contentType = "media_shelf",
+                            ) {
+                                SimilarRecommendationsSection(
+                                    recommendation = recommendation,
+                                    mediaMetadata = mediaMetadata,
+                                    isPlaying = isPlaying,
+                                    navController = navController,
+                                    playerConnection = playerConnection,
+                                    menuState = menuState,
+                                    haptic = haptic,
+                                    scope = scope,
+                                )
+                            }
+                        }
+
+                        homePageSections(
+                            sections = uiState.homePage?.sections.orEmpty(),
+                            mediaMetadata = mediaMetadata,
+                            isPlaying = isPlaying,
+                            navController = navController,
+                            playerConnection = playerConnection,
+                            menuState = menuState,
+                            haptic = haptic,
+                            scope = scope,
+                        )
+
+                    }
                     if (uiState.isLoadingMore) {
                         item(
                             key = "home_loading_more",
@@ -573,6 +611,86 @@ private fun HomeContent(
                     }
                 }
             }
+        }
+    }
+}
+
+@OptIn(
+    ExperimentalFoundationApi::class,
+    ExperimentalMaterial3ExpressiveApi::class,
+)
+private fun LazyListScope.homePageSections(
+    sections: List<HomePage.Section>,
+    mediaMetadata: MediaMetadata?,
+    isPlaying: Boolean,
+    navController: NavController,
+    playerConnection: PlayerConnection,
+    menuState: MenuState,
+    haptic: HapticFeedback,
+    scope: CoroutineScope,
+) {
+    sections.forEachIndexed { index, section ->
+        val sectionKey = "${section.endpoint?.browseId ?: section.title}_$index"
+        sectionSpacer("remote_$sectionKey")
+        item(
+            key = "home_remote_header_$sectionKey",
+            contentType = "section_header",
+        ) {
+            HomePageSectionTitle(
+                section = section,
+                navController = navController,
+            )
+        }
+        item(
+            key = "home_remote_$sectionKey",
+            contentType = "media_shelf",
+        ) {
+            HomePageSectionContent(
+                section = section,
+                mediaMetadata = mediaMetadata,
+                isPlaying = isPlaying,
+                navController = navController,
+                playerConnection = playerConnection,
+                menuState = menuState,
+                haptic = haptic,
+                scope = scope,
+            )
+        }
+    }
+}
+
+/**
+ * Shown when a home category is selected but YouTube Music returned no shelves for it.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun HomeChipEmptyState(
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = 32.dp, vertical = 48.dp),
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.music_note),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(48.dp),
+        )
+        Spacer(Modifier.height(16.dp))
+        Text(
+            text = stringResource(R.string.no_results_found),
+            style = MaterialTheme.typography.titleLargeEmphasized,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Spacer(Modifier.height(20.dp))
+        FilledTonalButton(onClick = onRetry) {
+            Text(stringResource(R.string.retry))
         }
     }
 }

--- a/app/src/main/kotlin/dev/citali/lunartune/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/viewmodels/HomeViewModel.kt
@@ -130,6 +130,12 @@ private data class HomeContent(
                 remote.homePage?.sections?.any { it.items.isNotEmpty() } == true
 }
 
+private data class HomeLoadingFlags(
+    val isRefreshing: Boolean,
+    val isLoadingMore: Boolean,
+    val isChipLoading: Boolean,
+)
+
 private data class HomeStateInputs(
     val content: HomeContent,
     val preferences: HomePresentationPreferences,
@@ -297,7 +303,7 @@ class HomeViewModel
                     loadError = loadError,
                 )
             }.combine(
-                combine(
+                combine<Boolean, Boolean, Boolean, HomeLoadingFlags>(
                     isRefreshing,
                     isLoadingMore,
                     isChipLoading,

--- a/app/src/main/kotlin/dev/citali/lunartune/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/viewmodels/HomeViewModel.kt
@@ -140,6 +140,7 @@ private data class HomeStateInputs(
     fun toScreenState(
         isRefreshing: Boolean,
         isLoadingMore: Boolean,
+        isChipLoading: Boolean,
     ): HomeScreenState {
         if (!content.hasContent) {
             if (loadError != null && isInitialLoadComplete) {
@@ -170,6 +171,7 @@ private data class HomeStateInputs(
                 showTonalBackdrop = preferences.showTonalBackdrop,
                 isRefreshing = isRefreshing,
                 isLoadingMore = isLoadingMore,
+                isChipLoading = isChipLoading,
             ),
         )
     }
@@ -193,6 +195,7 @@ class HomeViewModel
         private val isInitialLoadComplete = MutableStateFlow(false)
         private val loadError = MutableStateFlow<Int?>(null)
         private val isLoadingMore = MutableStateFlow(false)
+        private val isChipLoading = MutableStateFlow(false)
 
         private val quickPicksMode =
             context.dataStore.data
@@ -294,13 +297,22 @@ class HomeViewModel
                     loadError = loadError,
                 )
             }.combine(
-                combine(isRefreshing, isLoadingMore) { isRefreshing, isLoadingMore ->
-                    isRefreshing to isLoadingMore
+                combine(
+                    isRefreshing,
+                    isLoadingMore,
+                    isChipLoading,
+                ) { isRefreshing, isLoadingMore, isChipLoading ->
+                    HomeLoadingFlags(
+                        isRefreshing = isRefreshing,
+                        isLoadingMore = isLoadingMore,
+                        isChipLoading = isChipLoading,
+                    )
                 },
-            ) { inputs, loadingState ->
+            ) { inputs, loadingFlags ->
                 inputs.toScreenState(
-                    isRefreshing = loadingState.first,
-                    isLoadingMore = loadingState.second,
+                    isRefreshing = loadingFlags.isRefreshing,
+                    isLoadingMore = loadingFlags.isLoadingMore,
+                    isChipLoading = loadingFlags.isChipLoading,
                 )
             }.stateIn(
                 scope = viewModelScope,
@@ -786,50 +798,108 @@ class HomeViewModel
             }
         }
 
+        /**
+         * Drops the active chip and puts the regular home feed back.
+         *
+         * Only restores the previous page when we actually stashed one, so a failed or
+         * unsupported chip selection can never blank out the home screen.
+         */
+        private fun clearSelectedChip() {
+            isChipLoading.value = false
+            previousHomePage.value?.let {
+                homePage.value = it
+                remoteQuickPicks.value = previousRemoteQuickPicks.value
+            }
+            previousHomePage.value = null
+            previousRemoteQuickPicks.value = null
+            selectedChip.value = null
+        }
+
         private fun toggleChip(chip: HomePage.Chip?) {
             chipLoadJob?.cancel()
-            if (chip == null || chip == selectedChip.value && previousHomePage.value != null) {
-                homePage.value = previousHomePage.value
-                remoteQuickPicks.value = previousRemoteQuickPicks.value
-                previousHomePage.value = null
-                previousRemoteQuickPicks.value = null
-                selectedChip.value = null
+            chipLoadJob = null
+
+            val alreadySelected = chip != null && chip == selectedChip.value
+            if (chip == null || alreadySelected) {
+                clearSelectedChip()
                 return
             }
 
+            // Without params there is nothing to filter the home feed with, so don't
+            // pretend a category is selected — that only looks like a broken chip.
+            val params = chip.endpoint?.params
+            if (params.isNullOrBlank()) {
+                Timber.w("Home chip \"${chip.title}\" has no browse params")
+                clearSelectedChip()
+                return
+            }
+
+            // Stash the unfiltered feed once, so switching between chips keeps the
+            // same "all categories" page to fall back to.
             if (selectedChip.value == null) {
                 previousHomePage.value = homePage.value
                 previousRemoteQuickPicks.value = remoteQuickPicks.value
             }
 
+            // Select right away: the chip highlights instantly and the feed switches to
+            // the category while its shelves are still loading.
+            selectedChip.value = chip
+            loadChip(chip, params)
+        }
+
+        /** Re-runs the fetch for the active category after it came back empty or failed. */
+        private fun retryChip() {
+            val chip = selectedChip.value ?: return
+            val params = chip.endpoint?.params
+            if (params.isNullOrBlank()) {
+                clearSelectedChip()
+                return
+            }
+            loadChip(chip, params)
+        }
+
+        private fun loadChip(
+            chip: HomePage.Chip,
+            params: String,
+        ) {
+            isChipLoading.value = true
             chipLoadJob =
                 viewModelScope.launch(Dispatchers.IO) {
-                    val hideExplicit = context.dataStore.get(HideExplicitKey, false)
-                    val hideVideo = context.dataStore.get(HideVideoKey, false)
-                    val blockedArtistIds = database.getBlockedArtistIds().toSet()
-                    val aiContentFilterPolicy = loadAiContentFilterPolicy()
-                    val nextSections = YouTube.home(params = chip?.endpoint?.params).getOrNull() ?: return@launch
-                    val filteredPage =
-                        nextSections.copy(
-                            chips = homePage.value?.chips,
-                            sections =
-                                nextSections.sections.map { section ->
-                                    section.copy(
-                                        items =
-                                            filterAiContent(
-                                                section.items
-                                                    .filterExplicit(hideExplicit)
-                                                    .filterVideo(hideVideo)
-                                                    .filterBlockedArtists(blockedArtistIds),
-                                                aiContentFilterPolicy,
-                                            ),
-                                    )
-                                },
-                        )
-                    val (pageWithoutQuickPicks, quickPicksSection) = filteredPage.extractQuickPicks()
-                    remoteQuickPicks.value = quickPicksSection
-                    homePage.value = pageWithoutQuickPicks
-                    selectedChip.value = chip
+                    YouTube
+                        .home(params = params)
+                        .onSuccess { nextSections ->
+                            val hideExplicit = context.dataStore.get(HideExplicitKey, false)
+                            val hideVideo = context.dataStore.get(HideVideoKey, false)
+                            val blockedArtistIds = database.getBlockedArtistIds().toSet()
+                            val aiContentFilterPolicy = loadAiContentFilterPolicy()
+                            val filteredPage =
+                                nextSections.copy(
+                                    chips = previousHomePage.value?.chips ?: homePage.value?.chips,
+                                    sections =
+                                        nextSections.sections.map { section ->
+                                            section.copy(
+                                                items =
+                                                    filterAiContent(
+                                                        section.items
+                                                            .filterExplicit(hideExplicit)
+                                                            .filterVideo(hideVideo)
+                                                            .filterBlockedArtists(blockedArtistIds),
+                                                        aiContentFilterPolicy,
+                                                    ),
+                                            )
+                                        },
+                                )
+                            val (pageWithoutQuickPicks, quickPicksSection) = filteredPage.extractQuickPicks()
+                            remoteQuickPicks.value = quickPicksSection
+                            homePage.value = pageWithoutQuickPicks
+                            selectedChip.value = chip
+                            isChipLoading.value = false
+                        }.onFailure { error ->
+                            if (error is CancellationException) throw error
+                            Timber.w(error, "Failed to load home chip \"${chip.title}\"")
+                            // Don't leave the feed stuck on a category that never arrived.
+                            clearSelectedChip()
+                        }
                 }
         }
 
@@ -837,12 +907,17 @@ class HomeViewModel
             when (action) {
                 HomeAction.Refresh -> refresh()
                 is HomeAction.SelectChip -> toggleChip(action.chip)
+                HomeAction.RetryChip -> retryChip()
                 is HomeAction.LoadMore -> loadMoreYouTubeItems(action.continuation)
             }
         }
 
         private fun refresh() {
             if (isRefreshing.value) return
+            // A reload fetches the unfiltered home, so leave the active category first.
+            if (selectedChip.value != null) {
+                clearSelectedChip()
+            }
             viewModelScope.launch(Dispatchers.IO) {
                 isRefreshing.value = true
                 try {


### PR DESCRIPTION
## What was wrong

Tapping a home chip (Workout, Feel good, Romance, …) looked like it did nothing:

- the chip only highlighted *after* the network call came back, so a tap gave no feedback, and a failed call left the chip looking completely dead (`getOrNull() ?: return@launch` swallowed the error);
- when it did succeed, the category's shelves were appended **after** every personalised section — Quick picks, Speed dial, Keep listening, Account playlists, Forgotten favorites, Similar recommendations — so the top of the feed never changed and the new content sat far below the fold.

## Changes

- the chip is selected immediately, so it highlights on tap;
- a category now **replaces** the personalised feed: only its own shelves are shown, right under the chip row, with a loading indicator while they load;
- the list scrolls back to the top when the category changes, so you start at the new content;
- if a category comes back with no shelves there is a "No results found" state with a **Retry** (new `HomeAction.RetryChip`);
- failures and chips without browse params are logged and the selection is dropped instead of silently leaving an unchanged feed;
- pull-to-refresh leaves the active category, since it reloads the unfiltered home.

The fetch/filter path itself is unchanged — same `YouTube.home(params = ...)` call, same explicit/video/blocked-artist/AI-content filtering, same continuation paging, and the previously loaded home is still restored when you deselect.

## Screenshot context

The reported screen (chips row above Quick picks / Keep listening) is exactly the "content buried below the personalised sections" case.