### PR TITLE
feat: quick picks from YouTube Music instead of listening history

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/home/HomeRepository.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/home/HomeRepository.kt
@@ -11,6 +11,7 @@ import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import dev.citali.lunartune.constants.DisableBlurKey
 import dev.citali.lunartune.constants.QuickPicks
@@ -18,14 +19,20 @@ import dev.citali.lunartune.constants.QuickPicksKey
 import dev.citali.lunartune.constants.QuickPicksDisplayMode
 import dev.citali.lunartune.constants.QuickPicksDisplayModeKey
 import dev.citali.lunartune.constants.ShowHomeCategoryChipsKey
+import dev.citali.lunartune.db.MusicDatabase
+import dev.citali.lunartune.db.entities.Song
 import dev.citali.lunartune.extensions.toEnum
 import dev.citali.lunartune.utils.dataStore
+import moe.rukamori.archivetune.innertube.YouTube
+import moe.rukamori.archivetune.innertube.models.SongItem
+import moe.rukamori.archivetune.innertube.models.WatchEndpoint
 import javax.inject.Inject
 
 class HomeRepository
     @Inject
     constructor(
         @ApplicationContext context: Context,
+        private val database: MusicDatabase,
     ) {
         val showCategoryChips: Flow<Boolean> =
             context.dataStore.data
@@ -47,4 +54,45 @@ class HomeRepository
             context.dataStore.data
                 .map { preferences -> preferences[DisableBlurKey] != true }
                 .distinctUntilChanged()
+
+        /**
+         * Songs from the listening history that YouTube Music can build recommendations
+         * from. Most played songs of the last months come first, recent songs are used
+         * when there is nothing played often enough yet.
+         */
+        suspend fun loadQuickPickSeeds(limit: Int): List<Song> {
+            val fromTimestamp = System.currentTimeMillis() - QUICK_PICKS_HISTORY_WINDOW_MS
+            val mostPlayed =
+                database
+                    .mostPlayedSongs(fromTimestamp, limit = limit * 3)
+                    .first()
+                    .filter { song -> song.isYouTubeRecommendationSeed() }
+            val candidates =
+                mostPlayed.ifEmpty {
+                    database
+                        .recentSongs(limit = limit * 6)
+                        .first()
+                        .filter { song -> song.isYouTubeRecommendationSeed() }
+                }
+            return candidates
+                .distinctBy { song -> song.artists.firstOrNull()?.id ?: song.id }
+                .take(limit)
+        }
+
+        /** "Up next" style songs YouTube Music recommends for [seedSongId]. */
+        suspend fun loadRelatedSongs(seedSongId: String): Result<List<SongItem>> {
+            val nextPage =
+                YouTube.next(WatchEndpoint(videoId = seedSongId)).getOrElse { throwable ->
+                    return Result.failure(throwable)
+                }
+            val relatedEndpoint = nextPage.relatedEndpoint ?: return Result.success(emptyList())
+            return YouTube.related(relatedEndpoint).map { page -> page.songs }
+        }
+
+        private fun Song.isYouTubeRecommendationSeed(): Boolean = !song.isLocal && id.length == YOUTUBE_VIDEO_ID_LENGTH
+
+        private companion object {
+            const val QUICK_PICKS_HISTORY_WINDOW_MS = 90L * 24 * 60 * 60 * 1000
+            const val YOUTUBE_VIDEO_ID_LENGTH = 11
+        }
     }

--- a/app/src/main/kotlin/dev/citali/lunartune/home/HomeUseCases.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/home/HomeUseCases.kt
@@ -8,10 +8,16 @@
 package dev.citali.lunartune.home
 
 import androidx.compose.runtime.Immutable
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.supervisorScope
 import dev.citali.lunartune.constants.QuickPicks
 import dev.citali.lunartune.constants.QuickPicksDisplayMode
+import dev.citali.lunartune.db.entities.Song
+import moe.rukamori.archivetune.innertube.models.SongItem
 import javax.inject.Inject
 
 class ObserveHomePresentationPreferencesUseCase
@@ -42,3 +48,92 @@ data class HomePresentationPreferences(
     val quickPicksMode: QuickPicks,
     val showTonalBackdrop: Boolean,
 )
+
+/**
+ * Builds the home Quick picks from YouTube Music recommendations instead of the local
+ * listening history: a few recently played songs are used as seeds, their "related songs"
+ * pages are fetched in parallel and the results are ranked so songs recommended by several
+ * seeds, higher ranked seeds and artists you already listen to come first.
+ */
+class LoadPersonalizedQuickPicksUseCase
+    @Inject
+    constructor(
+        private val repository: HomeRepository,
+    ) {
+        suspend operator fun invoke(
+            excludedSongIds: Set<String>,
+            limit: Int = DEFAULT_RESULT_LIMIT,
+        ): Result<List<SongItem>> =
+            runCatching {
+                val seeds = repository.loadQuickPickSeeds(SEED_LIMIT)
+                if (seeds.isEmpty()) return@runCatching emptyList()
+
+                val relatedResults =
+                    supervisorScope {
+                        seeds.map { seed ->
+                            async { repository.loadRelatedSongs(seed.id) }
+                        }.awaitAll()
+                    }
+                relatedResults.firstNotNullOfOrNull { result ->
+                    result.exceptionOrNull() as? CancellationException
+                }?.let { cancellation -> throw cancellation }
+                val successfulResults = relatedResults.mapNotNull { result -> result.getOrNull() }
+                if (successfulResults.isEmpty()) {
+                    relatedResults.firstNotNullOfOrNull { result -> result.exceptionOrNull() }?.let { throwable -> throw throwable }
+                    return@runCatching emptyList()
+                }
+
+                val seedSongIds = seeds.mapTo(mutableSetOf(), Song::id)
+                val seedArtistIds = seeds.flatMapTo(mutableSetOf()) { song -> song.artists.mapNotNull { it.id } }
+                val candidates = LinkedHashMap<String, QuickPickCandidate>()
+                successfulResults.forEachIndexed { seedIndex, songs ->
+                    songs.distinctBy(SongItem::id).take(RELATED_SONG_LIMIT).forEachIndexed { songIndex, song ->
+                        if (song.id !in seedSongIds) {
+                            val artistAffinity =
+                                if (song.artists.any { artist -> artist.id != null && artist.id in seedArtistIds }) {
+                                    ARTIST_AFFINITY_SCORE
+                                } else {
+                                    0
+                                }
+                            val seedWeight = (seeds.size - seedIndex) * SEED_WEIGHT
+                            val positionWeight = RELATED_SONG_LIMIT - songIndex
+                            val candidate =
+                                candidates.getOrPut(song.id) {
+                                    QuickPickCandidate(
+                                        song = song,
+                                        firstSeenIndex = candidates.size,
+                                    )
+                                }
+                            candidate.sourceCount += 1
+                            candidate.score += seedWeight + positionWeight + artistAffinity
+                        }
+                    }
+                }
+
+                val rankedSongs =
+                    candidates.values
+                        .sortedWith(
+                            compareByDescending<QuickPickCandidate> { candidate -> candidate.sourceCount }
+                                .thenByDescending { candidate -> candidate.score }
+                                .thenBy { candidate -> candidate.firstSeenIndex },
+                        ).map { candidate -> candidate.song }
+                val unseenSongs = rankedSongs.filterNot { song -> song.id in excludedSongIds }
+                val previousSongs = rankedSongs.filter { song -> song.id in excludedSongIds }
+                (unseenSongs + previousSongs).take(limit)
+            }
+
+        private data class QuickPickCandidate(
+            val song: SongItem,
+            val firstSeenIndex: Int,
+            var sourceCount: Int = 0,
+            var score: Int = 0,
+        )
+
+        private companion object {
+            const val SEED_LIMIT = 6
+            const val RELATED_SONG_LIMIT = 30
+            const val DEFAULT_RESULT_LIMIT = 20
+            const val SEED_WEIGHT = 100
+            const val ARTIST_AFFINITY_SCORE = 80
+        }
+    }

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/HomeScreen.kt
@@ -399,25 +399,28 @@ private fun HomeContent(
                                 contentType = "section_header",
                             ) {
                                 HomeSectionHeader(
-                                    title = remoteQuickPicks.title,
+                                    title = stringResource(R.string.quick_picks),
                                 )
                             }
                             item(
                                 key = "home_remote_quick_picks",
-                                contentType = "media_shelf",
+                                contentType = "quick_picks",
                             ) {
-                                HomePageSectionContent(
+                                RemoteQuickPicksSection(
                                     section = remoteQuickPicks,
                                     mediaMetadata = mediaMetadata,
                                     isPlaying = isPlaying,
+                                    displayMode = uiState.quickPicksDisplayMode,
                                     navController = navController,
                                     playerConnection = playerConnection,
                                     menuState = menuState,
                                     haptic = haptic,
-                                    scope = scope,
                                 )
                             }
-                        } else if (uiState.quickPicks.isNotEmpty()) {
+                        } else if (
+                            uiState.quickPicksMode == QuickPicks.LAST_LISTEN &&
+                                uiState.quickPicks.isNotEmpty()
+                        ) {
                             item(
                                 key = "home_quick_picks_header",
                                 contentType = "section_header",

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/HomeScreenComponents.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/HomeScreenComponents.kt
@@ -124,6 +124,7 @@ import dev.citali.lunartune.ui.component.SongGridItem
 import dev.citali.lunartune.ui.component.SongListItem
 import dev.citali.lunartune.ui.component.SpeedDialGridItem
 import dev.citali.lunartune.ui.component.YouTubeGridItem
+import dev.citali.lunartune.ui.component.YouTubeListItem
 import dev.citali.lunartune.ui.menu.AlbumMenu
 import dev.citali.lunartune.ui.menu.ArtistMenu
 import dev.citali.lunartune.ui.menu.PlaylistMenu
@@ -1523,4 +1524,268 @@ fun HomePageSectionTitle(
             },
         modifier = modifier,
     )
+}
+
+/**
+ * Quick picks that came from YouTube Music (home shelf or recommendation seeds).
+ *
+ * Uses the same card/list layouts as the local quick picks so the "Quick picks display
+ * mode" preference applies to online picks too.
+ */
+@OptIn(
+    ExperimentalFoundationApi::class,
+    ExperimentalMaterial3Api::class,
+    ExperimentalMaterial3ExpressiveApi::class,
+)
+@Composable
+fun RemoteQuickPicksSection(
+    section: HomePage.Section,
+    mediaMetadata: MediaMetadata?,
+    isPlaying: Boolean,
+    displayMode: QuickPicksDisplayMode,
+    navController: NavController,
+    playerConnection: PlayerConnection,
+    menuState: MenuState,
+    haptic: HapticFeedback,
+    modifier: Modifier = Modifier,
+) {
+    val songs =
+        remember(section.items) {
+            section.items.filterIsInstance<SongItem>().distinctBy(SongItem::id)
+        }
+
+    when (displayMode) {
+        QuickPicksDisplayMode.CARD -> {
+            BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
+                val heroHeight =
+                    when {
+                        maxWidth >= 840.dp -> 380.dp
+                        maxWidth >= 600.dp -> 356.dp
+                        else -> 332.dp
+                    }
+                val heroMaxWidth =
+                    (maxWidth - 48.dp)
+                        .coerceAtLeast(232.dp)
+                        .coerceAtMost(440.dp)
+                val density = LocalDensity.current
+                val requestWidthPx = with(density) { heroMaxWidth.roundToPx().coerceAtLeast(1) }
+                val requestHeightPx = with(density) { heroHeight.roundToPx().coerceAtLeast(1) }
+
+                HorizontalCenteredHeroCarousel(
+                    state = rememberCarouselState { songs.size },
+                    maxItemWidth = heroMaxWidth,
+                    itemSpacing = 10.dp,
+                    contentPadding = PaddingValues(horizontal = 16.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(heroHeight),
+                ) { index ->
+                    val song = songs[index]
+                    val isActive = song.id == mediaMetadata?.id
+                    val context = LocalContext.current
+                    val imageRequest =
+                        remember(song.thumbnail, requestWidthPx, requestHeightPx) {
+                            ImageRequest
+                                .Builder(context)
+                                .data(song.thumbnail)
+                                .size(Size(requestWidthPx, requestHeightPx))
+                                .crossfade(true)
+                                .build()
+                        }
+
+                    Box(
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                                .maskClip(MaterialTheme.shapes.extraLarge)
+                                .border(
+                                    BorderStroke(
+                                        1.dp,
+                                        MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.72f),
+                                    ),
+                                    MaterialTheme.shapes.extraLarge,
+                                ).focusable()
+                                .combinedClickable(
+                                    onClick = {
+                                        if (isActive) {
+                                            playerConnection.player.togglePlayPause()
+                                        } else {
+                                            playerConnection.playQueue(
+                                                YouTubeQueue(
+                                                    endpoint = song.endpoint ?: WatchEndpoint(videoId = song.id),
+                                                    preloadItem = song.toMediaMetadata(),
+                                                ),
+                                            )
+                                        }
+                                    },
+                                    onLongClick = {
+                                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                        menuState.show {
+                                            YouTubeSongMenu(
+                                                song = song,
+                                                navController = navController,
+                                                onDismiss = menuState::dismiss,
+                                            )
+                                        }
+                                    },
+                                ),
+                    ) {
+                        AsyncImage(
+                            model = imageRequest,
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier.fillMaxSize(),
+                        )
+
+                        Box(
+                            modifier =
+                                Modifier
+                                    .fillMaxSize()
+                                    .background(
+                                        Brush.verticalGradient(
+                                            0f to Color.Transparent,
+                                            0.48f to Color.Black.copy(alpha = 0.08f),
+                                            1f to Color.Black.copy(alpha = 0.84f),
+                                        ),
+                                    ),
+                        )
+
+                        if (isActive && isPlaying) {
+                            Surface(
+                                color = MaterialTheme.colorScheme.primary,
+                                contentColor = MaterialTheme.colorScheme.onPrimary,
+                                shape = CircleShape,
+                                tonalElevation = 2.dp,
+                                modifier =
+                                    Modifier
+                                        .align(Alignment.TopEnd)
+                                        .padding(14.dp)
+                                        .size(36.dp),
+                            ) {
+                                Box(contentAlignment = Alignment.Center) {
+                                    Icon(
+                                        painter = painterResource(R.drawable.volume_up),
+                                        contentDescription = null,
+                                        modifier = Modifier.size(19.dp),
+                                    )
+                                }
+                            }
+                        }
+
+                        Column(
+                            verticalArrangement = Arrangement.spacedBy(2.dp),
+                            modifier =
+                                Modifier
+                                    .align(Alignment.BottomStart)
+                                    .padding(20.dp),
+                        ) {
+                            Text(
+                                text = song.title,
+                                style = MaterialTheme.typography.titleLargeEmphasized,
+                                color = Color.White,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            Text(
+                                text = song.artists.joinToString { artist -> artist.name },
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = Color.White.copy(alpha = 0.78f),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        QuickPicksDisplayMode.LIST -> {
+            BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
+                val widthFactor = if (maxWidth * 0.475f >= 320.dp) 0.475f else 0.9f
+                val itemWidth = maxWidth * widthFactor
+                val lazyGridState = rememberLazyGridState()
+                val snapLayoutInfoProvider =
+                    remember(lazyGridState, widthFactor) {
+                        buildSnapLayoutInfoProvider(
+                            lazyGridState = lazyGridState,
+                            positionInLayout = { layoutSize, itemSize ->
+                                layoutSize * widthFactor / 2f - itemSize / 2f
+                            },
+                        )
+                    }
+                LazyHorizontalGrid(
+                    state = lazyGridState,
+                    rows = GridCells.Fixed(4),
+                    flingBehavior = rememberSnapFlingBehavior(snapLayoutInfoProvider),
+                    contentPadding =
+                        WindowInsets.systemBars
+                            .only(WindowInsetsSides.Horizontal)
+                            .asPaddingValues(),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(ListItemHeight * 4),
+                ) {
+                    items(
+                        items = songs,
+                        key = SongItem::id,
+                        contentType = { "remote_quick_pick_song" },
+                    ) { song ->
+                        YouTubeListItem(
+                            item = song,
+                            isActive = song.id == mediaMetadata?.id,
+                            isPlaying = isPlaying,
+                            isSwipeable = false,
+                            trailingContent = {
+                                IconButton(
+                                    onClick = {
+                                        menuState.show {
+                                            YouTubeSongMenu(
+                                                song = song,
+                                                navController = navController,
+                                                onDismiss = menuState::dismiss,
+                                            )
+                                        }
+                                    },
+                                ) {
+                                    Icon(
+                                        painter = painterResource(R.drawable.more_vert),
+                                        contentDescription = null,
+                                    )
+                                }
+                            },
+                            modifier =
+                                Modifier
+                                    .width(itemWidth)
+                                    .combinedClickable(
+                                        onClick = {
+                                            if (song.id == mediaMetadata?.id) {
+                                                playerConnection.player.togglePlayPause()
+                                            } else {
+                                                playerConnection.playQueue(
+                                                    YouTubeQueue(
+                                                        endpoint = song.endpoint ?: WatchEndpoint(videoId = song.id),
+                                                        preloadItem = song.toMediaMetadata(),
+                                                    ),
+                                                )
+                                            }
+                                        },
+                                        onLongClick = {
+                                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                            menuState.show {
+                                                YouTubeSongMenu(
+                                                    song = song,
+                                                    navController = navController,
+                                                    onDismiss = menuState::dismiss,
+                                                )
+                                            }
+                                        },
+                                    ),
+                        )
+                    }
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/kotlin/dev/citali/lunartune/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/viewmodels/HomeViewModel.kt
@@ -18,6 +18,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
@@ -45,6 +46,7 @@ import dev.citali.lunartune.home.HomeAction
 import dev.citali.lunartune.home.HomePresentationPreferences
 import dev.citali.lunartune.home.HomeScreenState
 import dev.citali.lunartune.home.HomeUiState
+import dev.citali.lunartune.home.LoadPersonalizedQuickPicksUseCase
 import dev.citali.lunartune.home.ObserveHomePresentationPreferencesUseCase
 import moe.rukamori.archivetune.innertube.YouTube
 import moe.rukamori.archivetune.innertube.models.AccountChannel
@@ -195,6 +197,7 @@ class HomeViewModel
         observeAiContentFilter: ObserveAiContentFilterUseCase,
         private val loadAiContentFilterPolicy: LoadAiContentFilterPolicyUseCase,
         private val filterAiContent: FilterAiContentUseCase,
+        private val loadPersonalizedQuickPicksUseCase: LoadPersonalizedQuickPicksUseCase,
     ) : ViewModel() {
         private val isRefreshing = MutableStateFlow(false)
         private val isLoading = MutableStateFlow(false)
@@ -344,6 +347,47 @@ class HomeViewModel
             return copy(sections = sections.toMutableList().apply { removeAt(quickPicksIndex) }) to sections[quickPicksIndex]
         }
 
+        /**
+         * Quick picks come from YouTube Music: seeds from the listening history are expanded
+         * into related songs online. Returns true when online picks were produced, so the
+         * caller knows it can skip the "Quick picks" shelf of the home response.
+         */
+        private suspend fun loadPersonalizedQuickPicks(): Boolean {
+            if (quickPicksMode.first() != QuickPicks.QUICK_PICKS) return false
+            val excludedSongIds = remoteQuickPicks.value?.items.orEmpty().mapTo(mutableSetOf(), YTItem::id)
+            val songs =
+                loadPersonalizedQuickPicksUseCase(excludedSongIds).getOrElse { throwable ->
+                    if (throwable is CancellationException) throw throwable
+                    Timber.w(throwable, "Failed to load personalized quick picks")
+                    return false
+                }
+            if (songs.isEmpty()) return false
+
+            val hideExplicit = context.dataStore.get(HideExplicitKey, false)
+            val hideVideo = context.dataStore.get(HideVideoKey, false)
+            val blockedArtistIds = database.getBlockedArtistIds().toSet()
+            val aiContentFilterPolicy = loadAiContentFilterPolicy()
+            val filteredSongs =
+                filterAiContent(
+                    songs
+                        .filterExplicit(hideExplicit)
+                        .filterVideo(hideVideo)
+                        .filterBlockedArtists(blockedArtistIds),
+                    aiContentFilterPolicy,
+                )
+            if (filteredSongs.isEmpty()) return false
+
+            remoteQuickPicks.value =
+                HomePage.Section(
+                    title = "",
+                    label = null,
+                    thumbnail = null,
+                    endpoint = null,
+                    items = filteredSongs,
+                )
+            return true
+        }
+
         private fun List<Song>.toQuickPickSample(): List<Song> =
             filter { song -> song.artists.none { it.blockedAt != null } }
                 .distinctBy { it.id }
@@ -410,11 +454,10 @@ class HomeViewModel
                 quickPicksMode
                     .flatMapLatest { mode ->
                         when (mode) {
+                            // Quick picks are online recommendations now, the local
+                            // listening history is only used for "Last listen".
                             QuickPicks.QUICK_PICKS -> {
-                                database
-                                    .quickPicks()
-                                    .distinctUntilSongIdsChanged()
-                                    .map { songs -> quickPicksWithFallback(songs) }
+                                flowOf(null)
                             }
 
                             QuickPicks.LAST_LISTEN -> {
@@ -439,7 +482,7 @@ class HomeViewModel
             val picks =
                 when (quickPicksMode.first()) {
                     QuickPicks.QUICK_PICKS -> {
-                        quickPicksWithFallback(database.quickPicks().first())
+                        null
                     }
 
                     QuickPicks.LAST_LISTEN -> {
@@ -504,6 +547,7 @@ class HomeViewModel
                 supervisorScope {
 
                     launch { loadSpeedDialItems() }
+                    val personalizedQuickPicks = async { loadPersonalizedQuickPicks() }
                     launch {
                         forgottenFavorites.value =
                             database
@@ -564,8 +608,18 @@ class HomeViewModel
                                             },
                                     )
                                 val (pageWithoutQuickPicks, quickPicksSection) = filteredPage.extractQuickPicks()
-                                remoteQuickPicks.value = quickPicksSection
                                 homePage.value = pageWithoutQuickPicks
+                                // The shelves are up as fast as possible; the "Quick picks" shelf
+                                // of the home response is only used when YouTube Music gave us
+                                // nothing better from the recommendation seeds.
+                                if (
+                                    quickPicksMode.first() == QuickPicks.QUICK_PICKS &&
+                                    !personalizedQuickPicks.await()
+                                ) {
+                                    quickPicksSection?.takeIf { it.items.isNotEmpty() }?.let { fallback ->
+                                        remoteQuickPicks.value = fallback
+                                    }
+                                }
                             }.onFailure {
                                 reportException(it)
                                 loadError.value = R.string.error_unknown
@@ -795,8 +849,7 @@ class HomeViewModel
                                     )
                                 },
                         )
-                    val (pageWithoutQuickPicks, quickPicksSection) = mergedPage.extractQuickPicks()
-                    quickPicksSection?.let { remoteQuickPicks.value = it }
+                    val (pageWithoutQuickPicks, _) = mergedPage.extractQuickPicks()
                     homePage.value = pageWithoutQuickPicks
                 } finally {
                     isLoadingMore.value = false


### PR DESCRIPTION
## What changes for the user

Home → **Quick picks** is now online content from YouTube Music instead of songs pulled out of the local listening history.

## How it works

- **`HomeRepository`**
  - `loadQuickPickSeeds()`: seeds are the most played songs of the last 90 days, falling back to the most recent ones; only YouTube songs (not local files) are usable, and they are de-duplicated per artist.
  - `loadRelatedSongs(seedId)`: `YouTube.next(...)` → `relatedEndpoint` → `YouTube.related(...)`, i.e. the "up next" recommendations YouTube Music gives for that song.
- **`LoadPersonalizedQuickPicksUseCase`** (new): loads the seeds' related pages in parallel, then ranks the songs by how many seeds agree → seed strength (most played first) → position in the related list → artist affinity (artists you already listen to). Songs already shown last time are pushed to the back so the row keeps moving, and the result is capped at 20.
- **`HomeViewModel`**
  - Quick picks mode no longer observes `database.quickPicks()`; it emits nothing and the online picks are used instead.
  - `loadPersonalizedQuickPicks()` runs alongside the home load. The "Quick picks" shelf of the home response is kept **only as a fallback** when the seeds or the network produced nothing.
  - Chip categories and load-more pages no longer overwrite quick picks, so they stay stable while you browse.
  - The picks still go through hide-explicit, hide-video, blocked-artist and AI-content filtering.
- **`HomeScreen`**
  - Online picks render with `RemoteQuickPicksSection` (new), which uses the same hero-card / list layouts as the local picks, so the **Quick picks display mode** setting applies to them too; the header is always "Quick picks".
  - Local picks are only shown in **Last listen** mode.

## Source

This follows the quick picks work on ArchiveTune's dev branch ("use youTube quick picks and prevent fallback to local", "personalize quick picks from youtube recommendation seed", "fall back to remote quick picks"), adapted to LunarTune's `home` package, content filters and composables. Nothing changed in the submodules — the needed `YouTube.next` / `YouTube.related` / `NextResult.relatedEndpoint` APIs already exist in the pinned core.

## Notes

- No history at all (fresh install, nothing played) means no seeds → no online picks, so the home falls back to the YouTube Music "Quick picks" shelf, and if YouTube Music doesn't send one either the section stays empty instead of showing old history.
- Seeds are only *inputs* for the request: the songs themselves come from YouTube Music, not from the database.