### PR TITLE
fix: keep quick picks visible when YouTube Music gives none

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/home/HomeRepository.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/home/HomeRepository.kt
@@ -85,6 +85,11 @@ class HomeRepository
                 YouTube.next(WatchEndpoint(videoId = seedSongId)).getOrElse { throwable ->
                     return Result.failure(throwable)
                 }
+            // The up next list is the recommendation YouTube Music actually serves for a
+            // song (it is what the radio queue is built from). The related browse page is
+            // only a fallback: it is a different module and often missing or empty.
+            val upNextSongs = nextPage.items.filterNot { song -> song.id == seedSongId }
+            if (upNextSongs.isNotEmpty()) return Result.success(upNextSongs)
             val relatedEndpoint = nextPage.relatedEndpoint ?: return Result.success(emptyList())
             return YouTube.related(relatedEndpoint).map { page -> page.songs }
         }

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/HomeScreen.kt
@@ -418,7 +418,7 @@ private fun HomeContent(
                                 )
                             }
                         } else if (
-                            uiState.quickPicksMode == QuickPicks.LAST_LISTEN &&
+                            uiState.quickPicksMode != QuickPicks.DONT_SHOW &&
                                 uiState.quickPicks.isNotEmpty()
                         ) {
                             item(

--- a/app/src/main/kotlin/dev/citali/lunartune/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/viewmodels/HomeViewModel.kt
@@ -361,7 +361,10 @@ class HomeViewModel
                     Timber.w(throwable, "Failed to load personalized quick picks")
                     return false
                 }
-            if (songs.isEmpty()) return false
+            if (songs.isEmpty()) {
+                Timber.w("Personalized quick picks returned no songs")
+                return false
+            }
 
             val hideExplicit = context.dataStore.get(HideExplicitKey, false)
             val hideVideo = context.dataStore.get(HideVideoKey, false)
@@ -454,10 +457,13 @@ class HomeViewModel
                 quickPicksMode
                     .flatMapLatest { mode ->
                         when (mode) {
-                            // Quick picks are online recommendations now, the local
-                            // listening history is only used for "Last listen".
+                            // Online recommendations lead, the listening history is only
+                            // a safety net for when YouTube Music gives us nothing.
                             QuickPicks.QUICK_PICKS -> {
-                                flowOf(null)
+                                database
+                                    .quickPicks()
+                                    .distinctUntilSongIdsChanged()
+                                    .map { songs -> quickPicksWithFallback(songs) }
                             }
 
                             QuickPicks.LAST_LISTEN -> {
@@ -482,7 +488,7 @@ class HomeViewModel
             val picks =
                 when (quickPicksMode.first()) {
                     QuickPicks.QUICK_PICKS -> {
-                        null
+                        quickPicksWithFallback(database.quickPicks().first())
                     }
 
                     QuickPicks.LAST_LISTEN -> {


### PR DESCRIPTION
## Why the section disappeared

#66 made Quick picks online-only: `database.quickPicks()` was no longer observed, so as soon as the online lookup came back empty there was nothing left to render and the section vanished.

Two reasons it could come back empty:

1. **The recommendation source.** Seeds were expanded through `next → relatedEndpoint → YouTube.related`. The related *browse page* is a different module that is often missing for a plain song — in my own calls against YouTube Music the `relatedEndpoint` is simply absent — and when it is present it is not always a carousel, which is all `YouTube.related` parses.
2. **No seeds at all.** With no YouTube songs in the history (fresh install, or mostly local files) there is nothing to expand, so the row had no source left.

## The fix

- **`HomeRepository.loadRelatedSongs()`** now takes the recommendations from the **up next list of `YouTube.next(...)`** — the exact list `YouTubeQueue` builds the radio queue from, so it is the recommendation YouTube Music really serves for a song. The related browse page is kept as a fallback for when that list is empty.
- **`HomeViewModel`** observes the local lists again in Quick picks mode, so the history/library picks act as a **safety net** instead of an empty section. Online picks still take priority: they are applied as soon as they arrive and the local ones are only rendered when there are no online ones.
- **`HomeScreen`** shows the local picks whenever there are no online ones (Quick picks and Last listen mode, still hidden in Don't show).
- The empty-online case is logged, so it shows up in a logcat instead of failing silently.

Net effect: **online first, never empty**. Worst case is exactly the behaviour from before #66.

## Not done here (needs a decision)

ArchiveTune's dev branch gets its Quick picks shelf because its `core` submodule pins `28e38d47`, which teaches `HomePage` to parse `musicShelfRenderer` / `musicCardShelfRenderer` / `musicMultiRowListItemRenderer` — YouTube Music no longer sends Quick picks as a carousel, which is why our pinned `core` (`a0837f33`) never sees that shelf. Porting that means bumping the submodule, and that commit also rewrites `YouTube.kt`, `PlaybackAuthState`, `InnerTube` and drops the rotating-proxy classes — too risky to take blind on playback. Say the word and I'll do it as its own PR so it can be tested on a build before it lands.