### PR TITLE
perf: parallel downloads, retry failed downloads, hide duplicate settings row

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/playback/DownloadUtil.kt
@@ -56,10 +56,13 @@ import dev.citali.lunartune.utils.isLowDataModeActive
 import dev.citali.lunartune.utils.retryWithoutPlaybackLoginContext
 import okhttp3.ConnectionPool
 import okhttp3.OkHttpClient
+import timber.log.Timber
 import java.time.LocalDateTime
+import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -82,7 +85,11 @@ class DownloadUtil
         )
         private val downloadScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         private val songUrlCache = ConcurrentHashMap<String, AuthScopedCacheValue>()
-        private val downloadExecutor = Executors.newSingleThreadExecutor()
+        private val downloadAttempts = ConcurrentHashMap<String, Int>()
+        private val autoRetriedSongIds = Collections.newSetFromMap(ConcurrentHashMap<String, Boolean>())
+        private val sessionFailedSongIds = Collections.newSetFromMap(ConcurrentHashMap<String, Boolean>())
+        private val lastAutoRetryAtMs = AtomicLong(0L)
+        private val downloadExecutor = Executors.newFixedThreadPool(MAX_PARALLEL_DOWNLOADS)
 
         private val mediaOkHttpClient: OkHttpClient by lazy {
             OkHttpClient
@@ -96,7 +103,7 @@ class DownloadUtil
                 .dispatcher(
                     okhttp3.Dispatcher().apply {
                         maxRequests = MAX_DOWNLOAD_HTTP_REQUESTS
-                        maxRequestsPerHost = MAX_DOWNLOAD_HTTP_REQUESTS
+                        maxRequestsPerHost = MAX_DOWNLOAD_HTTP_REQUESTS_PER_HOST
                     },
                 ).connectionPool(
                     ConnectionPool(
@@ -210,9 +217,11 @@ class DownloadUtil
                             finalException: Exception?,
                         ) {
                             if (finalException != null || download.state == Download.STATE_FAILED) {
+                                sessionFailedSongIds.add(download.request.id)
                                 songUrlCache.keys.removeIf { it.startsWith("${download.request.id}:") }
                                 YTPlayerUtils.invalidateCachedStreamUrls(download.request.id)
                             }
+                            trackRetryState(download)
                             downloads.update { map ->
                                 map.toMutableMap().apply {
                                     set(download.request.id, download.toProgressSnapshot())
@@ -224,6 +233,9 @@ class DownloadUtil
                             downloadManager: DownloadManager,
                             download: Download,
                         ) {
+                            downloadAttempts.remove(download.request.id)
+                            autoRetriedSongIds.remove(download.request.id)
+                            sessionFailedSongIds.remove(download.request.id)
                             downloads.update { map -> map - download.request.id }
                         }
                     },
@@ -246,6 +258,7 @@ class DownloadUtil
                 while (isActive) {
                     delay(DOWNLOAD_PROGRESS_REFRESH_INTERVAL_MS)
                     refreshActiveDownloadSnapshots()
+                    retryFailedDownloadsWhenIdle()
                 }
             }
             downloadScope.launch {
@@ -261,6 +274,72 @@ class DownloadUtil
                     }
             }
         }
+
+        private fun trackRetryState(download: Download) {
+            val songId = download.request.id
+            when (download.state) {
+                Download.STATE_COMPLETED -> {
+                    downloadAttempts.remove(songId)
+                    autoRetriedSongIds.remove(songId)
+                    sessionFailedSongIds.remove(songId)
+                }
+
+                Download.STATE_DOWNLOADING -> {
+                    // A download that got going again without our retry is a fresh
+                    // attempt (manual resume), so give it its retries back.
+                    if (!autoRetriedSongIds.remove(songId)) {
+                        downloadAttempts.remove(songId)
+                    }
+                }
+            }
+        }
+
+        /**
+         * Re-queues downloads that failed on their own once nothing else is downloading,
+         * so a bulk download finishes instead of leaving a pile of failed songs behind.
+         *
+         * Manually paused downloads are left alone, the cached stream url is dropped so
+         * the retry resolves a fresh one, and every song only gets a few attempts. Only
+         * songs that failed while the app was running are retried, so a failed download
+         * from an older session is left for the user to resume instead of coming back on
+         * every launch.
+         */
+        private fun retryFailedDownloadsWhenIdle() {
+            val snapshot = downloads.value
+            if (snapshot.values.any { download -> download.state.isActiveDownloadState() }) return
+
+            val failed =
+                snapshot.values.filter { download ->
+                    download.state == Download.STATE_FAILED &&
+                        download.stopReason == Download.STOP_REASON_NONE &&
+                        download.request.id in sessionFailedSongIds
+                }
+            if (failed.isEmpty()) return
+
+            val now = System.currentTimeMillis()
+            if (now - lastAutoRetryAtMs.get() < AUTO_RETRY_COOLDOWN_MS) return
+            lastAutoRetryAtMs.set(now)
+
+            failed.forEach { download ->
+                val songId = download.request.id
+                val attempts = downloadAttempts[songId] ?: 0
+                if (attempts >= MAX_AUTO_RETRY_ATTEMPTS) return@forEach
+                downloadAttempts[songId] = attempts + 1
+                autoRetriedSongIds.add(songId)
+                songUrlCache.keys.removeIf { it.startsWith("$songId:") }
+                YTPlayerUtils.invalidateCachedStreamUrls(songId)
+                runCatching {
+                    downloadManager.addDownload(download.request)
+                }.onFailure { throwable ->
+                    Timber.w(throwable, "Failed to re-queue download $songId")
+                }
+            }
+        }
+
+        private fun Int.isActiveDownloadState(): Boolean =
+            this == Download.STATE_QUEUED ||
+                this == Download.STATE_DOWNLOADING ||
+                this == Download.STATE_RESTARTING
 
         private fun refreshActiveDownloadSnapshots() {
             val activeDownloads = downloadManager.currentDownloads
@@ -373,9 +452,12 @@ class DownloadUtil
         }
 
         companion object {
-            private const val MAX_PARALLEL_DOWNLOADS = 1
+            private const val MAX_PARALLEL_DOWNLOADS = 6
             private const val MAX_IDLE_DOWNLOAD_CONNECTIONS = 12
-            private const val MAX_DOWNLOAD_HTTP_REQUESTS = 1
+            private const val MAX_DOWNLOAD_HTTP_REQUESTS = 8
+            private const val MAX_DOWNLOAD_HTTP_REQUESTS_PER_HOST = 6
+            private const val MAX_AUTO_RETRY_ATTEMPTS = 3
+            private const val AUTO_RETRY_COOLDOWN_MS = 3_000L
             private const val DOWNLOAD_READ_TIMEOUT_SECONDS = 90L
             private const val DOWNLOAD_PROGRESS_REFRESH_INTERVAL_MS = 1_000L
             private const val DOWNLOAD_CONNECTION_KEEP_ALIVE_MINUTES = 5L

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/SettingsDataBuilders.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/SettingsDataBuilders.kt
@@ -394,6 +394,10 @@ fun buildSettingsGroups(
                 SettingsChild("Smart trimmer", "smart_trimmer", listOf("smart trimmer", "trim cache", "auto clean cache")) { SearchResultSwitch(SmartTrimmerKey, false) },
             ),
         )
+    // The row is hidden: it opened the same screen as Storage right next to it. The entry
+    // stays in the index so its children (clear all downloads, auto download on like,
+    // external downloader) are still reachable through settings search, and they also live
+    // on the Storage and Player screens.
     val downloads =
         SettingsItem(
             key = "downloads",
@@ -403,6 +407,7 @@ fun buildSettingsGroups(
             accentColor = MaterialTheme.colorScheme.primary,
             keywords = listOf("download", "downloader", "offline", "auto download", "external downloader", "clear downloads"),
             onClick = { navController.navigate("settings/storage") },
+            hidden = true,
             children = listOf(
                 SettingsChild("Clear all downloads", "clear_all_downloads", listOf("clear downloads", "delete downloads", "remove downloads")),
                 SettingsChild("Auto download on like", "auto_download_like", listOf("auto download", "like", "download liked")) { SearchResultSwitch(AutoDownloadOnLikeKey, false) },


### PR DESCRIPTION
## Faster downloads

Downloads ran strictly one at a time: `maxParallelDownloads = 1`, a single-thread download executor and an OkHttp dispatcher capped at 1 request / 1 per host. A 100-song playlist took as long as 100 separate downloads.

- **`MAX_PARALLEL_DOWNLOADS` 1 → 6**, with the download executor now a fixed pool of 6 threads (a single-thread executor would have serialized the work anyway)
- **OkHttp dispatcher 1 → 8 requests, 6 per host**, so the media connections can actually be used in parallel
- 6 is deliberately not "unlimited": each song still costs a stream-resolution call, and going much wider is what makes YouTube start handing out 403s on bulk downloads. It is one constant if you want to push it further.

## Failed downloads retry themselves

New in `DownloadUtil`: when **nothing is downloading any more**, any song that failed on its own is re-queued.

- up to **3 attempts** per song, spaced ~3s apart so a failing batch doesn't hammer the API
- the **cached stream url is dropped** before each retry, so it resolves a fresh one — an expired/403 url is the usual cause
- **manually paused downloads are never touched** (only `stopReason == STOP_REASON_NONE`)
- only songs that **failed while the app was running** are retried, so a failure from last week doesn't resurrect itself on every launch — those stay for the user to resume from the Downloads screen
- the attempt counter resets when a song completes, is removed, or is resumed by hand, so a manual retry always gets its full set of attempts back

Net effect for a mass download: it runs 6-wide, and whatever fell over gets picked up after the queue drains instead of sitting in the failed list.

## Settings: Downloads row removed

The Downloads row opened `settings/storage` — the exact same screen as the Storage row directly above it, with the same subtitle, so it was a duplicate.

It is now `hidden = true`, which removes it from the settings list but keeps it in the search index (the list filters on `hidden`, the child search does not). So "clear all downloads", "auto download on like" and "external downloader" are still findable via settings search, and they also live on the Storage screen (clear all downloads) and the Player screen (auto download on like, external downloader). Nothing became unreachable.

## Testing

CI is assemble + lint only, so the throughput and retry behaviour need a device: queue a large playlist, watch it run 6-wide, then kill the network mid-way — the failed songs should re-queue on their own once the rest finish, up to 3 times each.