### PR TITLE
refactor: move Spotify account to the Integration screen

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/BackupAndRestore.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/BackupAndRestore.kt
@@ -28,6 +28,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DatePicker

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/BackupAndRestore.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/BackupAndRestore.kt
@@ -9,22 +9,9 @@
 
 package dev.citali.lunartune.ui.screens.settings
 
-import android.annotation.SuppressLint
-import android.content.Intent
 import android.net.Uri
-import android.os.Message
-import android.view.ViewGroup
-import android.webkit.CookieManager
-import android.webkit.WebChromeClient
-import android.webkit.WebResourceRequest
-import android.webkit.WebSettings
-import android.webkit.WebView
-import android.webkit.WebViewClient
-import android.widget.FrameLayout
-import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -32,8 +19,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -42,19 +27,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Checkbox
-import androidx.compose.material3.CircularWavyProgressIndicator
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -63,11 +42,9 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberDatePickerState
-import androidx.compose.material3.rememberModalBottomSheetState
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -80,44 +57,33 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
-import coil3.compose.AsyncImage
-import coil3.request.ImageRequest
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import dev.citali.lunartune.LocalPlayerAwareWindowInsets
 import dev.citali.lunartune.R
 import dev.citali.lunartune.backup.ScheduledBackupFrequency
 import dev.citali.lunartune.constants.ImportSourcePriorityKey
-import dev.citali.lunartune.constants.ShowSpotifyPlaylistsKey
 import dev.citali.lunartune.db.entities.Song
-import dev.citali.lunartune.spotify.SpotifyAccountUiState
-import dev.citali.lunartune.spotify.SpotifyAccountViewModel
-import dev.citali.lunartune.spotify.SpotifyAuth
 import dev.citali.lunartune.ui.component.DefaultDialog
 import dev.citali.lunartune.ui.component.EnumListPreference
 import dev.citali.lunartune.ui.component.IconButton
 import dev.citali.lunartune.ui.component.ListPreference
 import dev.citali.lunartune.ui.component.PreferenceEntry
 import dev.citali.lunartune.ui.component.PreferenceGroup
-import dev.citali.lunartune.ui.component.PreferenceGroupScope
 import dev.citali.lunartune.ui.component.SwitchPreference
 import dev.citali.lunartune.ui.menu.AddToPlaylistDialogOnline
 import dev.citali.lunartune.ui.menu.LoadingScreen
 import dev.citali.lunartune.ui.utils.backToMain
 import dev.citali.lunartune.utils.rememberPreference
-import dev.citali.lunartune.utils.resetAuthWebViewSession
 import dev.citali.lunartune.viewmodels.BackupCategory
 import dev.citali.lunartune.viewmodels.BackupRestoreViewModel
 import dev.citali.lunartune.viewmodels.ScheduledBackupScreenState
@@ -142,15 +108,10 @@ private val CSV_MIME_TYPES =
         "application/octet-stream",
     )
 
-private val SpotifyAccountIconSize = 44.dp
-private const val SpotifyLoginUserAgent =
-    "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Mobile Safari/537.36"
-
 @Composable
 fun BackupAndRestore(
     navController: NavController,
     viewModel: BackupRestoreViewModel = hiltViewModel(),
-    spotifyAccountViewModel: SpotifyAccountViewModel = hiltViewModel(),
 ) {
     val importedSongs = remember { mutableStateListOf<Song>() }
     var showChoosePlaylistDialogOnline by rememberSaveable { mutableStateOf(false) }
@@ -161,16 +122,13 @@ fun BackupAndRestore(
     var showRestoreOptionsDialog by rememberSaveable { mutableStateOf(false) }
     var showRestoreValidationError by rememberSaveable { mutableStateOf(false) }
     var restoreValidationErrorMessage by remember { mutableStateOf("") }
-    var showSpotifyLogin by rememberSaveable { mutableStateOf(false) }
     var pendingBackupCategories by remember { mutableStateOf(BackupCategory.entries.toSet()) }
     var pendingRestoreCategories by remember { mutableStateOf(BackupCategory.entries.toSet()) }
     var pendingRestoreUri by remember { mutableStateOf<Uri?>(null) }
 
     val backupRestoreProgress by viewModel.backupRestoreProgress.collectAsStateWithLifecycle()
     val scheduledBackupState by viewModel.scheduledBackupState.collectAsStateWithLifecycle()
-    val spotifyState by spotifyAccountViewModel.uiState.collectAsStateWithLifecycle()
     val (importLocalFirst, onImportLocalFirstChange) = rememberPreference(ImportSourcePriorityKey, false)
-    val (showSpotifyPlaylists, onShowSpotifyPlaylistsChange) = rememberPreference(ShowSpotifyPlaylistsKey, false)
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -237,12 +195,6 @@ fun BackupAndRestore(
                 }
             }
         }
-
-    LaunchedEffect(spotifyState.isAuthenticated) {
-        if (spotifyState.isAuthenticated) {
-            showSpotifyLogin = false
-        }
-    }
 
     Scaffold(
         topBar = {
@@ -377,19 +329,6 @@ fun BackupAndRestore(
                     )
                 }
             }
-
-            PreferenceGroup(title = stringResource(R.string.external_service)) {
-                spotifyAccountPreferences(
-                    state = spotifyState,
-                    showPlaylists = showSpotifyPlaylists,
-                    onConnectClick = { showSpotifyLogin = true },
-                    onShowPlaylistsChange = onShowSpotifyPlaylistsChange,
-                    onReloadClick = spotifyAccountViewModel::reloadPlaylists,
-                    onLogoutClick = {
-                        spotifyAccountViewModel.logout()
-                    },
-                )
-            }
         }
     }
 
@@ -457,23 +396,6 @@ fun BackupAndRestore(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
-    }
-
-    if (showSpotifyLogin) {
-        SpotifyLoginSheet(
-            onDismiss = { showSpotifyLogin = false },
-            onCookiesCaptured = { spDc, spKey ->
-                showSpotifyLogin = false
-                spotifyAccountViewModel.connectWithCookies(spDc = spDc, spKey = spKey)
-            },
-        )
-    }
-
-    spotifyState.errorMessage?.let { error ->
-        SpotifyErrorDialog(
-            message = error,
-            onDismiss = spotifyAccountViewModel::dismissError,
-        )
     }
 
     AddToPlaylistDialogOnline(
@@ -650,512 +572,6 @@ private val ScheduledBackupFrequency.labelRes: Int
             ScheduledBackupFrequency.MONTHLY -> R.string.scheduled_backup_monthly
             ScheduledBackupFrequency.CUSTOM -> R.string.scheduled_backup_custom
         }
-
-private fun PreferenceGroupScope.spotifyAccountPreferences(
-    state: SpotifyAccountUiState,
-    showPlaylists: Boolean,
-    onConnectClick: () -> Unit,
-    onShowPlaylistsChange: (Boolean) -> Unit,
-    onReloadClick: () -> Unit,
-    onLogoutClick: () -> Unit,
-) {
-    if (!state.isAuthenticated) {
-        item {
-            PreferenceEntry(
-                title = { Text(stringResource(R.string.spotify_connect)) },
-                description = stringResource(R.string.spotify_not_connected),
-                icon = { Icon(painterResource(R.drawable.spotify_icon), null) },
-                trailingContent = {
-                    AnimatedVisibility(visible = state.isLoading) {
-                        CircularWavyProgressIndicator(
-                            modifier = Modifier.size(28.dp),
-                            color = MaterialTheme.colorScheme.primary,
-                        )
-                    }
-                },
-                onClick = onConnectClick,
-                isEnabled = !state.isLoading,
-            )
-        }
-        return
-    }
-
-    item {
-        PreferenceEntry(
-            title = {
-                Text(
-                    text =
-                        if (state.accountName.isNotBlank()) {
-                            stringResource(R.string.spotify_connected_as, state.accountName)
-                        } else {
-                            stringResource(R.string.spotify_account)
-                        },
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            },
-            description =
-                when {
-                    state.isLoading -> stringResource(R.string.spotify_loading_library)
-                    state.playlistCount > 0 -> stringResource(R.string.spotify_available_count, state.playlistCount)
-                    else -> stringResource(R.string.spotify_no_sources)
-                },
-            icon = { SpotifyAccountIcon(avatarUrl = state.accountAvatarUrl) },
-            trailingContent = {
-                AnimatedVisibility(visible = state.isLoading) {
-                    CircularWavyProgressIndicator(
-                        modifier = Modifier.size(28.dp),
-                        color = MaterialTheme.colorScheme.primary,
-                    )
-                }
-            },
-            isEnabled = false,
-        )
-    }
-
-    item {
-        SwitchPreference(
-            title = { Text(stringResource(R.string.spotify_show_playlist)) },
-            description = stringResource(R.string.spotify_show_playlist_desc),
-            icon = { Icon(painterResource(R.drawable.spotify_icon), null) },
-            checked = showPlaylists,
-            onCheckedChange = onShowPlaylistsChange,
-            isEnabled = !state.isLoading,
-        )
-    }
-
-    item {
-        PreferenceEntry(
-            title = { Text(stringResource(R.string.spotify_reload_playlist)) },
-            description = stringResource(R.string.spotify_reload_playlist_desc),
-            icon = { Icon(painterResource(R.drawable.sync), null) },
-            onClick = onReloadClick,
-            isEnabled = !state.isLoading,
-        )
-    }
-
-    item {
-        PreferenceEntry(
-            title = { Text(stringResource(R.string.action_logout)) },
-            icon = { Icon(painterResource(R.drawable.logout), null) },
-            onClick = onLogoutClick,
-            isEnabled = !state.isLoading,
-        )
-    }
-}
-
-@Composable
-private fun SpotifyAccountIcon(avatarUrl: String?) {
-    val context = LocalContext.current
-    val requestSize = with(LocalDensity.current) { SpotifyAccountIconSize.roundToPx() }
-    val accountIcon = painterResource(R.drawable.spotify_icon)
-    val imageRequest =
-        remember(context, avatarUrl, requestSize) {
-            avatarUrl
-                ?.takeIf(String::isNotBlank)
-                ?.let {
-                    ImageRequest
-                        .Builder(context)
-                        .data(it)
-                        .size(requestSize)
-                        .build()
-                }
-        }
-
-    Box(
-        modifier =
-            Modifier
-                .fillMaxSize()
-                .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.primaryContainer),
-        contentAlignment = Alignment.Center,
-    ) {
-        if (imageRequest != null) {
-            AsyncImage(
-                model = imageRequest,
-                contentDescription = null,
-                placeholder = accountIcon,
-                error = accountIcon,
-                contentScale = ContentScale.Crop,
-                modifier = Modifier.fillMaxSize(),
-            )
-        } else {
-            Icon(
-                painter = accountIcon,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                modifier = Modifier.size(24.dp),
-            )
-        }
-    }
-}
-
-@SuppressLint("SetJavaScriptEnabled")
-@Composable
-private fun SpotifyLoginSheet(
-    onDismiss: () -> Unit,
-    onCookiesCaptured: (spDc: String, spKey: String) -> Unit,
-) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    var webView by remember { mutableStateOf<WebView?>(null) }
-    var mainWebView by remember { mutableStateOf<WebView?>(null) }
-    var captured by remember { mutableStateOf(false) }
-
-    DisposableEffect(Unit) {
-        onDispose {
-            webView?.destroySpotifyLoginWebView()
-            mainWebView?.takeIf { it !== webView }?.destroySpotifyLoginWebView()
-            webView = null
-            mainWebView = null
-        }
-    }
-
-    BackHandler(enabled = webView != null) {
-        val activeWebView = webView
-        val rootWebView = mainWebView
-        when {
-            activeWebView?.canGoBack() == true -> {
-                activeWebView.goBack()
-            }
-
-            activeWebView != null && rootWebView != null && activeWebView !== rootWebView -> {
-                activeWebView.destroySpotifyLoginWebView()
-                webView = rootWebView
-            }
-
-            else -> {
-                onDismiss()
-            }
-        }
-    }
-
-    ModalBottomSheet(
-        modifier = Modifier.fillMaxHeight(),
-        onDismissRequest = onDismiss,
-        sheetState = sheetState,
-        shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
-        containerColor = MaterialTheme.colorScheme.surface,
-    ) {
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .fillMaxHeight()
-                    .padding(horizontal = 20.dp)
-                    .padding(bottom = 20.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.spotify_login_title),
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold,
-            )
-            Text(
-                text = stringResource(R.string.spotify_waiting_for_login),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            AndroidView(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .weight(1f)
-                        .clip(MaterialTheme.shapes.large),
-                factory = { context ->
-                    val container = FrameLayout(context)
-                    val spotifyWebView =
-                        WebView(context).apply {
-                            val cookieManager = CookieManager.getInstance()
-                            cookieManager.setAcceptCookie(true)
-                            cookieManager.setAcceptThirdPartyCookies(this, true)
-                            configureSpotifyLoginWebView()
-
-                            fun captureCookies(url: String?): Boolean {
-                                if (captured) return true
-                                val cookies = readSpotifyCookies(cookieManager, url)
-                                val spDc = cookies["sp_dc"].orEmpty()
-                                if (spDc.isBlank()) return false
-                                captured = true
-                                cookieManager.flush()
-                                onCookiesCaptured(spDc, cookies["sp_key"].orEmpty())
-                                return true
-                            }
-
-                            webViewClient =
-                                object : WebViewClient() {
-                                    override fun shouldOverrideUrlLoading(
-                                        view: WebView,
-                                        request: WebResourceRequest,
-                                    ): Boolean =
-                                        shouldOverrideSpotifyLoginUrl(
-                                            view = view,
-                                            url = request.url?.toString(),
-                                            captureCookies = { url -> captureCookies(url) },
-                                        )
-
-                                    @Deprecated("Deprecated in Java")
-                                    override fun shouldOverrideUrlLoading(
-                                        view: WebView,
-                                        url: String?,
-                                    ): Boolean =
-                                        shouldOverrideSpotifyLoginUrl(
-                                            view = view,
-                                            url = url,
-                                            captureCookies = { targetUrl -> captureCookies(targetUrl) },
-                                        )
-
-                                    override fun onPageStarted(
-                                        view: WebView,
-                                        url: String?,
-                                        favicon: android.graphics.Bitmap?,
-                                    ) {
-                                        captureCookies(url)
-                                    }
-
-                                    override fun onPageFinished(
-                                        view: WebView,
-                                        url: String?,
-                                    ) {
-                                        captureCookies(url)
-                                    }
-                                }
-                            webChromeClient =
-                                SpotifyLoginWebChromeClient(
-                                    container = container,
-                                    parentWebView = this,
-                                    captureCookies = { url -> captureCookies(url) },
-                                    onActiveWebViewChanged = { activeWebView -> webView = activeWebView },
-                                )
-                            webView = this
-                            mainWebView = this
-                            resetAuthWebViewSession(context, this) {
-                                loadUrl(SpotifyAuth.LOGIN_URL)
-                            }
-                        }
-                    container.addView(
-                        spotifyWebView,
-                        FrameLayout.LayoutParams(
-                            ViewGroup.LayoutParams.MATCH_PARENT,
-                            ViewGroup.LayoutParams.MATCH_PARENT,
-                        ),
-                    )
-                    container
-                },
-                update = {
-                    webView = webView ?: mainWebView
-                },
-            )
-        }
-    }
-}
-
-private fun WebView.destroySpotifyLoginWebView() {
-    stopLoading()
-    loadUrl("about:blank")
-    (parent as? ViewGroup)?.removeView(this)
-    destroy()
-}
-
-@SuppressLint("SetJavaScriptEnabled")
-private fun WebView.configureSpotifyLoginWebView() {
-    settings.apply {
-        javaScriptEnabled = true
-        domStorageEnabled = true
-        javaScriptCanOpenWindowsAutomatically = true
-        setSupportMultipleWindows(true)
-        setSupportZoom(true)
-        builtInZoomControls = true
-        displayZoomControls = false
-        mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
-        userAgentString = SpotifyLoginUserAgent
-    }
-}
-
-private class SpotifyLoginWebChromeClient(
-    private val container: FrameLayout,
-    private val parentWebView: WebView,
-    private val captureCookies: (String?) -> Boolean,
-    private val onActiveWebViewChanged: (WebView) -> Unit,
-) : WebChromeClient() {
-    override fun onCreateWindow(
-        view: WebView,
-        isDialog: Boolean,
-        isUserGesture: Boolean,
-        resultMsg: Message,
-    ): Boolean {
-        closePopupWebViews()
-
-        val popupWebView =
-            WebView(view.context).apply {
-                val cookieManager = CookieManager.getInstance()
-                cookieManager.setAcceptCookie(true)
-                cookieManager.setAcceptThirdPartyCookies(this, true)
-                configureSpotifyLoginWebView()
-                webViewClient =
-                    object : WebViewClient() {
-                        override fun shouldOverrideUrlLoading(
-                            view: WebView,
-                            request: WebResourceRequest,
-                        ): Boolean =
-                            shouldOverrideSpotifyLoginUrl(
-                                view = view,
-                                url = request.url?.toString(),
-                                captureCookies = captureCookies,
-                            )
-
-                        @Deprecated("Deprecated in Java")
-                        override fun shouldOverrideUrlLoading(
-                            view: WebView,
-                            url: String?,
-                        ): Boolean =
-                            shouldOverrideSpotifyLoginUrl(
-                                view = view,
-                                url = url,
-                                captureCookies = captureCookies,
-                            )
-
-                        override fun onPageStarted(
-                            view: WebView,
-                            url: String?,
-                            favicon: android.graphics.Bitmap?,
-                        ) {
-                            captureCookies(url)
-                        }
-
-                        override fun onPageFinished(
-                            view: WebView,
-                            url: String?,
-                        ) {
-                            captureCookies(url)
-                        }
-                    }
-            }
-
-        val transport = resultMsg.obj as? WebView.WebViewTransport ?: return false
-        container.addView(
-            popupWebView,
-            FrameLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT,
-            ),
-        )
-        popupWebView.bringToFront()
-        popupWebView.requestFocus()
-        onActiveWebViewChanged(popupWebView)
-        transport.webView = popupWebView
-        resultMsg.sendToTarget()
-        return true
-    }
-
-    override fun onCloseWindow(window: WebView) {
-        window.destroySpotifyLoginWebView()
-        onActiveWebViewChanged(parentWebView)
-    }
-
-    private fun closePopupWebViews() {
-        for (index in container.childCount - 1 downTo 0) {
-            val child = container.getChildAt(index) as? WebView ?: continue
-            if (child !== parentWebView) {
-                child.destroySpotifyLoginWebView()
-            }
-        }
-        onActiveWebViewChanged(parentWebView)
-    }
-}
-
-private fun shouldOverrideSpotifyLoginUrl(
-    view: WebView,
-    url: String?,
-    captureCookies: (String?) -> Boolean,
-): Boolean {
-    if (captureCookies(url)) return true
-
-    val targetUrl = url?.takeIf(String::isNotBlank) ?: return false
-    if (targetUrl.isWebViewLoadableUrl()) return false
-
-    targetUrl.intentBrowserFallbackUrl()?.let { fallbackUrl -> view.loadUrl(fallbackUrl) }
-    return true
-}
-
-private fun String.isWebViewLoadableUrl(): Boolean {
-    val scheme = runCatching { Uri.parse(this).scheme?.lowercase() }.getOrNull()
-    return scheme == "http" ||
-        scheme == "https" ||
-        scheme == "javascript" ||
-        scheme == "data" ||
-        scheme == "blob"
-}
-
-private fun String.intentBrowserFallbackUrl(): String? =
-    runCatching { Intent.parseUri(this, Intent.URI_INTENT_SCHEME) }
-        .getOrNull()
-        ?.getStringExtra("browser_fallback_url")
-        ?.takeIf { it.isWebViewLoadableUrl() }
-
-private fun readSpotifyCookies(
-    cookieManager: CookieManager,
-    currentUrl: String?,
-): Map<String, String> {
-    val urls =
-        linkedSetOf(
-            "https://open.spotify.com",
-            "https://accounts.spotify.com",
-            "https://spotify.com",
-        )
-    currentUrl?.toSpotifyCookieOrigin()?.let(urls::add)
-    val cookies = linkedMapOf<String, String>()
-    cookieManager.flush()
-    urls.forEach { url ->
-        cookieManager
-            .getCookie(url)
-            ?.split(";")
-            ?.map(String::trim)
-            ?.filter(String::isNotBlank)
-            ?.forEach { part ->
-                val separator = part.indexOf('=')
-                if (separator <= 0) return@forEach
-                val key = part.substring(0, separator).trim()
-                val value = part.substring(separator + 1).trim()
-                if (key.isNotBlank()) {
-                    cookies[key] = value
-                }
-            }
-    }
-    return cookies
-}
-
-private fun String.toSpotifyCookieOrigin(): String? {
-    val uri = runCatching { Uri.parse(this) }.getOrNull() ?: return null
-    val host = uri.host?.lowercase() ?: return null
-    if (host != "spotify.com" && !host.endsWith(".spotify.com")) return null
-    val scheme =
-        uri.scheme
-            ?.takeIf { it.equals("https", ignoreCase = true) || it.equals("http", ignoreCase = true) }
-            ?: "https"
-    return "$scheme://$host"
-}
-
-@Composable
-private fun SpotifyErrorDialog(
-    message: String,
-    onDismiss: () -> Unit,
-) {
-    DefaultDialog(
-        onDismiss = onDismiss,
-        title = { Text(stringResource(R.string.import_failed)) },
-        buttons = {
-            TextButton(onClick = onDismiss, shapes = ButtonDefaults.shapes()) {
-                Text(stringResource(android.R.string.ok))
-            }
-        },
-    ) {
-        Text(
-            text = message,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
-}
 
 @Composable
 private fun IconBubble(

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/IntegrationScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/IntegrationScreen.kt
@@ -7,6 +7,59 @@
 
 package dev.citali.lunartune.ui.screens.settings
 
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.net.Uri
+import android.os.Message
+import android.view.ViewGroup
+import android.webkit.CookieManager
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceRequest
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.widget.FrameLayout
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularWavyProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import dev.citali.lunartune.constants.ShowSpotifyPlaylistsKey
+import dev.citali.lunartune.spotify.SpotifyAccountUiState
+import dev.citali.lunartune.spotify.SpotifyAccountViewModel
+import dev.citali.lunartune.spotify.SpotifyAuth
+import dev.citali.lunartune.ui.component.DefaultDialog
+import dev.citali.lunartune.ui.component.PreferenceGroupScope
+import dev.citali.lunartune.utils.resetAuthWebViewSession
+
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
@@ -22,6 +75,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -41,9 +95,21 @@ import dev.citali.lunartune.utils.rememberPreference
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun IntegrationScreen(navController: NavController) {
+fun IntegrationScreen(
+    navController: NavController,
+    spotifyAccountViewModel: SpotifyAccountViewModel = hiltViewModel(),
+) {
     val (listenBrainzEnabled, onListenBrainzEnabledChange) = rememberPreference(ListenBrainzEnabledKey, false)
     val (listenBrainzToken, onListenBrainzTokenChange) = rememberPreference(ListenBrainzTokenKey, "")
+    val (showSpotifyPlaylists, onShowSpotifyPlaylistsChange) = rememberPreference(ShowSpotifyPlaylistsKey, false)
+    val spotifyState by spotifyAccountViewModel.uiState.collectAsStateWithLifecycle()
+    var showSpotifyLogin by rememberSaveable { mutableStateOf(false) }
+
+    LaunchedEffect(spotifyState.isAuthenticated) {
+        if (spotifyState.isAuthenticated) {
+            showSpotifyLogin = false
+        }
+    }
 
     var showListenBrainzTokenEditor = remember { mutableStateOf(false) }
 
@@ -125,7 +191,35 @@ fun IntegrationScreen(navController: NavController) {
                     )
                 }
             }
+
+            PreferenceGroup(title = stringResource(R.string.external_service)) {
+                spotifyAccountPreferences(
+                    state = spotifyState,
+                    showPlaylists = showSpotifyPlaylists,
+                    onConnectClick = { showSpotifyLogin = true },
+                    onShowPlaylistsChange = onShowSpotifyPlaylistsChange,
+                    onReloadClick = spotifyAccountViewModel::reloadPlaylists,
+                    onLogoutClick = { spotifyAccountViewModel.logout() },
+                )
+            }
         }
+    }
+
+    if (showSpotifyLogin) {
+        SpotifyLoginSheet(
+            onDismiss = { showSpotifyLogin = false },
+            onCookiesCaptured = { spDc, spKey ->
+                showSpotifyLogin = false
+                spotifyAccountViewModel.connectWithCookies(spDc = spDc, spKey = spKey)
+            },
+        )
+    }
+
+    spotifyState.errorMessage?.let { error ->
+        SpotifyErrorDialog(
+            message = error,
+            onDismiss = spotifyAccountViewModel::dismissError,
+        )
     }
 
     if (showListenBrainzTokenEditor.value) {
@@ -146,6 +240,516 @@ fun IntegrationScreen(navController: NavController) {
             extraContent = {
                 InfoLabel(text = stringResource(R.string.listenbrainz_scrobbling_description))
             },
+        )
+    }
+}
+
+private val SpotifyAccountIconSize = 44.dp
+private const val SpotifyLoginUserAgent =
+    "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Mobile Safari/537.36"
+
+private fun PreferenceGroupScope.spotifyAccountPreferences(
+    state: SpotifyAccountUiState,
+    showPlaylists: Boolean,
+    onConnectClick: () -> Unit,
+    onShowPlaylistsChange: (Boolean) -> Unit,
+    onReloadClick: () -> Unit,
+    onLogoutClick: () -> Unit,
+) {
+    if (!state.isAuthenticated) {
+        item {
+            PreferenceEntry(
+                title = { Text(stringResource(R.string.spotify_connect)) },
+                description = stringResource(R.string.spotify_not_connected),
+                icon = { Icon(painterResource(R.drawable.spotify_icon), null) },
+                trailingContent = {
+                    AnimatedVisibility(visible = state.isLoading) {
+                        CircularWavyProgressIndicator(
+                            modifier = Modifier.size(28.dp),
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                },
+                onClick = onConnectClick,
+                isEnabled = !state.isLoading,
+            )
+        }
+        return
+    }
+
+    item {
+        PreferenceEntry(
+            title = {
+                Text(
+                    text =
+                        if (state.accountName.isNotBlank()) {
+                            stringResource(R.string.spotify_connected_as, state.accountName)
+                        } else {
+                            stringResource(R.string.spotify_account)
+                        },
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            },
+            description =
+                when {
+                    state.isLoading -> stringResource(R.string.spotify_loading_library)
+                    state.playlistCount > 0 -> stringResource(R.string.spotify_available_count, state.playlistCount)
+                    else -> stringResource(R.string.spotify_no_sources)
+                },
+            icon = { SpotifyAccountIcon(avatarUrl = state.accountAvatarUrl) },
+            trailingContent = {
+                AnimatedVisibility(visible = state.isLoading) {
+                    CircularWavyProgressIndicator(
+                        modifier = Modifier.size(28.dp),
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            },
+            isEnabled = false,
+        )
+    }
+
+    item {
+        SwitchPreference(
+            title = { Text(stringResource(R.string.spotify_show_playlist)) },
+            description = stringResource(R.string.spotify_show_playlist_desc),
+            icon = { Icon(painterResource(R.drawable.spotify_icon), null) },
+            checked = showPlaylists,
+            onCheckedChange = onShowPlaylistsChange,
+            isEnabled = !state.isLoading,
+        )
+    }
+
+    item {
+        PreferenceEntry(
+            title = { Text(stringResource(R.string.spotify_reload_playlist)) },
+            description = stringResource(R.string.spotify_reload_playlist_desc),
+            icon = { Icon(painterResource(R.drawable.sync), null) },
+            onClick = onReloadClick,
+            isEnabled = !state.isLoading,
+        )
+    }
+
+    item {
+        PreferenceEntry(
+            title = { Text(stringResource(R.string.action_logout)) },
+            icon = { Icon(painterResource(R.drawable.logout), null) },
+            onClick = onLogoutClick,
+            isEnabled = !state.isLoading,
+        )
+    }
+}
+
+@Composable
+private fun SpotifyAccountIcon(avatarUrl: String?) {
+    val context = LocalContext.current
+    val requestSize = with(LocalDensity.current) { SpotifyAccountIconSize.roundToPx() }
+    val accountIcon = painterResource(R.drawable.spotify_icon)
+    val imageRequest =
+        remember(context, avatarUrl, requestSize) {
+            avatarUrl
+                ?.takeIf(String::isNotBlank)
+                ?.let {
+                    ImageRequest
+                        .Builder(context)
+                        .data(it)
+                        .size(requestSize)
+                        .build()
+                }
+        }
+
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primaryContainer),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (imageRequest != null) {
+            AsyncImage(
+                model = imageRequest,
+                contentDescription = null,
+                placeholder = accountIcon,
+                error = accountIcon,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize(),
+            )
+        } else {
+            Icon(
+                painter = accountIcon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                modifier = Modifier.size(24.dp),
+            )
+        }
+    }
+}
+
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+private fun SpotifyLoginSheet(
+    onDismiss: () -> Unit,
+    onCookiesCaptured: (spDc: String, spKey: String) -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var webView by remember { mutableStateOf<WebView?>(null) }
+    var mainWebView by remember { mutableStateOf<WebView?>(null) }
+    var captured by remember { mutableStateOf(false) }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            webView?.destroySpotifyLoginWebView()
+            mainWebView?.takeIf { it !== webView }?.destroySpotifyLoginWebView()
+            webView = null
+            mainWebView = null
+        }
+    }
+
+    BackHandler(enabled = webView != null) {
+        val activeWebView = webView
+        val rootWebView = mainWebView
+        when {
+            activeWebView?.canGoBack() == true -> {
+                activeWebView.goBack()
+            }
+
+            activeWebView != null && rootWebView != null && activeWebView !== rootWebView -> {
+                activeWebView.destroySpotifyLoginWebView()
+                webView = rootWebView
+            }
+
+            else -> {
+                onDismiss()
+            }
+        }
+    }
+
+    ModalBottomSheet(
+        modifier = Modifier.fillMaxHeight(),
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
+        containerColor = MaterialTheme.colorScheme.surface,
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .fillMaxHeight()
+                    .padding(horizontal = 20.dp)
+                    .padding(bottom = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.spotify_login_title),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                text = stringResource(R.string.spotify_waiting_for_login),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            AndroidView(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .weight(1f)
+                        .clip(MaterialTheme.shapes.large),
+                factory = { context ->
+                    val container = FrameLayout(context)
+                    val spotifyWebView =
+                        WebView(context).apply {
+                            val cookieManager = CookieManager.getInstance()
+                            cookieManager.setAcceptCookie(true)
+                            cookieManager.setAcceptThirdPartyCookies(this, true)
+                            configureSpotifyLoginWebView()
+
+                            fun captureCookies(url: String?): Boolean {
+                                if (captured) return true
+                                val cookies = readSpotifyCookies(cookieManager, url)
+                                val spDc = cookies["sp_dc"].orEmpty()
+                                if (spDc.isBlank()) return false
+                                captured = true
+                                cookieManager.flush()
+                                onCookiesCaptured(spDc, cookies["sp_key"].orEmpty())
+                                return true
+                            }
+
+                            webViewClient =
+                                object : WebViewClient() {
+                                    override fun shouldOverrideUrlLoading(
+                                        view: WebView,
+                                        request: WebResourceRequest,
+                                    ): Boolean =
+                                        shouldOverrideSpotifyLoginUrl(
+                                            view = view,
+                                            url = request.url?.toString(),
+                                            captureCookies = { url -> captureCookies(url) },
+                                        )
+
+                                    @Deprecated("Deprecated in Java")
+                                    override fun shouldOverrideUrlLoading(
+                                        view: WebView,
+                                        url: String?,
+                                    ): Boolean =
+                                        shouldOverrideSpotifyLoginUrl(
+                                            view = view,
+                                            url = url,
+                                            captureCookies = { targetUrl -> captureCookies(targetUrl) },
+                                        )
+
+                                    override fun onPageStarted(
+                                        view: WebView,
+                                        url: String?,
+                                        favicon: android.graphics.Bitmap?,
+                                    ) {
+                                        captureCookies(url)
+                                    }
+
+                                    override fun onPageFinished(
+                                        view: WebView,
+                                        url: String?,
+                                    ) {
+                                        captureCookies(url)
+                                    }
+                                }
+                            webChromeClient =
+                                SpotifyLoginWebChromeClient(
+                                    container = container,
+                                    parentWebView = this,
+                                    captureCookies = { url -> captureCookies(url) },
+                                    onActiveWebViewChanged = { activeWebView -> webView = activeWebView },
+                                )
+                            webView = this
+                            mainWebView = this
+                            resetAuthWebViewSession(context, this) {
+                                loadUrl(SpotifyAuth.LOGIN_URL)
+                            }
+                        }
+                    container.addView(
+                        spotifyWebView,
+                        FrameLayout.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                        ),
+                    )
+                    container
+                },
+                update = {
+                    webView = webView ?: mainWebView
+                },
+            )
+        }
+    }
+}
+
+private fun WebView.destroySpotifyLoginWebView() {
+    stopLoading()
+    loadUrl("about:blank")
+    (parent as? ViewGroup)?.removeView(this)
+    destroy()
+}
+
+@SuppressLint("SetJavaScriptEnabled")
+private fun WebView.configureSpotifyLoginWebView() {
+    settings.apply {
+        javaScriptEnabled = true
+        domStorageEnabled = true
+        javaScriptCanOpenWindowsAutomatically = true
+        setSupportMultipleWindows(true)
+        setSupportZoom(true)
+        builtInZoomControls = true
+        displayZoomControls = false
+        mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
+        userAgentString = SpotifyLoginUserAgent
+    }
+}
+
+private class SpotifyLoginWebChromeClient(
+    private val container: FrameLayout,
+    private val parentWebView: WebView,
+    private val captureCookies: (String?) -> Boolean,
+    private val onActiveWebViewChanged: (WebView) -> Unit,
+) : WebChromeClient() {
+    override fun onCreateWindow(
+        view: WebView,
+        isDialog: Boolean,
+        isUserGesture: Boolean,
+        resultMsg: Message,
+    ): Boolean {
+        closePopupWebViews()
+
+        val popupWebView =
+            WebView(view.context).apply {
+                val cookieManager = CookieManager.getInstance()
+                cookieManager.setAcceptCookie(true)
+                cookieManager.setAcceptThirdPartyCookies(this, true)
+                configureSpotifyLoginWebView()
+                webViewClient =
+                    object : WebViewClient() {
+                        override fun shouldOverrideUrlLoading(
+                            view: WebView,
+                            request: WebResourceRequest,
+                        ): Boolean =
+                            shouldOverrideSpotifyLoginUrl(
+                                view = view,
+                                url = request.url?.toString(),
+                                captureCookies = captureCookies,
+                            )
+
+                        @Deprecated("Deprecated in Java")
+                        override fun shouldOverrideUrlLoading(
+                            view: WebView,
+                            url: String?,
+                        ): Boolean =
+                            shouldOverrideSpotifyLoginUrl(
+                                view = view,
+                                url = url,
+                                captureCookies = captureCookies,
+                            )
+
+                        override fun onPageStarted(
+                            view: WebView,
+                            url: String?,
+                            favicon: android.graphics.Bitmap?,
+                        ) {
+                            captureCookies(url)
+                        }
+
+                        override fun onPageFinished(
+                            view: WebView,
+                            url: String?,
+                        ) {
+                            captureCookies(url)
+                        }
+                    }
+            }
+
+        val transport = resultMsg.obj as? WebView.WebViewTransport ?: return false
+        container.addView(
+            popupWebView,
+            FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+            ),
+        )
+        popupWebView.bringToFront()
+        popupWebView.requestFocus()
+        onActiveWebViewChanged(popupWebView)
+        transport.webView = popupWebView
+        resultMsg.sendToTarget()
+        return true
+    }
+
+    override fun onCloseWindow(window: WebView) {
+        window.destroySpotifyLoginWebView()
+        onActiveWebViewChanged(parentWebView)
+    }
+
+    private fun closePopupWebViews() {
+        for (index in container.childCount - 1 downTo 0) {
+            val child = container.getChildAt(index) as? WebView ?: continue
+            if (child !== parentWebView) {
+                child.destroySpotifyLoginWebView()
+            }
+        }
+        onActiveWebViewChanged(parentWebView)
+    }
+}
+
+private fun shouldOverrideSpotifyLoginUrl(
+    view: WebView,
+    url: String?,
+    captureCookies: (String?) -> Boolean,
+): Boolean {
+    if (captureCookies(url)) return true
+
+    val targetUrl = url?.takeIf(String::isNotBlank) ?: return false
+    if (targetUrl.isWebViewLoadableUrl()) return false
+
+    targetUrl.intentBrowserFallbackUrl()?.let { fallbackUrl -> view.loadUrl(fallbackUrl) }
+    return true
+}
+
+private fun String.isWebViewLoadableUrl(): Boolean {
+    val scheme = runCatching { Uri.parse(this).scheme?.lowercase() }.getOrNull()
+    return scheme == "http" ||
+        scheme == "https" ||
+        scheme == "javascript" ||
+        scheme == "data" ||
+        scheme == "blob"
+}
+
+private fun String.intentBrowserFallbackUrl(): String? =
+    runCatching { Intent.parseUri(this, Intent.URI_INTENT_SCHEME) }
+        .getOrNull()
+        ?.getStringExtra("browser_fallback_url")
+        ?.takeIf { it.isWebViewLoadableUrl() }
+
+private fun readSpotifyCookies(
+    cookieManager: CookieManager,
+    currentUrl: String?,
+): Map<String, String> {
+    val urls =
+        linkedSetOf(
+            "https://open.spotify.com",
+            "https://accounts.spotify.com",
+            "https://spotify.com",
+        )
+    currentUrl?.toSpotifyCookieOrigin()?.let(urls::add)
+    val cookies = linkedMapOf<String, String>()
+    cookieManager.flush()
+    urls.forEach { url ->
+        cookieManager
+            .getCookie(url)
+            ?.split(";")
+            ?.map(String::trim)
+            ?.filter(String::isNotBlank)
+            ?.forEach { part ->
+                val separator = part.indexOf('=')
+                if (separator <= 0) return@forEach
+                val key = part.substring(0, separator).trim()
+                val value = part.substring(separator + 1).trim()
+                if (key.isNotBlank()) {
+                    cookies[key] = value
+                }
+            }
+    }
+    return cookies
+}
+
+private fun String.toSpotifyCookieOrigin(): String? {
+    val uri = runCatching { Uri.parse(this) }.getOrNull() ?: return null
+    val host = uri.host?.lowercase() ?: return null
+    if (host != "spotify.com" && !host.endsWith(".spotify.com")) return null
+    val scheme =
+        uri.scheme
+            ?.takeIf { it.equals("https", ignoreCase = true) || it.equals("http", ignoreCase = true) }
+            ?: "https"
+    return "$scheme://$host"
+}
+
+@Composable
+private fun SpotifyErrorDialog(
+    message: String,
+    onDismiss: () -> Unit,
+) {
+    DefaultDialog(
+        onDismiss = onDismiss,
+        title = { Text(stringResource(R.string.import_failed)) },
+        buttons = {
+            TextButton(onClick = onDismiss, shapes = ButtonDefaults.shapes()) {
+                Text(stringResource(android.R.string.ok))
+            }
+        },
+    ) {
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
 }

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/IntegrationScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/IntegrationScreen.kt
@@ -76,6 +76,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource


### PR DESCRIPTION
Spotify is an account integration, exactly like Last.fm, ListenBrainz and Discord — but it lived under **Backup & Restore**, so connecting your Spotify account meant opening the backup screen and scrolling past backup schedules.

This moves it to the Integration screen, under its own *External service* group below the scrobbling entries:

- `IntegrationScreen.kt` gains the Spotify account entry, the cookie login sheet, the error dialog and the WebView login plumbing (moved as-is, ~500 lines)
- `BackupAndRestore.kt` drops all of it and the Spotify-only state, and prunes the imports that went with it
- settings search already listed Spotify under *Integration*, so search results now land where the entry actually is

Pure code move, no behaviour change.