### PR TITLE
feat: moving blur lyrics background, GPU blurred on Android 12+

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/constants/PreferenceKeys.kt
@@ -718,7 +718,8 @@ enum class LyricsBackgroundStyle {
     DEFAULT,
     FOLLOW_THEME,
     COLORING,
-    CUSTOM;
+    CUSTOM,
+    MOVING_BLUR;
 
     fun resolveFor(playerBackgroundStyle: PlayerBackgroundStyle): LyricsBackgroundStyle =
         when {
@@ -768,6 +769,9 @@ val HistoryDuration = intPreferencesKey("historyDuration")
 val PlayerButtonsStyleKey = stringPreferencesKey("player_buttons_style")
 val PlayerBackgroundStyleKey = stringPreferencesKey("playerBackgroundStyle")
 val LyricsBackgroundStyleKey = stringPreferencesKey("lyricsBackgroundStyle")
+// Android 12+ only. When off, the moving blur falls back to the pre-blurred bitmap
+// that Android 11 and below always use.
+val UseGpuBlurKey = booleanPreferencesKey("useGpuBlur")
 val ShowLyricsKey = booleanPreferencesKey("showLyrics")
 val LyricsTextPositionKey = stringPreferencesKey("lyricsTextPosition")
 val LyricsClickKey = booleanPreferencesKey("lyricsClick")

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -57,8 +58,18 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.ui.graphics.BlurEffect
+import androidx.compose.ui.graphics.RenderEffect
+import androidx.compose.ui.graphics.TileMode
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
@@ -80,6 +91,7 @@ import androidx.media3.common.Player.STATE_BUFFERING
 import androidx.media3.common.Player.STATE_READY
 import androidx.navigation.NavController
 import androidx.palette.graphics.Palette
+import android.os.Build
 import coil3.compose.AsyncImage
 import coil3.imageLoader
 import coil3.request.ImageRequest
@@ -100,6 +112,7 @@ import dev.citali.lunartune.constants.DisableBlurKey
 import dev.citali.lunartune.constants.EnableHapticFeedbackKey
 import dev.citali.lunartune.constants.LyricsBackgroundStyle
 import dev.citali.lunartune.constants.LyricsBackgroundStyleKey
+import dev.citali.lunartune.constants.UseGpuBlurKey
 import dev.citali.lunartune.constants.LyricsMode
 import dev.citali.lunartune.constants.LyricsModeKey
 import dev.citali.lunartune.constants.PlayerBackgroundStyle
@@ -166,6 +179,7 @@ fun LyricsScreen(
     val configuredLyricsBackground by rememberEnumPreference(LyricsBackgroundStyleKey, LyricsBackgroundStyle.DEFAULT)
     val lyricsBackground = configuredLyricsBackground.resolveFor(playerBackground)
     val disableBlur by rememberPreference(DisableBlurKey, false)
+    val useGpuBlur by rememberPreference(UseGpuBlurKey, true)
     val blurRadius by rememberPreference(BlurRadiusKey, 48f)
     val playerCustomImageUri by rememberPreference(PlayerCustomImageUriKey, "")
     val playerCustomBlur by rememberPreference(PlayerCustomBlurKey, 0f)
@@ -344,6 +358,7 @@ fun LyricsScreen(
             mediaMetadata = mediaMetadata,
             gradientColors = gradientColors,
             disableBlur = disableBlur,
+            useGpuBlur = useGpuBlur,
             blurRadius = blurRadius,
             playerCustomImageUri = playerCustomImageUri,
             playerCustomBlur = playerCustomBlur,
@@ -495,6 +510,7 @@ private fun LyricsScreenBackground(
     mediaMetadata: MediaMetadata,
     gradientColors: List<Color>,
     disableBlur: Boolean,
+    useGpuBlur: Boolean,
     blurRadius: Float,
     playerCustomImageUri: String,
     playerCustomBlur: Float,
@@ -523,6 +539,15 @@ private fun LyricsScreenBackground(
             }
 
             LyricsBackgroundStyle.FOLLOW_THEME -> Unit
+
+            LyricsBackgroundStyle.MOVING_BLUR -> {
+                MovingBlurBackground(
+                    mediaMetadata = mediaMetadata,
+                    useGpuBlur = useGpuBlur,
+                    blurRadius = blurRadius,
+                    disableBlur = disableBlur,
+                )
+            }
 
             LyricsBackgroundStyle.COLORING,
             LyricsBackgroundStyle.CUSTOM,
@@ -594,6 +619,135 @@ private fun AppleMusicBackground(
         )
     }
 }
+
+@Composable
+private fun MovingBlurBackground(
+    mediaMetadata: MediaMetadata,
+    useGpuBlur: Boolean,
+    blurRadius: Float,
+    disableBlur: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val thumbnailUrl = mediaMetadata.thumbnailUrl
+    val cacheRevision by LyricsArtBlurCache.updates.collectAsState()
+    val blurredArt =
+        remember(thumbnailUrl, cacheRevision) {
+            LyricsArtBlurCache.peek(thumbnailUrl)
+        }
+
+    LaunchedEffect(thumbnailUrl) {
+        LyricsArtBlurCache.prefetch(context, thumbnailUrl)
+    }
+
+    // RenderEffect is Android 12+. Below that — or with the toggle off — the
+    // pre-blurred bitmap is used and only its position animates.
+    val gpuBlurAvailable =
+        useGpuBlur &&
+            !disableBlur &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+            RenderEffect.isSupported
+    val blurEffect =
+        remember(gpuBlurAvailable, blurRadius) {
+            if (!gpuBlurAvailable) {
+                null
+            } else {
+                val radius = blurRadius.coerceIn(MOVING_BLUR_MIN_RADIUS, MOVING_BLUR_MAX_RADIUS)
+                BlurEffect(radius, radius, TileMode.Clamp).takeIf(RenderEffect::isSupported)
+            }
+        }
+    val gpuRequest =
+        remember(context, thumbnailUrl) {
+            thumbnailUrl?.let { url ->
+                ImageRequest
+                    .Builder(context)
+                    .data(url)
+                    // The blur hides the missing detail, so a small decode keeps
+                    // the per frame GPU cost down.
+                    .size(MOVING_BLUR_ART_PX)
+                    .build()
+            }
+        }
+
+    // Two different periods on the axes keep the drift from looking like a loop.
+    val drift = rememberInfiniteTransition(label = "movingBlur")
+    val driftX by drift.animateFloat(
+        initialValue = -1f,
+        targetValue = 1f,
+        animationSpec =
+            infiniteRepeatable(
+                animation = tween(MOVING_BLUR_DRIFT_MS, easing = LinearEasing),
+                repeatMode = RepeatMode.Reverse,
+            ),
+        label = "driftX",
+    )
+    val driftY by drift.animateFloat(
+        initialValue = -1f,
+        targetValue = 1f,
+        animationSpec =
+            infiniteRepeatable(
+                animation = tween(MOVING_BLUR_DRIFT_MS * 4 / 3, easing = LinearEasing),
+                repeatMode = RepeatMode.Reverse,
+            ),
+        label = "driftY",
+    )
+
+    Box(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .background(Color.Black),
+    ) {
+        val driftModifier =
+            Modifier
+                .fillMaxSize()
+                .offset {
+                    IntOffset(
+                        x = (driftX * MOVING_BLUR_DRIFT_DP).dp.roundToPx(),
+                        y = (driftY * MOVING_BLUR_DRIFT_DP * 0.7f).dp.roundToPx(),
+                    )
+                }
+
+        if (blurEffect != null && gpuRequest != null) {
+            AsyncImage(
+                model = gpuRequest,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier =
+                    driftModifier.graphicsLayer {
+                        scaleX = MOVING_BLUR_SCALE
+                        scaleY = MOVING_BLUR_SCALE
+                        renderEffect = blurEffect
+                    },
+            )
+        } else if (blurredArt != null) {
+            Image(
+                bitmap = blurredArt.asImageBitmap(),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier =
+                    driftModifier.graphicsLayer {
+                        scaleX = MOVING_BLUR_SCALE
+                        scaleY = MOVING_BLUR_SCALE
+                    },
+            )
+        }
+
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.52f)),
+        )
+    }
+}
+
+private const val MOVING_BLUR_ART_PX = 256
+private const val MOVING_BLUR_SCALE = 1.35f
+private const val MOVING_BLUR_DRIFT_DP = 26f
+private const val MOVING_BLUR_DRIFT_MS = 26_000
+private const val MOVING_BLUR_MIN_RADIUS = 8f
+private const val MOVING_BLUR_MAX_RADIUS = 32f
 
 @Composable
 private fun AppleMusicGrabber(

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
@@ -645,8 +645,7 @@ private fun MovingBlurBackground(
     val gpuBlurAvailable =
         useGpuBlur &&
             !disableBlur &&
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
-            RenderEffect.isSupported
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
     val blurEffect =
         remember(gpuBlurAvailable, blurRadius) {
             if (!gpuBlurAvailable) {

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/AppearanceSettings.kt
@@ -95,6 +95,7 @@ import dev.citali.lunartune.constants.LibraryChipOrderKey
 import dev.citali.lunartune.constants.LibraryFilter
 import dev.citali.lunartune.constants.LyricsBackgroundStyle
 import dev.citali.lunartune.constants.LyricsBackgroundStyleKey
+import dev.citali.lunartune.constants.UseGpuBlurKey
 import dev.citali.lunartune.constants.MiniPlayerBackgroundStyle
 import dev.citali.lunartune.constants.MiniPlayerBackgroundStyleKey
 import dev.citali.lunartune.constants.PlayerBackgroundStyle
@@ -228,6 +229,7 @@ fun AppearanceSettings(navController: NavController) {
             defaultValue = true,
         )
     val (blurRadius, onBlurRadiusChange) = rememberPreference(BlurRadiusKey, defaultValue = 48f)
+    val (useGpuBlur, onUseGpuBlurChange) = rememberPreference(UseGpuBlurKey, defaultValue = true)
     val (backdropEnabled, onBackdropEnabledChange) = rememberPreference(BackdropEnabledKey, defaultValue = true)
     val (backdropBlurAmount, onBackdropBlurAmountChange) = rememberPreference(BackdropBlurAmountKey, defaultValue = 60)
     val (fontPreference, onFontPreferenceChange) =
@@ -376,6 +378,7 @@ fun AppearanceSettings(navController: NavController) {
                 LyricsBackgroundStyle.DEFAULT,
                 LyricsBackgroundStyle.FOLLOW_THEME,
                 LyricsBackgroundStyle.COLORING,
+                LyricsBackgroundStyle.MOVING_BLUR,
             )
         }
     val lyricsBackground = configuredLyricsBackground.resolveFor(playerBackground)
@@ -634,6 +637,17 @@ fun AppearanceSettings(navController: NavController) {
                 }
 
                 item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.use_gpu_blur)) },
+                        description = stringResource(R.string.use_gpu_blur_desc),
+                        icon = { Icon(painterResource(R.drawable.blur_on), null) },
+                        checked = useGpuBlur,
+                        onCheckedChange = onUseGpuBlurChange,
+                        isEnabled = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S,
+                    )
+                }
+
+                item {
                     PreferenceEntry(
                         title = { Text(stringResource(R.string.blur_intensity)) },
                         description = stringResource(R.string.blur_intensity_value, blurRadius.roundToInt()),
@@ -811,6 +825,7 @@ fun AppearanceSettings(navController: NavController) {
                                 LyricsBackgroundStyle.FOLLOW_THEME -> stringResource(R.string.follow_theme)
                                 LyricsBackgroundStyle.COLORING -> stringResource(R.string.coloring)
                                 LyricsBackgroundStyle.CUSTOM -> stringResource(R.string.custom)
+                                LyricsBackgroundStyle.MOVING_BLUR -> stringResource(R.string.lyrics_background_moving_blur)
                             }
                         },
                     )

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/SettingsDataBuilders.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/SettingsDataBuilders.kt
@@ -70,6 +70,7 @@ import dev.citali.lunartune.constants.SwipeToSongKey
 import dev.citali.lunartune.constants.TranslateLyricsKey
 import dev.citali.lunartune.constants.UseLyricsV2Key
 import dev.citali.lunartune.constants.UseSystemFontKey
+import dev.citali.lunartune.constants.UseGpuBlurKey
 import dev.citali.lunartune.constants.WakelockKey
 import dev.citali.lunartune.utils.rememberPreference
 
@@ -77,11 +78,13 @@ import dev.citali.lunartune.utils.rememberPreference
 private fun SearchResultSwitch(
     key: androidx.datastore.preferences.core.Preferences.Key<Boolean>,
     defaultValue: Boolean,
+    enabled: Boolean = true,
 ) {
     val (checked, onCheckedChange) = rememberPreference(key, defaultValue)
     Switch(
         checked = checked,
         onCheckedChange = onCheckedChange,
+        enabled = enabled,
     )
 }
 
@@ -138,6 +141,7 @@ fun buildSettingsGroups(
                 SettingsChild("App icon", "app_icon", listOf("icon", "app icon", "icon pack", "launcher icon")),
                 SettingsChild("Disable blur", "disable_blur", listOf("blur", "disable blur", "no blur", "performance")) { SearchResultSwitch(DisableBlurKey, false) },
                 SettingsChild("Blur intensity", "blur_intensity", listOf("blur intensity", "blur amount", "blur level", "blur radius")),
+                SettingsChild("Use GPU blur", "use_gpu_blur", listOf("gpu blur", "hardware blur", "render effect", "blur")) { SearchResultSwitch(UseGpuBlurKey, true, enabled = isAndroid12OrLater) },
                 SettingsChild("Backdrop blur", "backdrop_blur", listOf("backdrop", "backdrop blur", "background blur", "frosted")) { SearchResultSwitch(BackdropEnabledKey, false) },
                 SettingsChild("Font preference", "font_preference", listOf("font", "font style", "typography")),
                 SettingsChild("Use system font", "use_system_font", listOf("system font", "default font", "roboto")) { SearchResultSwitch(UseSystemFontKey, false) },
@@ -145,7 +149,7 @@ fun buildSettingsGroups(
                 SettingsChild("Crop thumbnail to square", "crop_thumbnail_to_square", listOf("crop thumbnail", "square thumbnail", "thumbnail crop")) { SearchResultSwitch(CropThumbnailToSquareKey, false) },
                 SettingsChild("Player design style", "player_design_style", listOf("player design", "player layout", "player style")),
                 SettingsChild("Player background style", "player_background_style", listOf("player background", "player bg", "background style")),
-                SettingsChild("Lyrics background style", "lyrics_background_style", listOf("lyrics background", "lyrics bg")),
+                SettingsChild("Lyrics background style", "lyrics_background_style", listOf("lyrics background", "lyrics bg", "moving blur", "blur lyrics")),
                 SettingsChild("Mini player background style", "mini_player_background_style", listOf("mini player", "mini player background")),
                 SettingsChild("Player buttons style", "player_buttons_style", listOf("player buttons", "button style", "controls style")),
                 SettingsChild("Player slider style", "player_slider_style", listOf("player slider", "slider style", "progress bar")),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1136,5 +1136,8 @@
     <string name="navigation_bar_corner_radius">Corner radius</string>
     <string name="navigation_bar_corner_radius_desc">Roundedness of the bar corners (dp)</string>
     <string name="navigation_bar_reset_dimensions">Reset dimensions to default</string>
+    <!-- Moving blur lyrics background -->
+    <string name="lyrics_background_moving_blur">Moving blur</string>
+    <string name="use_gpu_blur">Use GPU blur</string>
+    <string name="use_gpu_blur_desc">Blur the moving lyrics background on the GPU instead of reusing a pre-blurred image. Android 12 and above only.</string>
 </resources>
-


### PR DESCRIPTION
New lyrics page background style, **Moving blur**: the cover art drifts slowly behind the lyrics instead of sitting still.

### Two blur paths, one look

- **Android 12+** — the art is blurred with a `RenderEffect` on the GPU, so the blur is re-applied every frame and stays correct while the image moves. The artwork is decoded at **256px**; the blur hides the missing detail and it keeps the per-frame cost down.
- **Android 11 and below** — no `RenderEffect` exists there, so it reuses the **pre-blurred bitmap from `LyricsArtBlurCache`** and only animates its position. That is exactly the approach the existing Apple Music lyrics style already uses, so the fallback look is already familiar.

### The movement

Two axes with **different periods** (26s and ~34.7s, reversing) so the drift never reads as an obvious loop, over a 1.35× upscale and 26dp of travel — enough to feel alive, small enough that the blur hides the edges. The offset is applied with the **layout-phase `Modifier.offset { }`**, so the animation never triggers composition — only placement and draw.

### Use GPU blur toggle

Appearance → **Use GPU blur**, next to blur intensity:

- **greyed out on Android 11 and below** (nothing to toggle, `RenderEffect` doesn't exist)
- **on** (default) on Android 12+: GPU `RenderEffect`
- **off** on Android 12+: falls back to the pre-blurred bitmap, i.e. the Android 11 path

It also respects the global **Disable blur** setting — with blur disabled the GPU path is skipped. **Blur intensity** drives the GPU radius, clamped to 8–32.

### Bits around it

- `SearchResultSwitch` gained an `enabled` flag so the search result switch can be greyed out the same way the settings one is
- settings search finds the new controls via "gpu blur", "moving blur", "hardware blur"

### Testing

CI only assembles and lints, so this needs a device: open the lyrics page with the new style, then flip **Use GPU blur** off and on and compare — the GPU one should look smoother as it moves, the CPU one slightly softer. Check frame pacing on an older Android 12+ phone, and confirm the toggle is visibly disabled on an Android 11 device.

The whole effect lives in one composable (`MovingBlurBackground`), so if it behaves, lifting it into the player background is a matter of reusing it there.