### PR TITLE
feat: crossfade the lyrics backdrop between tracks

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/BlurWanderDrift.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/BlurWanderDrift.kt
@@ -1,0 +1,301 @@
+/*
+ * LunarTune (2026)
+ * © cognitiveshadows03 — github.com/cognitiveshadows03
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ *
+ * The random-walk drift and the footprint maths below are adapted from
+ * 4nx3b/ArchiveTune (GPL-3.0, © Rukamori and contributors — github.com/4nx3b/ArchiveTune),
+ * which solved the two problems this file exists for: a periodic path turns
+ * around at full speed, and a rotating rectangle only covers its inscribed
+ * circle. Kept under GPL-3.0 with the original notices intact.
+ */
+
+package dev.citali.lunartune.ui.player
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.FloatState
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.isActive
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.hypot
+import kotlin.math.max
+import kotlin.math.sin
+import kotlin.random.Random
+
+/**
+ * Drift for the heavily blurred artwork behind lyrics, shared by every surface that draws a
+ * moving-blur backdrop so they move identically.
+ *
+ * ### Why a random walk and not a formula
+ *
+ * The obvious version is a pair of `RepeatMode.Reverse` tweens: the artwork sweeps to one
+ * extreme and turns around at full speed, which reads as the colours whipping back. A Lissajous
+ * path (two sines per axis off one ever-advancing phase) removes the hard turnaround but not the
+ * underlying problem — a closed periodic path still spends half its cycle travelling back the way
+ * it came, so the colours are still seen "suddenly travelling in the opposite direction", just
+ * more smoothly.
+ *
+ * This drives the drift as a walk between random waypoints instead:
+ *
+ *  * each leg carries the artwork from where it currently rests to a new waypoint drawn at
+ *    random inside a disc of [WanderRadiusDp],
+ *  * each leg also turns the artwork by a random angle — see [rotationDeg],
+ *  * the interpolation is a raised cosine, so speed starts and ends at zero — the artwork
+ *    *finishes its path*, settles, and only then sets off again, which means no reversal ever
+ *    happens while it is moving,
+ *  * the next waypoint is at least [MinTurnRadians] away in angle from the leg that just
+ *    finished, so the colours visibly head off in a genuinely different direction rather than
+ *    retracing the previous path,
+ *  * legs are timed off their own length at a constant [WanderSpeedDpPerSecond], so a long leg
+ *    doesn't race and a short one doesn't crawl.
+ *
+ * The walk starts at the centre, so the first frame after the backdrop appears has zero offset
+ * and the drift grows out of nothing.
+ *
+ * ### Why translation alone was not enough
+ *
+ * Translating the backdrop moves every colour by the *same* vector, so their arrangement is
+ * rigid: whatever sits in the top third of the artwork stays in the top third of the screen,
+ * free to shuffle by at most [WanderRadiusDp]. That is why some colours "only spread at the top
+ * and never reach the bottom" however long you watch. No amount of panning can carry them there;
+ * it was never a matter of tuning the path.
+ *
+ * [rotationDeg] is what breaks the rigidity. Turning the artwork about its centre sweeps a colour
+ * from one edge to the opposite one over half a turn. Rotation walks per leg like the offsets do,
+ * rather than spinning at a constant rate, which keeps the same "settle, then set off again"
+ * character and stops it reading as a turntable.
+ *
+ * ### Bounds
+ *
+ * [WanderRadiusDp] is the largest offset this can ever produce, and callers rely on that: the
+ * blurred artwork is drawn scaled up so that it still covers the screen at maximum offset. See
+ * [blurBackdropFootprint], which is what callers use to size the layer.
+ *
+ * ### Threading / recomposition
+ *
+ * [xDp], [yDp] and [rotationDeg] are [FloatState]s meant to be read **only** from draw-phase
+ * lambdas (`Modifier.graphicsLayer { }`). Reading them during composition would invalidate the
+ * whole subtree on every animation frame. Applying them through `graphicsLayer` rather than
+ * `Modifier.offset` is what lets this run on Android 11 and below as well: a canvas transform
+ * costs one matrix multiply per frame, where a layout-phase offset re-measures and re-places the
+ * backdrop 60 times a second and tears on older devices.
+ */
+internal class BlurWanderDrift(
+    private val random: Random = Random.Default,
+) {
+    private val xState = mutableFloatStateOf(0f)
+    private val yState = mutableFloatStateOf(0f)
+    private val rotationState = mutableFloatStateOf(0f)
+
+    /** Horizontal offset in dp, in `-WanderRadiusDp..WanderRadiusDp`. */
+    val xDp: FloatState get() = xState
+
+    /** Vertical offset in dp, in `-WanderRadiusDp..WanderRadiusDp`. */
+    val yDp: FloatState get() = yState
+
+    /**
+     * Rotation of the backdrop about its own centre, in degrees.
+     *
+     * Unbounded on purpose. It is an angle, so it wraps for free, and letting it accumulate is
+     * what lets a colour keep travelling the same way past a half-turn instead of being tugged
+     * back toward a nominal zero.
+     */
+    val rotationDeg: FloatState get() = rotationState
+
+    private var fromX = 0f
+    private var fromY = 0f
+    private var toX = 0f
+    private var toY = 0f
+    private var fromRotation = 0f
+    private var toRotation = 0f
+    private var legAngle = random.nextFloat() * TwoPi
+    private var legDurationMs = 0f
+    private var legElapsedMs = 0f
+
+    init {
+        startNextLeg()
+    }
+
+    /**
+     * Advances the walk by [deltaMs] of wall time. Legs roll over inside the same call, so a
+     * dropped frame is caught up rather than skipped.
+     */
+    fun advance(deltaMs: Float) {
+        if (deltaMs <= 0f) return
+        legElapsedMs += deltaMs
+        while (legElapsedMs >= legDurationMs) {
+            legElapsedMs -= legDurationMs
+            startNextLeg()
+        }
+        // Raised cosine: zero velocity at both ends of the leg.
+        val t = legElapsedMs / legDurationMs
+        val eased = 0.5f - 0.5f * cos(PI.toFloat() * t)
+        xState.floatValue = fromX + (toX - fromX) * eased
+        yState.floatValue = fromY + (toY - fromY) * eased
+        rotationState.floatValue = fromRotation + (toRotation - fromRotation) * eased
+    }
+
+    private fun startNextLeg() {
+        fromX = toX
+        fromY = toY
+        fromRotation = toRotation
+        // Turn by at least MinTurnRadians so the new leg is never a retread of the one that ended.
+        val turn = MinTurnRadians + random.nextFloat() * (TwoPi - 2f * MinTurnRadians)
+        legAngle = (legAngle + turn) % TwoPi
+        // Waypoints sit in the outer half of the disc: the backdrop reads as more alive when the
+        // colours actually reach the edges.
+        val radius = WanderRadiusDp * (MinRadiusFraction + random.nextFloat() * (1f - MinRadiusFraction))
+        toX = cos(legAngle) * radius
+        // No vertical squash. Shaving the vertical amplitude worked directly against the symptom
+        // rotation is here to fix, by making the axis that already struggled to reach the bottom
+        // of the screen the shorter of the two.
+        toY = sin(legAngle) * radius
+        // Rotation direction is drawn per leg rather than taken from the leg's own angle: tying
+        // the two together would make the backdrop appear to roll along its path, which reads as
+        // a mechanism instead of as drifting colour.
+        val rotationSign = if (random.nextBoolean()) 1f else -1f
+        val rotationSpan =
+            MinLegRotationDegrees + random.nextFloat() * (MaxLegRotationDegrees - MinLegRotationDegrees)
+        toRotation = fromRotation + rotationSign * rotationSpan
+        val distance = hypot(toX - fromX, toY - fromY)
+        legDurationMs =
+            (distance / WanderSpeedDpPerSecond * 1000f)
+                .coerceIn(MinLegDurationMs, MaxLegDurationMs)
+    }
+
+    internal companion object {
+        /**
+         * Largest offset the walk can ever produce, in dp.
+         *
+         * Rotation supplies far more travel than translation alone ever did, and measures its
+         * covering budget to the container's corner rather than its edge, so trading a little pan
+         * for the headroom is the better deal.
+         */
+        const val WanderRadiusDp = 120f
+
+        /** Average travel speed. Deliberately slow — this sits behind lyrics. */
+        private const val WanderSpeedDpPerSecond = 26f
+
+        private const val MinLegDurationMs = 6_000f
+        private const val MaxLegDurationMs = 18_000f
+
+        /**
+         * Degrees of rotation one leg may add. Against the ~12s median leg that is roughly 3°/s,
+         * so a colour crosses the screen — half a turn — in about a minute: ambient, rather than
+         * something you notice while reading lyrics.
+         */
+        private const val MinLegRotationDegrees = 18f
+        private const val MaxLegRotationDegrees = 55f
+
+        /** Waypoints are never closer to the centre than this fraction of the radius. */
+        private const val MinRadiusFraction = 0.5f
+
+        /** ~72°: enough that a new leg is unmistakably a new direction. */
+        private const val MinTurnRadians = 1.25f
+
+        private const val TwoPi = (2.0 * PI).toFloat()
+    }
+}
+
+/**
+ * Footprint the blurred backdrop layer has to occupy so that [BlurWanderDrift]'s rotation can
+ * never swing one of the layer's own corners into view.
+ *
+ * ### Why the layer cannot simply be the container
+ *
+ * The backdrop is built as `Modifier.graphicsLayer { scale / translate / rotate }.blur(radius)`:
+ * the blur is applied to the still, centred artwork and the drift transform is applied to the
+ * blurred result. `Modifier.blur`'s default `BlurredEdgeTreatment.Rectangle` clips the layer it
+ * creates to the composable's bounds, so the blurred result is an opaque rectangle of **exactly
+ * the composable's bounds**.
+ *
+ * A rectangle rotated by an arbitrary angle only reliably covers its own inscribed circle, whose
+ * radius comes from the rectangle's *short* side. With the layer sized to the container that is
+ * `scale * min(W, H) / 2` — 432dp on a 360x800 phone at 2.4x — while the point that has to stay
+ * covered is the container's furthest corner plus the drift, `hypot(W, H) / 2 + WanderRadiusDp` =
+ * 559dp. The shortfall is not theoretical: it is a near-black wedge sweeping through a corner of
+ * the backdrop in time with the rotation, and it is there even at zero drift.
+ *
+ * ### What this returns
+ *
+ * A footprint whose *shorter* side is long enough that the inscribed circle reaches that corner.
+ * Only the short side grows: `max(width, height)` comes out unchanged in every real window shape,
+ * and because `ContentScale.Crop` of a square artwork renders it at side `max(w, h)`, the artwork
+ * is still rasterised at exactly the same scale and the backdrop looks identical. The extra area
+ * exists purely for the rotation to swing into.
+ *
+ * If the cost ever needs to come down, the lever is resolution rather than footprint: halving the
+ * footprint while doubling the caller's scales and halving its blur radius is pixel-identical (the
+ * on-screen blur is `radius * scale`, the visible window is `containerSide / scale` of an artwork
+ * drawn at `max(footprint)`, and the coverage product `scale * footprint` is unchanged) at a
+ * quarter of the pixels.
+ *
+ * @param restScale the scale the layer sits at while it carries no drift and no rotation (equal to
+ *   [driftScale] for surfaces that never ramp).
+ * @param driftScale the scale the layer reaches once it carries the full drift and rotation.
+ * @param maxDriftDp the largest translation the walk can produce, i.e. [BlurWanderDrift.WanderRadiusDp].
+ */
+internal fun blurBackdropFootprint(
+    width: Dp,
+    height: Dp,
+    restScale: Float,
+    driftScale: Float,
+    maxDriftDp: Float = BlurWanderDrift.WanderRadiusDp,
+): DpSize {
+    val w = width.value
+    val h = height.value
+    if (w <= 0f || h <= 0f || restScale <= 0f || driftScale <= 0f) return DpSize(width, height)
+
+    val corner = hypot(w, h) / 2f
+    // Callers ramp scale, translation and rotation off one progress value, so the requirement
+    // along the ramp is `2 * (corner + drift * p) / (restScale + (driftScale - restScale) * p)`.
+    // That is a Mobius function of p, so it has no interior extremum and the worst case is an
+    // endpoint: either resting (no drift, but the smallest scale) or fully drifting (largest
+    // scale, but the corner has moved out by the whole wander radius).
+    val requiredAtRest = 2f * corner / restScale
+    val requiredAtFullDrift = 2f * (corner + maxDriftDp) / driftScale
+    val required = max(requiredAtRest, requiredAtFullDrift) * BlurBackdropCoverSafety
+
+    return DpSize(max(w, required).dp, max(h, required).dp)
+}
+
+/**
+ * A little headroom on [blurBackdropFootprint]'s result. The derivation is exact, so this only
+ * absorbs rounding between the dp maths here and the pixel maths the layer is actually rasterised
+ * with — 2% is a couple of dp on a phone.
+ */
+private const val BlurBackdropCoverSafety = 1.02f
+
+/**
+ * Remembers a [BlurWanderDrift] and advances it from the frame clock while [active].
+ *
+ * The loop is gated because it is the only thing keeping the frame clock busy: an
+ * `InfiniteTransition` (what this replaces) keeps asking for a frame every ~16ms for as long as it
+ * is composed, even when nothing reads its value. When [active] goes false the walk freezes where
+ * it is and resumes from there, so closing and reopening lyrics doesn't restart the path.
+ */
+@Composable
+internal fun rememberBlurWanderDrift(active: Boolean): BlurWanderDrift {
+    val drift = remember { BlurWanderDrift() }
+    LaunchedEffect(active) {
+        if (!active) return@LaunchedEffect
+        var lastFrameNanos = 0L
+        while (isActive) {
+            withFrameNanos { frameTimeNanos ->
+                if (lastFrameNanos != 0L) {
+                    drift.advance((frameTimeNanos - lastFrameNanos) / 1_000_000f)
+                }
+                lastFrameNanos = frameTimeNanos
+            }
+        }
+    }
+    return drift
+}

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
@@ -55,6 +56,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
@@ -67,7 +69,6 @@ import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.layout.requiredSize
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -785,6 +786,15 @@ private fun MovingBlurBackground(
                         }
                         .alpha(MOVING_BLUR_ALPHA)
 
+                // Blur only when there is something to blur: a zero radius is not a no-op at the
+                // RenderEffect level, it is an invalid argument.
+                val blurModifier =
+                    if (blurRadius > 0.5f) {
+                        Modifier.blur((blurRadius * MOVING_BLUR_BLUR_GAIN / MOVING_BLUR_SCALE).dp)
+                    } else {
+                        Modifier
+                    }
+
                 AsyncImage(
                     model = gpuRequest,
                     contentDescription = null,
@@ -793,14 +803,7 @@ private fun MovingBlurBackground(
                     // blur INSIDE the transform: the artwork is blurred while it is still centred
                     // and only then moved, so the blur never samples the transparent area behind
                     // the layer's trailing edge.
-                    modifier =
-                        driftModifier.then(
-                            if (blurRadius > 0.5f) {
-                                Modifier.blur((blurRadius * MOVING_BLUR_BLUR_GAIN / MOVING_BLUR_SCALE).dp)
-                            } else {
-                                Modifier
-                            },
-                        ),
+                    modifier = driftModifier.then(blurModifier),
                 )
             }
         } else if (blurredArt != null) {

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
@@ -18,13 +18,13 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -57,21 +57,17 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
-import androidx.compose.ui.graphics.BlurEffect
-import androidx.compose.ui.graphics.RenderEffect
-import androidx.compose.ui.graphics.TileMode
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ColorMatrix
+import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.requiredSize
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -543,6 +539,7 @@ private fun LyricsScreenBackground(
             LyricsBackgroundStyle.MOVING_BLUR -> {
                 MovingBlurBackground(
                     mediaMetadata = mediaMetadata,
+                    gradientColors = gradientColors,
                     useGpuBlur = useGpuBlur,
                     blurRadius = blurRadius,
                     disableBlur = disableBlur,
@@ -579,6 +576,27 @@ private fun AppleMusicBackground(
     gradientColors: List<Color>,
     modifier: Modifier = Modifier,
 ) {
+    val colors = if (gradientColors.isNotEmpty()) gradientColors else AppleMusicFallbackGradient
+    val backgroundBrush =
+        remember(colors) {
+            Brush.verticalGradient(
+                listOf(
+                    colors.getOrElse(0) { AppleMusicFallbackGradient[0] }.copy(alpha = 0.88f),
+                    colors.getOrElse(1) { AppleMusicFallbackGradient[1] }.copy(alpha = 0.76f),
+                    colors.getOrElse(2) { AppleMusicFallbackGradient[2] }.copy(alpha = 0.96f),
+                ),
+            )
+        }
+    val bottomScrim =
+        remember {
+            Brush.verticalGradient(
+                listOf(
+                    Color.Transparent,
+                    Color.Black.copy(alpha = 0.28f),
+                ),
+            )
+        }
+
     val context = LocalContext.current
     val thumbnailUrl = mediaMetadata.thumbnailUrl
     val cacheRevision by LyricsArtBlurCache.updates.collectAsState()
@@ -591,11 +609,13 @@ private fun AppleMusicBackground(
         LyricsArtBlurCache.prefetch(context, thumbnailUrl)
     }
 
+    // The blurred cover sits under the track's own palette rather than under a flat black scrim,
+    // which is what makes this read as an Apple Music backdrop instead of a dimmed thumbnail.
     Box(
         modifier =
             modifier
                 .fillMaxSize()
-                .background(Color.Black),
+                .background(AppleMusicFallbackGradient.last()),
     ) {
         if (blurredArt != null) {
             Image(
@@ -606,28 +626,90 @@ private fun AppleMusicBackground(
                     Modifier
                         .fillMaxSize()
                         .graphicsLayer {
-                            scaleX = 1.12f
-                            scaleY = 1.12f
-                        },
+                            scaleX = AppleMusicBackdropScale
+                            scaleY = AppleMusicBackdropScale
+                        }
+                        .alpha(0.62f),
             )
         }
         Box(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.52f)),
+                    .background(backgroundBrush),
+        )
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.18f)),
+        )
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(bottomScrim),
         )
     }
 }
 
+private const val AppleMusicBackdropScale = 1.12f
+
 @Composable
 private fun MovingBlurBackground(
     mediaMetadata: MediaMetadata,
+    gradientColors: List<Color>,
     useGpuBlur: Boolean,
     blurRadius: Float,
     disableBlur: Boolean,
     modifier: Modifier = Modifier,
 ) {
+    val colors = if (gradientColors.isNotEmpty()) gradientColors else AppleMusicFallbackGradient
+    val backgroundBrush =
+        remember(colors) {
+            Brush.verticalGradient(
+                listOf(
+                    // Pulled in line with the static AppleMusicBackground alphas (0.88 / 0.76 /
+                    // 0.96) so the moving-blur page reads just as vivid as the default one.
+                    colors.getOrElse(0) { AppleMusicFallbackGradient[0] }.copy(alpha = 0.85f),
+                    colors.getOrElse(1) { AppleMusicFallbackGradient[1] }.copy(alpha = 0.75f),
+                    colors.getOrElse(2) { AppleMusicFallbackGradient[2] }.copy(alpha = 0.95f),
+                ),
+            )
+        }
+    val bottomScrim =
+        remember {
+            Brush.verticalGradient(
+                listOf(
+                    Color.Transparent,
+                    Color.Black.copy(alpha = 0.18f),
+                ),
+            )
+        }
+
+    // 1.6x saturation, applied only to this backdrop — it does not touch the shared
+    // PlayerColorExtractor palette that other screens consume, and it is what lets the colours
+    // punch through the blur. ColorMatrix is built by hand because
+    // androidx.compose.ui.graphics.ColorMatrix has no setSaturation(); the terms below are the
+    // standard Rec. 709 saturation matrix (sat = 1 gives the identity).
+    val vibrancyColorFilter =
+        remember {
+            val sat = 1.6f
+            val r = 0.213f + 0.787f * sat
+            val g = 0.715f - 0.715f * sat
+            val b = 0.072f - 0.072f * sat
+            ColorFilter.colorMatrix(
+                ColorMatrix(
+                    floatArrayOf(
+                        r, g, b, 0f, 0f,
+                        r, g, b, 0f, 0f,
+                        r, g, b, 0f, 0f,
+                        0f, 0f, 0f, 1f, 0f,
+                    ),
+                ),
+            )
+        }
+
     val context = LocalContext.current
     val thumbnailUrl = mediaMetadata.thumbnailUrl
     val cacheRevision by LyricsArtBlurCache.updates.collectAsState()
@@ -640,113 +722,146 @@ private fun MovingBlurBackground(
         LyricsArtBlurCache.prefetch(context, thumbnailUrl)
     }
 
-    // RenderEffect is Android 12+. Below that — or with the toggle off — the
-    // pre-blurred bitmap is used and only its position animates.
-    val gpuBlurAvailable =
-        useGpuBlur &&
-            !disableBlur &&
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
-    val blurEffect =
-        remember(gpuBlurAvailable, blurRadius) {
-            if (!gpuBlurAvailable) {
-                null
-            } else {
-                val radius = blurRadius.coerceIn(MOVING_BLUR_MIN_RADIUS, MOVING_BLUR_MAX_RADIUS)
-                BlurEffect(radius, radius, TileMode.Clamp).takeIf(RenderEffect::isSupported)
-            }
-        }
+    // Modifier.blur is a no-op below Android 12 — it needs RenderEffect, API 31+ — so pre-S, and
+    // Android 12+ with the toggle off, draw the bitmap LyricsArtBlurCache blurred once on the CPU
+    // instead. The drift is a graphicsLayer transform either way, and a canvas transform is
+    // something every API level can do, so the backdrop still moves on old devices. (Animating a
+    // pre-blurred bitmap with a layout-phase Modifier.offset instead is what tears on them.)
+    val gpuBlur = useGpuBlur && !disableBlur && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+    val wander = rememberBlurWanderDrift(active = thumbnailUrl != null)
+
     val gpuRequest =
         remember(context, thumbnailUrl) {
             thumbnailUrl?.let { url ->
                 ImageRequest
                     .Builder(context)
                     .data(url)
-                    // The blur hides the missing detail, so a small decode keeps
-                    // the per frame GPU cost down.
+                    // The blur destroys the detail anyway, and the layer is rasterised at the
+                    // footprint size below, so a small decode keeps both the bitmap and the
+                    // per-frame GPU blur cheap.
                     .size(MOVING_BLUR_ART_PX)
                     .build()
             }
         }
 
-    // Two different periods on the axes keep the drift from looking like a loop.
-    val drift = rememberInfiniteTransition(label = "movingBlur")
-    val driftX by drift.animateFloat(
-        initialValue = -1f,
-        targetValue = 1f,
-        animationSpec =
-            infiniteRepeatable(
-                animation = tween(MOVING_BLUR_DRIFT_MS, easing = LinearEasing),
-                repeatMode = RepeatMode.Reverse,
-            ),
-        label = "driftX",
-    )
-    val driftY by drift.animateFloat(
-        initialValue = -1f,
-        targetValue = 1f,
-        animationSpec =
-            infiniteRepeatable(
-                animation = tween(MOVING_BLUR_DRIFT_MS * 4 / 3, easing = LinearEasing),
-                repeatMode = RepeatMode.Reverse,
-            ),
-        label = "driftY",
-    )
-
-    Box(
+    BoxWithConstraints(
         modifier =
             modifier
                 .fillMaxSize()
-                .background(Color.Black),
+                .clipToBounds()
+                .background(AppleMusicFallbackGradient.last()),
     ) {
-        val driftModifier =
-            Modifier
-                .fillMaxSize()
-                .offset {
-                    IntOffset(
-                        x = (driftX * MOVING_BLUR_DRIFT_DP).dp.roundToPx(),
-                        y = (driftY * MOVING_BLUR_DRIFT_DP * 0.7f).dp.roundToPx(),
-                    )
-                }
+        // The blur clips to its own bounds, so the layer cannot simply be screen-shaped: rotated
+        // by the walk, a screen-sized rectangle only covers its inscribed circle and a black wedge
+        // sweeps through a corner. This sizes it to the container's furthest corner instead.
+        val footprint =
+            remember(maxWidth, maxHeight) {
+                blurBackdropFootprint(
+                    width = maxWidth,
+                    height = maxHeight,
+                    restScale = MOVING_BLUR_SCALE,
+                    driftScale = MOVING_BLUR_SCALE,
+                )
+            }
 
-        if (blurEffect != null && gpuRequest != null) {
-            AsyncImage(
-                model = gpuRequest,
-                contentDescription = null,
-                contentScale = ContentScale.Crop,
-                modifier =
-                    driftModifier.graphicsLayer {
-                        scaleX = MOVING_BLUR_SCALE
-                        scaleY = MOVING_BLUR_SCALE
-                        renderEffect = blurEffect
-                    },
-            )
+        if (gpuBlur && gpuRequest != null) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                val driftModifier =
+                    Modifier
+                        .requiredSize(footprint)
+                        .graphicsLayer {
+                            scaleX = MOVING_BLUR_SCALE
+                            scaleY = MOVING_BLUR_SCALE
+                            // Deferred, draw-phase reads — see BlurWanderDrift.
+                            translationX = wander.xDp.floatValue.dp.toPx()
+                            translationY = wander.yDp.floatValue.dp.toPx()
+                            // Rotation is the only part of the walk that can carry a colour across
+                            // the whole surface; translation moves every colour by the same vector.
+                            rotationZ = wander.rotationDeg.floatValue
+                            compositingStrategy = CompositingStrategy.Offscreen
+                        }
+                        .alpha(MOVING_BLUR_ALPHA)
+
+                AsyncImage(
+                    model = gpuRequest,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    colorFilter = vibrancyColorFilter,
+                    // blur INSIDE the transform: the artwork is blurred while it is still centred
+                    // and only then moved, so the blur never samples the transparent area behind
+                    // the layer's trailing edge.
+                    modifier =
+                        driftModifier.then(
+                            if (blurRadius > 0.5f) {
+                                Modifier.blur((blurRadius * MOVING_BLUR_BLUR_GAIN / MOVING_BLUR_SCALE).dp)
+                            } else {
+                                Modifier
+                            },
+                        ),
+                )
+            }
         } else if (blurredArt != null) {
-            Image(
-                bitmap = blurredArt.asImageBitmap(),
-                contentDescription = null,
-                contentScale = ContentScale.Crop,
-                modifier =
-                    driftModifier.graphicsLayer {
-                        scaleX = MOVING_BLUR_SCALE
-                        scaleY = MOVING_BLUR_SCALE
-                    },
-            )
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                Image(
+                    bitmap = blurredArt.asImageBitmap(),
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    colorFilter = vibrancyColorFilter,
+                    modifier =
+                        Modifier
+                            .requiredSize(footprint)
+                            .graphicsLayer {
+                                scaleX = MOVING_BLUR_SCALE
+                                scaleY = MOVING_BLUR_SCALE
+                                translationX = wander.xDp.floatValue.dp.toPx()
+                                translationY = wander.yDp.floatValue.dp.toPx()
+                                rotationZ = wander.rotationDeg.floatValue
+                                compositingStrategy = CompositingStrategy.Offscreen
+                            }
+                            .alpha(MOVING_BLUR_ALPHA),
+                )
+            }
         }
 
         Box(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.52f)),
+                    .background(backgroundBrush),
+        )
+
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(bottomScrim),
         )
     }
 }
 
+/**
+ * How far the layer is scaled up. It has to be large enough that the walk's drift and rotation
+ * can never pull the artwork's own edge into view — see [blurBackdropFootprint].
+ */
+private const val MOVING_BLUR_SCALE = 2.4f
+
+/**
+ * The layer is drawn scaled by [MOVING_BLUR_SCALE], and Compose scales the blur along with it, so
+ * the on-screen radius is `radius * MOVING_BLUR_SCALE`. This gain turns the Blur intensity slider
+ * (0..64, default 48) into the ~77dp of on-screen blur the backdrop wants at its default.
+ */
+private const val MOVING_BLUR_BLUR_GAIN = 1.6f
+
+private const val MOVING_BLUR_ALPHA = 0.95f
+
+/** Decode size for the drifting artwork — the blur hides everything finer than this. */
 private const val MOVING_BLUR_ART_PX = 256
-private const val MOVING_BLUR_SCALE = 1.35f
-private const val MOVING_BLUR_DRIFT_DP = 26f
-private const val MOVING_BLUR_DRIFT_MS = 26_000
-private const val MOVING_BLUR_MIN_RADIUS = 8f
-private const val MOVING_BLUR_MAX_RADIUS = 32f
 
 @Composable
 private fun AppleMusicGrabber(

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
@@ -12,6 +12,7 @@ package dev.citali.lunartune.ui.player
 import android.content.res.Configuration
 import android.view.HapticFeedbackConstants
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -82,6 +83,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.runtime.collectAsState
+import androidx.compose.animation.core.tween
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.media3.common.C
 import androidx.media3.common.Player.STATE_BUFFERING
@@ -618,20 +620,29 @@ private fun AppleMusicBackground(
                 .fillMaxSize()
                 .background(AppleMusicFallbackGradient.last()),
     ) {
-        if (blurredArt != null) {
-            Image(
-                bitmap = blurredArt.asImageBitmap(),
-                contentDescription = null,
-                contentScale = ContentScale.Crop,
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .graphicsLayer {
-                            scaleX = AppleMusicBackdropScale
-                            scaleY = AppleMusicBackdropScale
-                        }
-                        .alpha(0.62f),
-            )
+        // Keyed on the bitmap, not the url: the outgoing artwork stays on screen until the incoming
+        // one is actually ready, so a track change never flashes an empty backdrop.
+        Crossfade(
+            targetState = blurredArt,
+            animationSpec = tween(BACKDROP_FADE_MS),
+            label = "appleMusicBackdrop",
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .graphicsLayer {
+                        scaleX = AppleMusicBackdropScale
+                        scaleY = AppleMusicBackdropScale
+                    }
+                    .alpha(0.62f),
+        ) { art ->
+            if (art != null) {
+                Image(
+                    bitmap = art.asImageBitmap(),
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
         }
         Box(
             modifier =
@@ -655,6 +666,13 @@ private fun AppleMusicBackground(
 }
 
 private const val AppleMusicBackdropScale = 1.12f
+
+/**
+ * How long the backdrop takes to trade one track's artwork for the next. Without it the backdrop
+ * pops the instant the new bitmap lands, which is the one thing that makes the whole effect read
+ * as a glitch rather than as a finish.
+ */
+private const val BACKDROP_FADE_MS = 700
 
 @Composable
 private fun MovingBlurBackground(
@@ -795,27 +813,37 @@ private fun MovingBlurBackground(
                         Modifier
                     }
 
-                AsyncImage(
-                    model = gpuRequest,
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
-                    colorFilter = vibrancyColorFilter,
+                // The crossfade sits under the blur, so what fades is the artwork and not the
+                // finished blurred result — no sharp edge is ever visible mid-transition.
+                Crossfade(
+                    targetState = gpuRequest,
+                    animationSpec = tween(BACKDROP_FADE_MS),
+                    label = "movingBlurBackdrop",
                     // blur INSIDE the transform: the artwork is blurred while it is still centred
                     // and only then moved, so the blur never samples the transparent area behind
                     // the layer's trailing edge.
                     modifier = driftModifier.then(blurModifier),
-                )
+                ) { request ->
+                    AsyncImage(
+                        model = request,
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        colorFilter = vibrancyColorFilter,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
             }
         } else if (blurredArt != null) {
             Box(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center,
             ) {
-                Image(
-                    bitmap = blurredArt.asImageBitmap(),
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
-                    colorFilter = vibrancyColorFilter,
+                // Keyed on the bitmap, so the old artwork holds the frame until the new one has
+                // been blurred and cached — the CPU path is the one that would otherwise flash.
+                Crossfade(
+                    targetState = blurredArt,
+                    animationSpec = tween(BACKDROP_FADE_MS),
+                    label = "movingBlurBackdrop",
                     modifier =
                         Modifier
                             .requiredSize(footprint)
@@ -828,7 +856,15 @@ private fun MovingBlurBackground(
                                 compositingStrategy = CompositingStrategy.Offscreen
                             }
                             .alpha(MOVING_BLUR_ALPHA),
-                )
+                ) { art ->
+                    Image(
+                        bitmap = art.asImageBitmap(),
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        colorFilter = vibrancyColorFilter,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
             }
         }
 

--- a/app/src/main/kotlin/dev/citali/lunartune/utils/LyricsArtBlurCache.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/utils/LyricsArtBlurCache.kt
@@ -27,8 +27,11 @@ import kotlinx.coroutines.withContext
  * page can open on an already-blurred bitmap instead of a sharp cover.
  */
 object LyricsArtBlurCache {
-    private const val DecodeSizePx = 160
-    private const val BlurRadius = 24f
+    // Both consumers draw this across the whole lyrics page — the Apple Music background fills
+    // the screen and the moving-blur backdrop magnifies it further — so it is decoded and blurred
+    // at a size that survives being scaled up, rather than at thumbnail size.
+    private const val DecodeSizePx = 384
+    private const val BlurRadius = 32f
     private const val MaxEntries = 8
 
     private val mutex = Mutex()


### PR DESCRIPTION
Stacked on #73 — this branch currently contains #73's commits plus the crossfade on top. Once #73 lands, GitHub will recompute the diff and this PR will shrink to just the crossfade commit. Build `feat/backdrop-crossfade` if you want both at once.

### The problem

The backdrop swapped the instant a new blurred bitmap landed: old artwork gone, new artwork there, same frame, mid-drift. That pop is the one detail that reads as a glitch rather than as a finish.

### The fix

700ms crossfade on both lyrics backgrounds. Two details that matter more than the duration:

- **Keyed on the bitmap, not the url** (Apple Music background and the CPU path of the moving blur). The outgoing artwork holds the frame until the incoming one has actually been decoded and blurred. Keying on the url would fade *out* immediately and leave an empty backdrop for however long the decode takes — a worse glitch than the pop it replaces.
- **The crossfade sits under the blur** on the moving-blur backdrop, so what fades is the artwork and not the finished blurred result. No sharp edge is visible mid-transition, and because the drift transform is applied outside the fade, the walk never restarts or stutters when the track changes.

One constant (`BACKDROP_FADE_MS = 700`) — trivial to tune or pull back out.

### To try it

Change tracks while the lyrics page is open. Also worth trying with **Use GPU blur off**, which takes the CPU path where the bitmap keying matters most.

### Not included

The player backdrop crossfade. The player has its own blurred album backdrop with its own artwork pipeline, so it needs the same treatment separately — happy to follow up if this one feels right.