### PR TITLE
fix: the moving blur was greyscale, and slow the drift down

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/BlurWanderDrift.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/BlurWanderDrift.kt
@@ -181,19 +181,22 @@ internal class BlurWanderDrift(
          */
         const val WanderRadiusDp = 120f
 
-        /** Average travel speed. Deliberately slow — this sits behind lyrics. */
-        private const val WanderSpeedDpPerSecond = 26f
+        /**
+         * Average travel speed. Deliberately slow — this sits behind lyrics. Was 26dp/s, which
+         * read as slightly busy when you were trying to read.
+         */
+        private const val WanderSpeedDpPerSecond = 19f
 
         private const val MinLegDurationMs = 6_000f
-        private const val MaxLegDurationMs = 18_000f
+        private const val MaxLegDurationMs = 22_000f
 
         /**
-         * Degrees of rotation one leg may add. Against the ~12s median leg that is roughly 3°/s,
-         * so a colour crosses the screen — half a turn — in about a minute: ambient, rather than
-         * something you notice while reading lyrics.
+         * Degrees of rotation one leg may add. Against the ~15s median leg that is roughly 2°/s,
+         * so a colour crosses the screen — half a turn — in about a minute and a half: ambient,
+         * rather than something you notice while reading lyrics.
          */
-        private const val MinLegRotationDegrees = 18f
-        private const val MaxLegRotationDegrees = 55f
+        private const val MinLegRotationDegrees = 15f
+        private const val MaxLegRotationDegrees = 45f
 
         /** Waypoints are never closer to the centre than this fraction of the radius. */
         private const val MinRadiusFraction = 0.5f

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
@@ -732,16 +732,23 @@ private fun MovingBlurBackground(
     // [MOVING_BLUR_BRIGHTNESS] to lift the result.
     val vibrancyColorFilter =
         remember {
-            val sat = MOVING_BLUR_SATURATION
-            val r = (0.213f + 0.787f * sat) * MOVING_BLUR_BRIGHTNESS
-            val g = (0.715f - 0.715f * sat) * MOVING_BLUR_BRIGHTNESS
-            val b = (0.072f - 0.072f * sat) * MOVING_BLUR_BRIGHTNESS
+            val s = MOVING_BLUR_SATURATION
+            val gain = MOVING_BLUR_BRIGHTNESS
+            // Rec. 709 saturation matrix. The rows are deliberately *not* identical: each output
+            // channel keeps its own channel at (luma + s) and takes the other two at
+            // (luma * (1 - s)). Writing one row three times — which is what the ported version of
+            // this did — computes the same weighted sum for R, G and B, and that is a greyscale
+            // conversion however high s goes: a blue sky came out grey, and turning the saturation
+            // up only made the grey brighter. At s = 1 this is the identity matrix.
+            val lr = 0.213f * (1f - s)
+            val lg = 0.715f * (1f - s)
+            val lb = 0.072f * (1f - s)
             ColorFilter.colorMatrix(
                 ColorMatrix(
                     floatArrayOf(
-                        r, g, b, 0f, 0f,
-                        r, g, b, 0f, 0f,
-                        r, g, b, 0f, 0f,
+                        (lr + s) * gain, lg * gain, lb * gain, 0f, 0f,
+                        lr * gain, (lg + s) * gain, lb * gain, 0f, 0f,
+                        lr * gain, lg * gain, (lb + s) * gain, 0f, 0f,
                         0f, 0f, 0f, 1f, 0f,
                     ),
                 ),
@@ -928,8 +935,13 @@ private const val MOVING_BLUR_SCRIM_TOP = 0.55f
 private const val MOVING_BLUR_SCRIM_MID = 0.45f
 private const val MOVING_BLUR_SCRIM_BOTTOM = 0.68f
 
-private const val MOVING_BLUR_SATURATION = 1.75f
-private const val MOVING_BLUR_BRIGHTNESS = 1.12f
+private const val MOVING_BLUR_SATURATION = 1.6f
+
+/**
+ * Only a slight lift now. The larger gain this used to carry was compensating for the filter
+ * turning everything grey — with real saturation, much more than this blows the highlights out.
+ */
+private const val MOVING_BLUR_BRIGHTNESS = 1.06f
 
 /** Decode size for the drifting artwork — the blur hides everything finer than this. */
 private const val MOVING_BLUR_ART_PX = 256


### PR DESCRIPTION
#76 merged before these landed, so they arrive separately. Two changes, both from the same round of testing.

### The colour filter was a greyscale conversion

The "vibrancy" filter ported in #73 wrote **one row of the saturation matrix into all three output channels**:

```
R =  1.472 R  -0.429 G  -0.043 B
G =  1.472 R  -0.429 G  -0.043 B   <- identical
B =  1.472 R  -0.429 G  -0.043 B   <- identical
```

Every output channel gets the same weighted sum of R, G and B. That is a **greyscale conversion**, not a saturation boost — a blue sky went in, grey came out, and turning the saturation up only made the grey brighter. The upstream it was ported from carries the same bug; it came across verbatim and I ported the numbers without checking the matrix.

Rec. 709 saturation needs three *different* rows: each output channel keeps its own at `(luma + s)` and takes the other two at `luma * (1 - s)`.

```
R =  1.472 R  -0.429 G  -0.043 B
G = -0.128 R   1.171 G  -0.043 B
B = -0.128 R  -0.429 G   1.557 B
```

At `s = 1` that is the identity matrix, so the filter is a no-op at neutral.

This was also a good part of the earlier "too dim" report — grey reads flatter and darker than saturated colour — so the brightness lift #76 added was compensating for the bug rather than doing real work. It drops **1.12 → 1.06**, with saturation at **1.6**. With real saturation working, much more than that blows the highlights out.

### Slower

Travel **26dp/s → 19dp/s**, rotation per leg **18-55° → 15-45°**, and the leg ceiling rises to 22s so shorter legs don't race to cover the same distance. Roughly a quarter slower overall; a colour now takes about a minute and a half to cross the screen instead of a minute.

### Tuning

`MOVING_BLUR_SATURATION` and `MOVING_BLUR_BRIGHTNESS` in `LyricsScreen.kt`; `WanderSpeedDpPerSecond`, `MinLegRotationDegrees`, `MaxLegRotationDegrees` in `BlurWanderDrift.kt`.

Only the moving blur is touched. The default Apple Music backdrop never used this filter, which is why it didn't go grey.