### PR TITLE
fix: player blur backgrounds had no blur at all below Android 12

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/BlurredArtwork.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/BlurredArtwork.kt
@@ -1,0 +1,116 @@
+/*
+ * LunarTune (2026)
+ * © cognitiveshadows03 — github.com/cognitiveshadows03
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package dev.citali.lunartune.ui.player
+
+import android.os.Build
+import androidx.compose.foundation.Image
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import dev.citali.lunartune.utils.LyricsArtBlurCache
+
+/**
+ * Artwork blurred by whatever means this device actually has.
+ *
+ * `Modifier.blur` needs `RenderEffect`, which is Android 12 and above — and below that it is a
+ * **silent no-op**, not an error. That is what made this hard to spot: the player's blur
+ * backgrounds were rendering on old devices with the cover entirely unblurred, with nothing in the
+ * logs to explain why. The album backdrop guards for this and falls back to its own CPU path; the
+ * background *styles* did not.
+ *
+ * So this picks the path: GPU blur on 12+, and below it the same CPU stack blur the lyrics
+ * backdrop uses, served from the same cache.
+ */
+@Composable
+internal fun BlurredArtwork(
+    model: Any?,
+    radius: Dp,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+    contentScale: ContentScale = ContentScale.Crop,
+    colorFilter: ColorFilter? = null,
+) {
+    val url = model?.toString()
+
+    if (radius > 0.dp && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        AsyncImage(
+            model = model,
+            contentDescription = contentDescription,
+            contentScale = contentScale,
+            colorFilter = colorFilter,
+            modifier = modifier.blur(radius),
+        )
+        return
+    }
+
+    // No blur asked for, or nothing to blur it with — show the artwork as it comes.
+    val cpuRadius = (radius.value * CpuBlurPixelsPerDp).coerceIn(0f, 48f)
+    if (url == null || cpuRadius < 0.5f) {
+        AsyncImage(
+            model = model,
+            contentDescription = contentDescription,
+            contentScale = contentScale,
+            colorFilter = colorFilter,
+            modifier = modifier,
+        )
+        return
+    }
+
+    val context = LocalContext.current
+    val revision by LyricsArtBlurCache.updates.collectAsState()
+    val blurred =
+        remember(url, cpuRadius, revision) {
+            LyricsArtBlurCache.peek(url, cpuRadius)
+        }
+
+    LaunchedEffect(url, cpuRadius) {
+        LyricsArtBlurCache.prefetch(context, url, cpuRadius)
+    }
+
+    if (blurred != null) {
+        Image(
+            bitmap = blurred.asImageBitmap(),
+            contentDescription = contentDescription,
+            contentScale = contentScale,
+            colorFilter = colorFilter,
+            modifier = modifier,
+        )
+    } else {
+        // Still being blurred. Show the plain artwork rather than an empty background — the
+        // styles that use this all lay a gradient over the top, so the moment it swaps to the
+        // blurred version is far less visible than a hole would be.
+        AsyncImage(
+            model = model,
+            contentDescription = contentDescription,
+            contentScale = contentScale,
+            colorFilter = colorFilter,
+            modifier = modifier,
+        )
+    }
+}
+
+/**
+ * Pixels of blur on the cached bitmap per dp of blur asked for.
+ *
+ * The two are not the same unit: the GPU radius is in dp on screen, the stack blur operates on the
+ * pixels of a 384px bitmap that is then stretched across the screen. This matches the ratio the
+ * album backdrop's own pre-S path already uses — 44dp of GPU blur against 25px on a 500px decode —
+ * scaled down to this cache's 384px.
+ */
+private const val CpuBlurPixelsPerDp = 0.44f

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/PlayerComponents.kt
@@ -78,7 +78,6 @@ import kotlinx.coroutines.delay
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
@@ -4014,14 +4013,11 @@ fun PlayerBackground(
                 ) { thumbnailUrl ->
                     if (thumbnailUrl != null) {
                         Box(modifier = Modifier.fillMaxSize()) {
-                            AsyncImage(
+                            BlurredArtwork(
                                 model = thumbnailUrl.highRes(),
+                                radius = if (styleAppliesBlur) effectiveBlurRadius.dp else 0.dp,
                                 contentDescription = "Blurred background",
-                                contentScale = ContentScale.Crop,
-                                modifier =
-                                    Modifier.fillMaxSize().let {
-                                        if (styleAppliesBlur) it.blur(radius = effectiveBlurRadius.dp) else it
-                                    },
+                                modifier = Modifier.fillMaxSize(),
                             )
                             val overlayStops = PlayerBackgroundColorUtils.buildBlurOverlayStops(gradientColors)
                             Box(
@@ -4123,14 +4119,11 @@ fun PlayerBackground(
                 ) { thumbnailUrl ->
                     if (thumbnailUrl != null) {
                         Box(modifier = Modifier.fillMaxSize()) {
-                            AsyncImage(
+                            BlurredArtwork(
                                 model = thumbnailUrl.highRes(),
+                                radius = if (styleAppliesBlur) effectiveBlurRadius.dp else 0.dp,
                                 contentDescription = "Blurred background",
-                                contentScale = ContentScale.Crop,
-                                modifier =
-                                    Modifier.fillMaxSize().let {
-                                        if (styleAppliesBlur) it.blur(radius = effectiveBlurRadius.dp) else it
-                                    },
+                                modifier = Modifier.fillMaxSize(),
                             )
                             val gradientColorStops =
                                 PlayerBackgroundColorUtils.buildBlurGradientStops(gradientColors)
@@ -4192,15 +4185,12 @@ fun PlayerBackground(
 
                             val cm = ColorMatrix(matrix)
 
-                            AsyncImage(
+                            BlurredArtwork(
                                 model = Uri.parse(uri),
+                                radius = if (disableBlur) 0.dp else blurPx.dp,
                                 contentDescription = "Custom background",
-                                contentScale = ContentScale.Crop,
-                                modifier =
-                                    Modifier.fillMaxSize().let {
-                                        if (disableBlur) it else it.blur(radius = blurPx.dp)
-                                    },
                                 colorFilter = ColorFilter.colorMatrix(cm),
+                                modifier = Modifier.fillMaxSize(),
                             )
                             Box(
                                 modifier =

--- a/app/src/main/kotlin/dev/citali/lunartune/utils/LyricsArtBlurCache.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/utils/LyricsArtBlurCache.kt
@@ -14,6 +14,7 @@ import coil3.request.ImageRequest
 import coil3.request.allowHardware
 import coil3.size.Size
 import coil3.toBitmap
+import kotlin.math.roundToInt
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -23,8 +24,12 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 /**
- * Pre-blurs the playing track's cover on a background thread so the lyrics
- * page can open on an already-blurred bitmap instead of a sharp cover.
+ * Pre-blurs the playing track's cover on a background thread so a surface that needs blurred
+ * artwork can show an already-blurred bitmap instead of a sharp cover.
+ *
+ * Started out serving only the lyrics page — hence the name — but it is now also how the player's
+ * blur backgrounds get their blur on Android 11 and below, where `Modifier.blur` does nothing at
+ * all. One blur per track, shared by every surface that needs one.
  */
 object LyricsArtBlurCache {
     // Both consumers draw this across the whole lyrics page — the Apple Music background fills
@@ -33,6 +38,12 @@ object LyricsArtBlurCache {
     private const val DecodeSizePx = 384
     private const val BlurRadius = 32f
     private const val MaxEntries = 8
+
+    /**
+     * Blur radii are rounded to this before they are used as a cache key. A blur slider would
+     * otherwise fill the cache with one entry per value it is dragged through.
+     */
+    private const val RadiusStep = 8f
 
     private val mutex = Mutex()
     private val bitmaps =
@@ -45,26 +56,32 @@ object LyricsArtBlurCache {
 
     val updates: StateFlow<Int> = revision.asStateFlow()
 
-    fun peek(url: String?): Bitmap? {
+    fun peek(
+        url: String?,
+        radius: Float = BlurRadius,
+    ): Bitmap? {
         if (url.isNullOrBlank()) return null
+        val key = key(url, radius)
         synchronized(bitmaps) {
-            return bitmaps[url]
+            return bitmaps[key]
         }
     }
 
     suspend fun prefetch(
         context: Context,
         url: String?,
+        radius: Float = BlurRadius,
     ) {
         if (url.isNullOrBlank()) return
-        if (peek(url) != null) return
+        val key = key(url, radius)
+        if (peek(url, radius) != null) return
 
         val shouldLoad =
             mutex.withLock {
-                if (url in inFlight || peek(url) != null) {
+                if (key in inFlight || peek(url, radius) != null) {
                     false
                 } else {
-                    inFlight.add(url)
+                    inFlight.add(key)
                     true
                 }
             }
@@ -82,15 +99,23 @@ object LyricsArtBlurCache {
                             .build()
                     val image = context.applicationContext.imageLoader.execute(request).image ?: return@withContext null
                     val bitmap = image.toBitmap().copy(Bitmap.Config.ARGB_8888, true)
-                    ImageBlurUtils.blur(bitmap, BlurRadius)
+                    ImageBlurUtils.blur(bitmap, quantize(radius))
                 } ?: return
 
             synchronized(bitmaps) {
-                bitmaps[url] = blurred
+                bitmaps[key] = blurred
             }
             revision.value = revision.value + 1
         } finally {
-            mutex.withLock { inFlight.remove(url) }
+            mutex.withLock { inFlight.remove(key) }
         }
     }
+
+    private fun key(
+        url: String,
+        radius: Float,
+    ): String = "$url#${quantize(radius).toInt()}"
+
+    private fun quantize(radius: Float): Float =
+        (radius / RadiusStep).roundToInt() * RadiusStep
 }


### PR DESCRIPTION
The player's blur background styles had no blur on Android 11 and below — not broken blur, **no blur**. The cover rendered completely sharp.

### Why it was invisible in the logs

`Modifier.blur` needs `RenderEffect`, which is Android 12 and above. Below that it is a **silent no-op**, not an error — AOSP's own wording is "Attempts to use this Modifier on older Android versions will be ignored". So nothing crashed, nothing logged, and the styles just quietly didn't blur.

Three call sites in `PlayerBackground` applied it with no API guard at all:

- `BLUR`
- `BLUR_GRADIENT`
- `CUSTOM`, when its blur is on

The **album backdrop** never had the problem — it checks for API 31 and falls back to its own CPU path (`BackdropBlurApi30`), as does the V7 backdrop. Only the selectable background styles missed the check, which is why this showed up as "some minor bugs in the styles" rather than everywhere.

### The fix

`BlurredArtwork` picks the path — GPU blur on 12+, and below that the **same CPU stack blur the lyrics backdrop uses**, served from the same cache (`LyricsArtBlurCache`). One blur per track, shared by every surface that needs one.

Supporting changes:

- `LyricsArtBlurCache` now takes a blur radius and keys on it, **quantised to 8px steps** so dragging a blur slider doesn't fill the cache one value at a time. Its default keeps the lyrics' existing behaviour exactly.
- While the CPU blur is still warming there's no hole: the unblurred artwork stands in until it lands. These styles all lay a gradient over the top, so that swap is far less visible than an empty background would be.

### One approximation worth knowing

The GPU radius is in dp on screen; the stack blur operates on the pixels of a 384px bitmap that is then stretched across the screen. Those are different units, and `CpuBlurPixelsPerDp` (0.44) bridges them — derived from the ratio the album backdrop's own pre-S path already uses, 44dp against 25px on a 500px decode, scaled to 384px. So the CPU blur matches the GPU blur *approximately*, not exactly. If it reads too strong or too weak next to a 12+ device, that single constant is the dial.

### Scope

Only the three guarded styles. The moving blur as a player background style is still parked and untouched.