### PR TITLE
revert: default lyrics background to its pre-moving-blur look

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
@@ -579,33 +579,6 @@ private fun AppleMusicBackground(
     gradientColors: List<Color>,
     modifier: Modifier = Modifier,
 ) {
-    val colors = if (gradientColors.isNotEmpty()) gradientColors else AppleMusicFallbackGradient
-    val backgroundBrush =
-        remember(colors) {
-            Brush.verticalGradient(
-                listOf(
-                    // The palette has to tint the artwork, not replace it. At 0.88 / 0.76 / 0.96,
-                    // with the artwork itself at 0.62, less than a tenth of the cover survived, so
-                    // the backdrop read as a flat opaque colour instead of as a blurred cover.
-                    // These leave about as much of the artwork visible as the old flat
-                    // Black @ 0.52 scrim did — but the rest of the pixel is palette colour rather
-                    // than black, which is where the vividness comes from.
-                    colors.getOrElse(0) { AppleMusicFallbackGradient[0] }.copy(alpha = AppleMusicScrimTop),
-                    colors.getOrElse(1) { AppleMusicFallbackGradient[1] }.copy(alpha = AppleMusicScrimMid),
-                    colors.getOrElse(2) { AppleMusicFallbackGradient[2] }.copy(alpha = AppleMusicScrimBottom),
-                ),
-            )
-        }
-    val bottomScrim =
-        remember {
-            Brush.verticalGradient(
-                listOf(
-                    Color.Transparent,
-                    Color.Black.copy(alpha = 0.28f),
-                ),
-            )
-        }
-
     val context = LocalContext.current
     val thumbnailUrl = mediaMetadata.thumbnailUrl
     val cacheRevision by LyricsArtBlurCache.updates.collectAsState()
@@ -618,13 +591,14 @@ private fun AppleMusicBackground(
         LyricsArtBlurCache.prefetch(context, thumbnailUrl)
     }
 
-    // The blurred cover sits under the track's own palette rather than under a flat black scrim,
-    // which is what makes this read as an Apple Music backdrop instead of a dimmed thumbnail.
+    // The look this had before the moving-blur work: the blurred cover, full strength, under a
+    // flat black scrim. The palette-tinted version that replaced it was richer but buried the
+    // artwork, and this one is the one that reads as a blurred cover rather than as a colour.
     Box(
         modifier =
             modifier
                 .fillMaxSize()
-                .background(AppleMusicFallbackGradient.last()),
+                .background(Color.Black),
     ) {
         // Keyed on the bitmap, not the url: the outgoing artwork stays on screen until the incoming
         // one is actually ready, so a track change never flashes an empty backdrop.
@@ -653,32 +627,12 @@ private fun AppleMusicBackground(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .background(backgroundBrush),
-        )
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.10f)),
-        )
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .background(bottomScrim),
+                    .background(Color.Black.copy(alpha = 0.52f)),
         )
     }
 }
 
 private const val AppleMusicBackdropScale = 1.12f
-
-/**
- * How much of the track's own palette is laid over the blurred artwork, top to bottom. Lower these
- * to let more of the cover through; raise them for a flatter, more coloured backdrop.
- */
-private const val AppleMusicScrimTop = 0.55f
-private const val AppleMusicScrimMid = 0.45f
-private const val AppleMusicScrimBottom = 0.66f
 
 /**
  * How long the backdrop takes to trade one track's artwork for the next. Without it the backdrop


### PR DESCRIPTION
The **default** lyrics background goes back to what it was before the moving-blur work: the blurred cover at full strength, under a flat `Black @ 0.52` scrim on a black base.

The palette-tinted version that #73 replaced it with was richer, but it buried the artwork — #77 pulled the scrim back to 0.55 / 0.45 / 0.66 and it still didn't read the same. This is the composition that reads as a blurred cover rather than as a colour.

### What is untouched

**The moving blur.** It keeps everything it gained: the palette scrim from #76, the corrected saturation matrix and the slower drift from #78. Its constants, its colour filter and its pace are all exactly as they are on main — this PR only touches `AppleMusicBackground`.

### What kept, deliberately

**The crossfade.** It came from #74, it is a transition rather than a look, and it costs nothing to keep the track change smooth on the default background too. Say the word if you want a literal revert to the old snap instead.

### One difference from the old build

The art cache decodes at 384px with a blur radius of 32 now, where it was 160px at radius 24 before #73. So the cover will look a little less smeared than in your older screenshot — same composition, slightly more detail in it. That cache is shared with the moving blur, which you've said is working, so I didn't move it. If you want the old softness back specifically on the default background, that's a separate request: the cache already takes a radius per call, so the default can ask for 24 while the moving blur keeps 32 — the decode size would need the same treatment.