### PR TITLE
perf: request the top refresh rate while the UI is animating, not always

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/AppearanceSettings.kt
@@ -15,8 +15,12 @@ import android.content.ContextWrapper
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.view.View
+import android.view.ViewTreeObserver
 import android.widget.Toast
+import androidx.annotation.RequiresApi
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
@@ -1213,13 +1217,94 @@ fun ApplyRefreshRate(
     }
 }
 
+/**
+ * Runs the UI at the display's fastest refresh rate for as long as something is actually moving.
+ *
+ * Android 15 and above can take a frame-rate request per view and act on it without switching the
+ * display's mode, so the request can come and go as the UI starts and stops. Below that the only
+ * lever is the window's display mode, and changing *that* mid-animation is itself a hitch — so the
+ * old behaviour is kept there: pin it for as long as the setting is on.
+ */
 @Composable
 internal fun ApplyForcedRefreshRate(enabled: Boolean) {
-    val supportedHighestFps = rememberSupportedHighestFps()
-    ApplyRefreshRate(
-        isEnabled = enabled && supportedHighestFps > HIGH_REFRESH_RATE_THRESHOLD_FPS,
-        targetFps = supportedHighestFps,
-    )
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+        BoostRefreshRateWhileAnimating(enabled = enabled)
+    } else {
+        val supportedHighestFps = rememberSupportedHighestFps()
+        ApplyRefreshRate(
+            isEnabled = enabled && supportedHighestFps > HIGH_REFRESH_RATE_THRESHOLD_FPS,
+            targetFps = supportedHighestFps,
+        )
+    }
+}
+
+/**
+ * Holds a high frame-rate request for as long as the view keeps drawing, and drops it once it has
+ * been still for [BOOST_RELEASE_DELAY_MS].
+ *
+ * A draw pass is the one signal that covers *every* animation whatever drives it — a spring, a
+ * transition, a fling, the moving blur's drift — without this code having to know about any of
+ * them. It also costs nothing while nothing is happening: no draw, no callback, no request.
+ */
+@Composable
+private fun BoostRefreshRateWhileAnimating(enabled: Boolean) {
+    val view = LocalView.current
+    val targetFps = rememberSupportedHighestFps()
+
+    // Nothing to gain on a display that cannot go past the standard rate.
+    if (!enabled || targetFps <= HIGH_REFRESH_RATE_THRESHOLD_FPS) return
+
+    DisposableEffect(view, targetFps) {
+        val boost = AnimationFrameRateBoost(view, targetFps)
+        boost.start()
+        onDispose { boost.stop() }
+    }
+}
+
+/**
+ * How long the view has to sit still before the request is dropped. Long enough that the gap
+ * between two animations does not drop the display back down and then have to climb again.
+ */
+private const val BOOST_RELEASE_DELAY_MS = 900L
+
+@RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+private class AnimationFrameRateBoost(
+    private val view: View,
+    private val fps: Float,
+) : ViewTreeObserver.OnPreDrawListener {
+    private val handler = Handler(Looper.getMainLooper())
+    private var requested = false
+
+    private val release =
+        Runnable {
+            if (!requested) return@Runnable
+            requested = false
+            view.setRequestedFrameRate(DEFAULT_REFRESH_RATE_REQUEST)
+        }
+
+    fun start() {
+        if (view.isAttachedToWindow) {
+            view.viewTreeObserver.addOnPreDrawListener(this)
+        }
+    }
+
+    fun stop() {
+        if (view.isAttachedToWindow) {
+            view.viewTreeObserver.removeOnPreDrawListener(this)
+        }
+        handler.removeCallbacks(release)
+        release.run()
+    }
+
+    override fun onPreDraw(): Boolean {
+        if (!requested) {
+            requested = true
+            view.setRequestedFrameRate(fps)
+        }
+        handler.removeCallbacks(release)
+        handler.postDelayed(release, BOOST_RELEASE_DELAY_MS)
+        return true
+    }
 }
 
 @Composable


### PR DESCRIPTION
"Force high refresh rate" already existed and defaults to **on** — but it pinned the window to the display's fastest mode for as long as the app was open. Right rate, wrong duration: it holds the display at 120Hz to render a screen that isn't moving.

### What changed

On **Android 15+** the request is now held only while the view keeps drawing, and dropped 900ms after it goes still.

The detection is a `ViewTreeObserver.OnPreDrawListener`: a draw pass is the one signal that covers **every** animation regardless of what drives it — springs, navigation transitions, flings, the moving blur's continuous drift — without this code needing to know about any of them. It is also free when idle: no draw, no callback, no request. The 900ms hold stops the gap between two animations from dropping the display back down only to climb again.

On **Android 14 and below** nothing changes. There the only lever is the window's display mode, and switching *that* mid-animation is a hitch in itself, so it stays pinned while the setting is on.

### What this means on a 60Hz display

Nothing, honestly. No request can raise the ceiling past what the panel is running at — if the display is set to 60Hz, animations are already vsync-bound at 60 and this is a no-op. The gain is on panels running above 60, where animations previously shared the pin with static screens and now don't.

If what you're actually seeing on your device is **stutter** rather than a low ceiling, that is a different problem — dropped frames, not a capped rate — and worth chasing separately. The mini player unfold is the likeliest candidate: it re-tessellates its clip shape every frame.

### One thing to confirm on device

Google's adaptive-refresh-rate docs carry this caution: *"When setRequestedFrameRate is called on a ViewGroup, the specified value does not automatically propagate to its child Views."* In Compose that caveat should not bite, because every composable is drawn by the single `AndroidComposeView` rather than by a tree of Views, so a vote on the root covers the whole UI. I could not verify that on a device — worth a look while animations are running.