### PR TITLE
feat: drift the default lyrics backdrop, and keep the glow as its own style

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/constants/PreferenceKeys.kt
@@ -719,7 +719,8 @@ enum class LyricsBackgroundStyle {
     FOLLOW_THEME,
     COLORING,
     CUSTOM,
-    MOVING_BLUR;
+    MOVING_BLUR,
+    MOVING_GLOW;
 
     fun resolveFor(playerBackgroundStyle: PlayerBackgroundStyle): LyricsBackgroundStyle =
         when {

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
@@ -546,6 +546,18 @@ private fun LyricsScreenBackground(
                     useGpuBlur = useGpuBlur,
                     blurRadius = blurRadius,
                     disableBlur = disableBlur,
+                    glow = false,
+                )
+            }
+
+            LyricsBackgroundStyle.MOVING_GLOW -> {
+                MovingBlurBackground(
+                    mediaMetadata = mediaMetadata,
+                    gradientColors = gradientColors,
+                    useGpuBlur = useGpuBlur,
+                    blurRadius = blurRadius,
+                    disableBlur = disableBlur,
+                    glow = true,
                 )
             }
 
@@ -627,12 +639,18 @@ private fun AppleMusicBackground(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.52f)),
+                    .background(Color.Black.copy(alpha = AppleMusicScrimAlpha)),
         )
     }
 }
 
 private const val AppleMusicBackdropScale = 1.12f
+
+/**
+ * The flat scrim laid over the blurred artwork. Shared with the moving backdrop's plain variant so
+ * the two read as the same picture — one still, one drifting.
+ */
+private const val AppleMusicScrimAlpha = 0.52f
 
 /**
  * How long the backdrop takes to trade one track's artwork for the next. Without it the backdrop
@@ -648,6 +666,7 @@ private fun MovingBlurBackground(
     useGpuBlur: Boolean,
     blurRadius: Float,
     disableBlur: Boolean,
+    glow: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val colors = if (gradientColors.isNotEmpty()) gradientColors else AppleMusicFallbackGradient
@@ -748,7 +767,7 @@ private fun MovingBlurBackground(
             modifier
                 .fillMaxSize()
                 .clipToBounds()
-                .background(AppleMusicFallbackGradient.last()),
+                .background(if (glow) AppleMusicFallbackGradient.last() else Color.Black),
     ) {
         // The blur clips to its own bounds, so the layer cannot simply be screen-shaped: rotated
         // by the walk, a screen-sized rectangle only covers its inscribed circle and a black wedge
@@ -808,7 +827,7 @@ private fun MovingBlurBackground(
                         model = request,
                         contentDescription = null,
                         contentScale = ContentScale.Crop,
-                        colorFilter = vibrancyColorFilter,
+                        colorFilter = if (glow) vibrancyColorFilter else null,
                         modifier = Modifier.fillMaxSize(),
                     )
                 }
@@ -841,26 +860,38 @@ private fun MovingBlurBackground(
                         bitmap = art.asImageBitmap(),
                         contentDescription = null,
                         contentScale = ContentScale.Crop,
-                        colorFilter = vibrancyColorFilter,
+                        colorFilter = if (glow) vibrancyColorFilter else null,
                         modifier = Modifier.fillMaxSize(),
                     )
                 }
             }
         }
 
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .background(backgroundBrush),
-        )
+        if (glow) {
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .background(backgroundBrush),
+            )
 
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .background(bottomScrim),
-        )
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .background(bottomScrim),
+            )
+        } else {
+            // The still backdrop's own treatment, moving: the blurred cover under a flat black
+            // scrim, with the track's palette left out of it entirely. Same artwork, dimmed by the
+            // same amount as the still one — the walk is the only thing added.
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .background(Color.Black.copy(alpha = AppleMusicScrimAlpha)),
+            )
+        }
     }
 }
 

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/AppearanceSettings.kt
@@ -383,6 +383,7 @@ fun AppearanceSettings(navController: NavController) {
                 LyricsBackgroundStyle.FOLLOW_THEME,
                 LyricsBackgroundStyle.COLORING,
                 LyricsBackgroundStyle.MOVING_BLUR,
+                LyricsBackgroundStyle.MOVING_GLOW,
             )
         }
     val lyricsBackground = configuredLyricsBackground.resolveFor(playerBackground)
@@ -830,6 +831,7 @@ fun AppearanceSettings(navController: NavController) {
                                 LyricsBackgroundStyle.COLORING -> stringResource(R.string.coloring)
                                 LyricsBackgroundStyle.CUSTOM -> stringResource(R.string.custom)
                                 LyricsBackgroundStyle.MOVING_BLUR -> stringResource(R.string.lyrics_background_moving_blur)
+                                LyricsBackgroundStyle.MOVING_GLOW -> stringResource(R.string.lyrics_background_moving_glow)
                             }
                         },
                     )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1138,6 +1138,7 @@
     <string name="navigation_bar_reset_dimensions">Reset dimensions to default</string>
     <!-- Moving blur lyrics background -->
     <string name="lyrics_background_moving_blur">Moving blur</string>
+    <string name="lyrics_background_moving_glow">Moving glow</string>
     <string name="use_gpu_blur">Use GPU blur</string>
     <string name="use_gpu_blur_desc">Blur the moving lyrics background on the GPU instead of reusing a pre-blurred image. Android 12 and above only.</string>
 </resources>


### PR DESCRIPTION
The moving backdrop had exactly one look: the artwork pushed through a saturation and brightness lift, then washed with the track's own palette. It reads as a glow rather than as a cover. The **still** default reads as a blurred cover — and that is the one worth setting in motion.

### What changed

**Moving blur** now draws the still backdrop's own treatment: the blurred artwork, unfiltered, under the same flat black scrim on the same black base. The palette wash, the saturation lift and the brightness lift are all gone.

**Moving glow** is a new entry in the picker carrying everything that was removed — palette scrim, bottom scrim, saturation, brightness. The look you have now, kept, just no longer the only option.

Both are the same composable with one flag, so the walk is identical between them: same footprint, same rotation, same pace.

The scrim alpha is now a single shared constant (`AppleMusicScrimAlpha`), used by the still backdrop and the plain moving one, so the two cannot quietly drift apart.

### What to expect

The moving backdrop is blurred far harder than the still one — radius x1.6 over a 256px decode, because the drift needs the softness to hide its own edges. So at the same scrim it will read **softer and a little darker** than the still default. That is the one thing worth judging on device.

If it goes too far, there are two dials and they are both single constants:

- `AppleMusicScrimAlpha` (0.52) — lower it to let more of the cover through. Shared, so it moves the still backdrop too; say the word if you want them independent.
- The blur radius setting, which the moving backdrop multiplies by 1.6.

### Scope

Four files: the enum, `LyricsScreen.kt`, the settings picker, and one string. The `when` that dispatches the style had no `else`, so the new value needed its own arm — it has one.