### PR TITLE
refactor: drop the moving glow style, and lift the moving blur's colour and light

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/constants/PreferenceKeys.kt
@@ -719,8 +719,7 @@ enum class LyricsBackgroundStyle {
     FOLLOW_THEME,
     COLORING,
     CUSTOM,
-    MOVING_BLUR,
-    MOVING_GLOW;
+    MOVING_BLUR;
 
     fun resolveFor(playerBackgroundStyle: PlayerBackgroundStyle): LyricsBackgroundStyle =
         when {

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
@@ -548,19 +548,6 @@ private fun LyricsScreenBackground(
                 )
             }
 
-            LyricsBackgroundStyle.MOVING_GLOW -> {
-                MovingGlowBackground(
-                    mediaMetadata = mediaMetadata,
-                    gradientColors = gradientColors,
-                    disableBlur = disableBlur,
-                    blurRadius = blurRadius,
-                    playerCustomImageUri = playerCustomImageUri,
-                    playerCustomBlur = playerCustomBlur,
-                    playerCustomContrast = playerCustomContrast,
-                    playerCustomBrightness = playerCustomBrightness,
-                )
-            }
-
             LyricsBackgroundStyle.COLORING,
             LyricsBackgroundStyle.CUSTOM,
             -> {
@@ -668,16 +655,17 @@ private fun MovingBlurBackground(
     disableBlur: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    // Blurring this hard averages a cover towards its own mean, which costs it the colour the
-    // still backdrop keeps — so the artwork gets a light saturation correction on the way in. Not
-    // the glow's lift, which pushed saturation to 1.6 and brightness past 1.0: this only gives
-    // back what the blur averaged away. If this still reads pale, this is the dial.
+    // Blurring this hard averages a cover towards its own mean, which costs it both colour and
+    // brightness — so the artwork gets a light saturation correction and a small lift on the way
+    // in. Only giving back what the blur averaged away, not a look of its own: both dials are
+    // constants below, and if this still reads pale or dim they are the two to turn.
     //
     // Built by hand because androidx.compose.ui.graphics.ColorMatrix has no setSaturation(): these
     // are the standard Rec. 709 saturation terms, and at s = 1 the matrix is the identity.
     val vibrancyColorFilter =
         remember {
             val s = MOVING_BLUR_SATURATION
+            val gain = MOVING_BLUR_BRIGHTNESS
             // The rows are deliberately *not* identical: each output channel keeps its own channel
             // at (luma + s) and takes the other two at (luma * (1 - s)). Writing one row three
             // times — which is what the ported version of this did — computes the same weighted sum
@@ -689,9 +677,9 @@ private fun MovingBlurBackground(
             ColorFilter.colorMatrix(
                 ColorMatrix(
                     floatArrayOf(
-                        lr + s, lg, lb, 0f, 0f,
-                        lr, lg + s, lb, 0f, 0f,
-                        lr, lg, lb + s, 0f, 0f,
+                        (lr + s) * gain, lg * gain, lb * gain, 0f, 0f,
+                        lr * gain, (lg + s) * gain, lb * gain, 0f, 0f,
+                        lr * gain, lg * gain, (lb + s) * gain, 0f, 0f,
                         0f, 0f, 0f, 1f, 0f,
                     ),
                 ),
@@ -794,44 +782,6 @@ private fun MovingBlurBackground(
 }
 
 /**
- * The player's own GLOW background, set on the same walk as the moving blur.
- *
- * GLOW is a field of radial gradients drawn from the track's palette — the album's colours doing
- * the glowing rather than the cover itself, which is the other reading of "a moving glow". Getting
- * it moving is only a matter of wrapping it: it fills whatever box it is put in.
- */
-@Composable
-private fun MovingGlowBackground(
-    mediaMetadata: MediaMetadata,
-    gradientColors: List<Color>,
-    disableBlur: Boolean,
-    blurRadius: Float,
-    playerCustomImageUri: String,
-    playerCustomBlur: Float,
-    playerCustomContrast: Float,
-    playerCustomBrightness: Float,
-    modifier: Modifier = Modifier,
-) {
-    Box(modifier = modifier.fillMaxSize().background(Color.Black)) {
-        // Keyed on the palette, not the artwork: GLOW draws no cover, so it is the colours
-        // arriving that should start it moving.
-        DriftingBackdrop(active = gradientColors.isNotEmpty()) {
-            PlayerBackground(
-                playerBackground = PlayerBackgroundStyle.GLOW,
-                mediaMetadata = mediaMetadata,
-                gradientColors = gradientColors,
-                disableBlur = disableBlur,
-                blurRadius = blurRadius,
-                playerCustomImageUri = playerCustomImageUri,
-                playerCustomBlur = playerCustomBlur,
-                playerCustomContrast = playerCustomContrast,
-                playerCustomBrightness = playerCustomBrightness,
-            )
-        }
-    }
-}
-
-/**
  * Puts [content] on the walk.
  *
  * The layer cannot simply be screen-shaped: rotated by the walk, a screen-sized rectangle only
@@ -907,9 +857,17 @@ private const val MOVING_BLUR_ALPHA = 1f
 
 /**
  * Light saturation for the drifting artwork. Blurring averages colour away, so this gives a little
- * of it back — a correction, not the glow's 1.6, which was a look in itself.
+ * of it back. A correction, not a look: the earlier version ran this at 1.6 and laid a palette wash
+ * over the top as well, which turned the backdrop into a glow rather than a cover.
  */
-private const val MOVING_BLUR_SATURATION = 1.2f
+private const val MOVING_BLUR_SATURATION = 1.3f
+
+/**
+ * A small brightness lift on the same reasoning. The blur averages a cover towards its own mean,
+ * and that mean sits below the cover's own highlights, so the backdrop reads dimmer than the still
+ * one under the same scrim. Kept small on purpose — past roughly 1.15 the highlights start to blow.
+ */
+private const val MOVING_BLUR_BRIGHTNESS = 1.08f
 
 /** Decode size for the drifting artwork — the blur hides everything finer than this. */
 private const val MOVING_BLUR_ART_PX = 256

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/AppearanceSettings.kt
@@ -383,7 +383,6 @@ fun AppearanceSettings(navController: NavController) {
                 LyricsBackgroundStyle.FOLLOW_THEME,
                 LyricsBackgroundStyle.COLORING,
                 LyricsBackgroundStyle.MOVING_BLUR,
-                LyricsBackgroundStyle.MOVING_GLOW,
             )
         }
     val lyricsBackground = configuredLyricsBackground.resolveFor(playerBackground)
@@ -831,7 +830,6 @@ fun AppearanceSettings(navController: NavController) {
                                 LyricsBackgroundStyle.COLORING -> stringResource(R.string.coloring)
                                 LyricsBackgroundStyle.CUSTOM -> stringResource(R.string.custom)
                                 LyricsBackgroundStyle.MOVING_BLUR -> stringResource(R.string.lyrics_background_moving_blur)
-                                LyricsBackgroundStyle.MOVING_GLOW -> stringResource(R.string.lyrics_background_moving_glow)
                             }
                         },
                     )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1138,7 +1138,6 @@
     <string name="navigation_bar_reset_dimensions">Reset dimensions to default</string>
     <!-- Moving blur lyrics background -->
     <string name="lyrics_background_moving_blur">Moving blur</string>
-    <string name="lyrics_background_moving_glow">Moving glow</string>
     <string name="use_gpu_blur">Use GPU blur</string>
     <string name="use_gpu_blur_desc">Blur the moving lyrics background on the GPU instead of reusing a pre-blurred image. Android 12 and above only.</string>
 </resources>


### PR DESCRIPTION
Two things: the moving glow is gone for now, and the moving blur gets a small colour and brightness lift.

### Moving glow removed

Everything, not just the picker entry — the enum value, the dispatch arm, the `MovingGlowBackground` composable and its string. Nothing left referencing it.

The drifting wrapper (`DriftingBackdrop`) stays: #84 factored it out and the moving blur uses it too, so it was shared rather than glow-specific.

### Moving blur: saturation 1.2 -> 1.3, brightness -> 1.08

The moving blur carries a heavy blur, and blurring averages a cover towards its own mean. That mean costs it both colour *and* brightness next to the still backdrop under the same scrim, and it is why it has kept reading a little pale and dim.

- **Saturation 1.2 -> 1.3.** #84 had already put a light correction back at 1.2; this nudges it.
- **Brightness 1.08, added.** #84 dropped brightness to nothing when it separated the two styles. This puts a smaller one back, applied as a gain across the Rec. 709 rows rather than as a second filter, so it costs nothing extra per frame.

For reference, the old glow ran saturation 1.6 with brightness 1.06 *and* a palette wash over the top — which is why it read as a glow rather than as a cover. This is deliberately nowhere near that.

### The dials

Both are single constants at the bottom of `LyricsScreen.kt`, each with the reasoning next to it:

- `MOVING_BLUR_SATURATION = 1.3f`
- `MOVING_BLUR_BRIGHTNESS = 1.08f`

Past roughly 1.15 on the brightness the highlights start to blow, so that is the ceiling worth trying before anything else.

### Relanding the glow

It comes back with a revert of the removal half of this commit — the colour and brightness changes are independent of it.