### PR TITLE
fix: app lock said there was no screen lock on Android 10

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/AppLockScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/AppLockScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -43,6 +44,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.navigation.NavController
 import dev.citali.lunartune.LocalPlayerAwareWindowInsets
 import dev.citali.lunartune.R
@@ -85,7 +89,20 @@ fun AppLockScreen(navController: NavController) {
         rememberPreference(AppLockBiometricUnlockKey, defaultValue = false)
 
     val pinSet = pinHash.isNotBlank()
-    val screenLockAvailable = remember { SecurityUtils.canUseScreenLock(context) }
+    // Re-checked every time the screen comes back to the front, so setting up a
+    // screen lock in the system settings and returning is enough.
+    var screenLockAvailable by remember { mutableStateOf(SecurityUtils.canUseScreenLock(context)) }
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer =
+            LifecycleEventObserver { _, event ->
+                if (event == Lifecycle.Event.ON_RESUME) {
+                    screenLockAvailable = SecurityUtils.canUseScreenLock(context)
+                }
+            }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
     var pendingChange by remember { mutableStateOf<(() -> Unit)?>(null) }
 
     // Switching away from a configured PIN throws it away, so confirm first.

--- a/app/src/main/kotlin/dev/citali/lunartune/utils/SecurityUtils.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/utils/SecurityUtils.kt
@@ -32,16 +32,27 @@ object SecurityUtils {
             .joinToString("") { "%02x".format(it) }
 
     /**
-     * True when the device can actually authenticate, either with a strong
-     * biometric or with the screen lock PIN, pattern or password.
+     * Biometric or device credential. BIOMETRIC_WEAK rather than STRONG because
+     * the lock guards the UI, not a key: nothing here is bound to a CryptoObject,
+     * so a Class 2 face unlock is as good as a Class 3 fingerprint. It is also
+     * the only biometric | credential combination androidx.biometric supports on
+     * every API level. STRONG | DEVICE_CREDENTIAL is rejected outright on
+     * Android 9 and 10: canAuthenticate() answers BIOMETRIC_ERROR_UNSUPPORTED
+     * without looking at the device, and PromptInfo.Builder.build() throws. That
+     * showed up as "set up a screen lock first" on a phone that had one.
+     */
+    private const val ALLOWED_AUTHENTICATORS =
+        BiometricManager.Authenticators.BIOMETRIC_WEAK or
+            BiometricManager.Authenticators.DEVICE_CREDENTIAL
+
+    /**
+     * True when the device can actually authenticate, either with a biometric
+     * or with the screen lock PIN, pattern or password.
      */
     fun canUseScreenLock(context: Context): Boolean =
         BiometricManager
             .from(context)
-            .canAuthenticate(
-                BiometricManager.Authenticators.BIOMETRIC_STRONG or
-                    BiometricManager.Authenticators.DEVICE_CREDENTIAL,
-            ) == BiometricManager.BIOMETRIC_SUCCESS
+            .canAuthenticate(ALLOWED_AUTHENTICATORS) == BiometricManager.BIOMETRIC_SUCCESS
 
     /**
      * Shows the system authentication sheet. Device credential is allowed
@@ -80,10 +91,8 @@ object SecurityUtils {
                 .PromptInfo
                 .Builder()
                 .setTitle(title)
-                .setAllowedAuthenticators(
-                    BiometricManager.Authenticators.BIOMETRIC_STRONG or
-                        BiometricManager.Authenticators.DEVICE_CREDENTIAL,
-                ).build(),
+                .setAllowedAuthenticators(ALLOWED_AUTHENTICATORS)
+                .build(),
         )
     }
 }


### PR DESCRIPTION
Follow-up to #71. On a stock Android 10 phone with a PIN **and** a fingerprint enrolled, tapping **Same as screen lock** showed *"Set up a screen lock on your device first"*.

### Why

`canUseScreenLock` asked `BiometricManager` for `BIOMETRIC_STRONG | DEVICE_CREDENTIAL`. `androidx.biometric` does not support that pairing below Android 11 — on 9 and 10 `canAuthenticate()` returns `BIOMETRIC_ERROR_UNSUPPORTED` without even looking at the device, and `PromptInfo.Builder.build()` throws for the same flags. So the phone was told it had no screen lock, and if it had got past that check the prompt would have crashed.

### Fix

- Use `BIOMETRIC_WEAK | DEVICE_CREDENTIAL` for both the availability check and the prompt. It's the only biometric-or-credential combination the library accepts on every API level, and nothing in the app lock is bound to a `CryptoObject`, so a Class 2 biometric is exactly as good as a Class 3 one for gating the UI. On Android 11+ behaviour is unchanged (fingerprint / face / device PIN, all through the system sheet).
- The availability check ran once per screen (`remember {}`) and never refreshed. It now re-checks on every `ON_RESUME`, so going to system settings to enrol a screen lock and coming back is enough — no need to leave the page.

Affects both the *Same as screen lock* option and the *Unlock with fingerprint* toggle under Custom PIN.
