### PR TITLE
feat: app lock timeout, personal-screens scope, and forced secure flag

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/MainActivity.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/MainActivity.kt
@@ -19,6 +19,7 @@ import android.content.res.Configuration
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.os.SystemClock
 import android.os.IBinder
 import android.provider.OpenableColumns
 import android.view.View
@@ -115,6 +116,7 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -200,6 +202,10 @@ import dev.citali.lunartune.constants.CustomThemeColorKey
 import dev.citali.lunartune.constants.AppLockBiometricUnlockKey
 import dev.citali.lunartune.constants.AppLockEnabledKey
 import dev.citali.lunartune.constants.AppLockPinHashKey
+import dev.citali.lunartune.constants.AppLockScope
+import dev.citali.lunartune.constants.AppLockScopeKey
+import dev.citali.lunartune.constants.AppLockTimeout
+import dev.citali.lunartune.constants.AppLockTimeoutKey
 import dev.citali.lunartune.constants.AppLockType
 import dev.citali.lunartune.constants.AppLockTypeKey
 import dev.citali.lunartune.constants.DarkModeKey
@@ -270,6 +276,8 @@ import dev.citali.lunartune.playback.queues.Queue
 import dev.citali.lunartune.playback.queues.YouTubeAlbumRadio
 import dev.citali.lunartune.playback.queues.YouTubeQueue
 import dev.citali.lunartune.ui.component.AppLockGate
+import dev.citali.lunartune.ui.component.appLockConfigured
+import dev.citali.lunartune.ui.component.isSensitiveRoute
 import dev.citali.lunartune.ui.component.BottomSheetMenu
 import dev.citali.lunartune.ui.component.BottomSheetPage
 import dev.citali.lunartune.ui.component.COLLAPSED_ANCHOR
@@ -560,7 +568,10 @@ class MainActivity : FragmentActivity() {
 
         lifecycleScope.launch(Dispatchers.IO) {
             dataStore.data
-                .map { it[DisableScreenshotKey] ?: false }
+                // An app lock implies the secure flag: without it the task switcher
+                // keeps a thumbnail of whatever was on screen when the app was left,
+                // which is exactly what the lock is meant to hide.
+                .map { (it[DisableScreenshotKey] ?: false) || it.appLockConfigured() }
                 .distinctUntilChanged()
                 .collectLatest {
                     withContext(Dispatchers.Main) {
@@ -2515,53 +2526,84 @@ class MainActivity : FragmentActivity() {
                             openSearch()
                         }
                     }
-                }
-                val appLockEnabled by rememberPreference(AppLockEnabledKey, defaultValue = false)
-                val appLockType by rememberEnumPreference(AppLockTypeKey, defaultValue = AppLockType.NONE)
-                val appLockPinHash by rememberPreference(AppLockPinHashKey, defaultValue = "")
-                val appLockBiometricUnlock by rememberPreference(AppLockBiometricUnlockKey, defaultValue = false)
 
-                val appLockActive =
-                    appLockEnabled &&
-                        (
-                            appLockType == AppLockType.BIOMETRIC ||
-                                (appLockType == AppLockType.PIN && appLockPinHash.isNotBlank())
-                        )
-                var isLocked by rememberSaveable { mutableStateOf(appLockActive) }
-                var unlockedOnce by rememberSaveable { mutableStateOf(false) }
+                    val appLockEnabled by rememberPreference(AppLockEnabledKey, defaultValue = false)
+                    val appLockType by rememberEnumPreference(AppLockTypeKey, defaultValue = AppLockType.NONE)
+                    val appLockPinHash by rememberPreference(AppLockPinHashKey, defaultValue = "")
+                    val appLockBiometricUnlock by rememberPreference(AppLockBiometricUnlockKey, defaultValue = false)
+                    val appLockTimeout by rememberEnumPreference(AppLockTimeoutKey, defaultValue = AppLockTimeout.IMMEDIATELY)
+                    val appLockScope by rememberEnumPreference(AppLockScopeKey, defaultValue = AppLockScope.WHOLE_APP)
 
-                LaunchedEffect(appLockActive) {
-                    if (!appLockActive) {
-                        isLocked = false
-                    } else if (!isLocked && !unlockedOnce) {
-                        // Covers the case where the cached preference had not been read
-                        // when the first frame was composed. Turning the lock on from the
-                        // settings does not lock the session that is already open.
-                        isLocked = true
-                    }
-                }
+                    val appLockActive =
+                        appLockEnabled &&
+                            (
+                                appLockType == AppLockType.BIOMETRIC ||
+                                    (appLockType == AppLockType.PIN && appLockPinHash.isNotBlank())
+                            )
+                    var isLocked by rememberSaveable { mutableStateOf(appLockActive) }
+                    var unlockedOnce by rememberSaveable { mutableStateOf(false) }
+                    // When the app went to the background, or 0 while it is in front.
+                    // Kept across rotation so a config change cannot be used to skip the timeout.
+                    var leftAt by rememberSaveable { mutableLongStateOf(0L) }
 
-                DisposableEffect(appLockActive) {
-                    val observer =
-                        object : DefaultLifecycleObserver {
-                            override fun onStop(owner: LifecycleOwner) {
-                                if (appLockActive) isLocked = true
-                            }
-                        }
-                    ProcessLifecycleOwner.get().lifecycle.addObserver(observer)
-                    onDispose { ProcessLifecycleOwner.get().lifecycle.removeObserver(observer) }
-                }
-
-                if (isLocked && appLockActive) {
-                    AppLockGate(
-                        lockType = appLockType,
-                        pinHash = appLockPinHash,
-                        biometricUnlock = appLockBiometricUnlock,
-                        onUnlocked = {
+                    LaunchedEffect(appLockActive) {
+                        if (!appLockActive) {
                             isLocked = false
-                            unlockedOnce = true
-                        },
-                    )
+                        } else if (!isLocked && !unlockedOnce) {
+                            // Covers the case where the cached preference had not been read
+                            // when the first frame was composed. Turning the lock on from the
+                            // settings does not lock the session that is already open.
+                            isLocked = true
+                        }
+                    }
+
+                    DisposableEffect(appLockActive, appLockTimeout) {
+                        val observer =
+                            object : DefaultLifecycleObserver {
+                                override fun onStop(owner: LifecycleOwner) {
+                                    if (!appLockActive) return
+                                    if (appLockTimeout == AppLockTimeout.IMMEDIATELY) {
+                                        isLocked = true
+                                    } else {
+                                        leftAt = SystemClock.elapsedRealtime()
+                                    }
+                                }
+
+                                override fun onStart(owner: LifecycleOwner) {
+                                    if (!appLockActive || leftAt == 0L) return
+                                    // elapsedRealtime cannot be wound back by changing the clock.
+                                    if (SystemClock.elapsedRealtime() - leftAt >= appLockTimeout.millis) {
+                                        isLocked = true
+                                    }
+                                    leftAt = 0L
+                                }
+                            }
+                        ProcessLifecycleOwner.get().lifecycle.addObserver(observer)
+                        onDispose { ProcessLifecycleOwner.get().lifecycle.removeObserver(observer) }
+                    }
+
+                    // With the lock scoped to sensitive screens, the gate only drops over
+                    // the screens that hold personal data. Everything else stays usable,
+                    // and the lock waits until such a screen is opened.
+                    val appLockGateVisible =
+                        isLocked &&
+                            appLockActive &&
+                            (
+                                appLockScope == AppLockScope.WHOLE_APP ||
+                                    isSensitiveRoute(navBackStackEntry?.destination?.route)
+                            )
+
+                    if (appLockGateVisible) {
+                        AppLockGate(
+                            lockType = appLockType,
+                            pinHash = appLockPinHash,
+                            biometricUnlock = appLockBiometricUnlock,
+                            onUnlocked = {
+                                isLocked = false
+                                unlockedOnce = true
+                            },
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/dev/citali/lunartune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/constants/PreferenceKeys.kt
@@ -994,6 +994,8 @@ val AppLockTypeKey = stringPreferencesKey("appLockType")
 val AppLockPinHashKey = stringPreferencesKey("appLockPinHash")
 val AppLockPinLengthKey = stringPreferencesKey("appLockPinLength")
 val AppLockBiometricUnlockKey = booleanPreferencesKey("appLockBiometricUnlock")
+val AppLockTimeoutKey = stringPreferencesKey("appLockTimeout")
+val AppLockScopeKey = stringPreferencesKey("appLockScope")
 
 enum class AppLockType {
     NONE,
@@ -1005,6 +1007,22 @@ enum class AppLockPinLength(val digits: Int) {
     FOUR(4),
     SIX(6),
 }
+
+/** How long the app may stay in the background before it locks again. */
+enum class AppLockTimeout(val millis: Long) {
+    IMMEDIATELY(0L),
+    THIRTY_SECONDS(30_000L),
+    ONE_MINUTE(60_000L),
+    FIVE_MINUTES(5 * 60_000L),
+    FIFTEEN_MINUTES(15 * 60_000L),
+}
+
+/** What the lock covers: the whole app, or only the screens that hold personal data. */
+enum class AppLockScope {
+    WHOLE_APP,
+    SENSITIVE_ONLY,
+}
+
 
 enum class UpdateChannel {
     STABLE,

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/component/PinLockScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/component/PinLockScreen.kt
@@ -12,6 +12,11 @@ import androidx.fragment.app.FragmentActivity
 import androidx.compose.material3.Button
 import androidx.compose.ui.platform.LocalContext
 import dev.citali.lunartune.constants.AppLockPinLength
+import androidx.datastore.preferences.core.Preferences
+import dev.citali.lunartune.constants.AppLockEnabledKey
+import dev.citali.lunartune.constants.AppLockPinHashKey
+import dev.citali.lunartune.constants.AppLockTypeKey
+import dev.citali.lunartune.extensions.toEnum
 import dev.citali.lunartune.constants.AppLockPinLengthKey
 import dev.citali.lunartune.constants.AppLockType
 import dev.citali.lunartune.utils.SecurityUtils
@@ -65,6 +70,7 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
@@ -463,6 +469,44 @@ private const val DELAY_AUTO_SUBMIT = 100L
 private const val DELAY_WAVE_STAGGER = 30L
 
 /**
+ * True when a lock is configured, from a raw preferences snapshot. Mirrors the
+ * condition MainActivity uses to decide whether the gate can appear.
+ */
+fun Preferences.appLockConfigured(): Boolean {
+    if (this[AppLockEnabledKey] != true) return false
+    return when (this[AppLockTypeKey].toEnum(AppLockType.NONE)) {
+        AppLockType.BIOMETRIC -> true
+        AppLockType.PIN -> !this[AppLockPinHashKey].isNullOrBlank()
+        AppLockType.NONE -> false
+    }
+}
+
+/**
+ * Routes the lock covers when it is scoped to sensitive screens: the library
+ * and everything reached from it, listening history and stats, the account
+ * page, and all of the settings (linked accounts, backups, the lock itself).
+ * Home, search, browsing and the player stay open.
+ */
+fun isSensitiveRoute(route: String?): Boolean {
+    if (route == null) return false
+    return SENSITIVE_ROUTE_PREFIXES.any { route == it || route.startsWith("$it/") || route.startsWith("$it?") }
+}
+
+private val SENSITIVE_ROUTE_PREFIXES =
+    listOf(
+        "library",
+        "local_songs",
+        "history",
+        "stats",
+        "account",
+        "settings",
+        "auto_playlist",
+        "top_playlist",
+        "cache_playlist",
+        "local_playlist",
+    )
+
+/**
  * Full screen gate drawn over the whole app while it is locked.
  *
  * With a PIN it shows the PIN pad, optionally with a fingerprint key that opens
@@ -496,33 +540,43 @@ fun AppLockGate(
         }
     }
 
-    when (lockType) {
-        AppLockType.BIOMETRIC -> {
-            LaunchedEffect(Unit) { launchScreenLock() }
-            ScreenLockGate(onUnlockClick = { launchScreenLock() })
-        }
-
-        AppLockType.PIN -> {
-            val fingerprintAvailable = biometricUnlock && SecurityUtils.canUseScreenLock(context)
-            LaunchedEffect(Unit) {
-                if (fingerprintAvailable) launchScreenLock()
+    // The gate is drawn over the live app, so it must swallow every touch that
+    // its own controls do not use. Otherwise a tap on an empty part of the
+    // lock screen would reach whatever is underneath.
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .pointerInput(Unit) { awaitPointerEventScope { while (true) { awaitPointerEvent() } } },
+    ) {
+        when (lockType) {
+            AppLockType.BIOMETRIC -> {
+                LaunchedEffect(Unit) { launchScreenLock() }
+                ScreenLockGate(onUnlockClick = { launchScreenLock() })
             }
-            PinLockScreen(
-                title = stringResource(R.string.enter_pin),
-                isError = pinError,
-                maxPinLength = pinLength.digits,
-                onBiometricClick = if (fingerprintAvailable) ({ launchScreenLock() }) else null,
-                onPinSubmitted = { pin ->
-                    if (SecurityUtils.hashPin(pin) == pinHash) {
-                        onUnlocked()
-                    } else {
-                        pinError = true
-                    }
-                },
-            )
-        }
 
-        AppLockType.NONE -> Unit
+            AppLockType.PIN -> {
+                val fingerprintAvailable = biometricUnlock && SecurityUtils.canUseScreenLock(context)
+                LaunchedEffect(Unit) {
+                    if (fingerprintAvailable) launchScreenLock()
+                }
+                PinLockScreen(
+                    title = stringResource(R.string.enter_pin),
+                    isError = pinError,
+                    maxPinLength = pinLength.digits,
+                    onBiometricClick = if (fingerprintAvailable) ({ launchScreenLock() }) else null,
+                    onPinSubmitted = { pin ->
+                        if (SecurityUtils.hashPin(pin) == pinHash) {
+                            onUnlocked()
+                        } else {
+                            pinError = true
+                        }
+                    },
+                )
+            }
+
+            AppLockType.NONE -> Unit
+        }
     }
 }
 

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/AppLockScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/AppLockScreen.kt
@@ -55,10 +55,15 @@ import dev.citali.lunartune.constants.AppLockEnabledKey
 import dev.citali.lunartune.constants.AppLockPinHashKey
 import dev.citali.lunartune.constants.AppLockPinLength
 import dev.citali.lunartune.constants.AppLockPinLengthKey
+import dev.citali.lunartune.constants.AppLockScope
+import dev.citali.lunartune.constants.AppLockScopeKey
+import dev.citali.lunartune.constants.AppLockTimeout
+import dev.citali.lunartune.constants.AppLockTimeoutKey
 import dev.citali.lunartune.constants.AppLockType
 import dev.citali.lunartune.constants.AppLockTypeKey
 import dev.citali.lunartune.ui.component.DefaultDialog
 import dev.citali.lunartune.ui.component.IconButton as AppIconButton
+import dev.citali.lunartune.ui.component.ListPreference
 import dev.citali.lunartune.ui.component.PinLockScreen
 import dev.citali.lunartune.ui.component.PreferenceEntry
 import dev.citali.lunartune.ui.component.PreferenceGroup
@@ -87,6 +92,10 @@ fun AppLockScreen(navController: NavController) {
         rememberEnumPreference(AppLockPinLengthKey, defaultValue = AppLockPinLength.SIX)
     val (biometricUnlock, onBiometricUnlockChange) =
         rememberPreference(AppLockBiometricUnlockKey, defaultValue = false)
+    val (lockTimeout, onLockTimeoutChange) =
+        rememberEnumPreference(AppLockTimeoutKey, defaultValue = AppLockTimeout.IMMEDIATELY)
+    val (lockScope, onLockScopeChange) =
+        rememberEnumPreference(AppLockScopeKey, defaultValue = AppLockScope.WHOLE_APP)
 
     val pinSet = pinHash.isNotBlank()
     // Re-checked every time the screen comes back to the front, so setting up a
@@ -196,6 +205,49 @@ fun AppLockScreen(navController: NavController) {
                             }
                         },
                     )
+                }
+            }
+
+            val lockConfigured =
+                lockEnabled && (lockType == AppLockType.BIOMETRIC || (lockType == AppLockType.PIN && pinSet))
+
+            if (lockConfigured) {
+                Spacer(modifier = Modifier.height(16.dp))
+
+                PreferenceGroup(title = stringResource(R.string.app_lock_options)) {
+                    item {
+                        ListPreference(
+                            title = { Text(stringResource(R.string.lock_after)) },
+                            description = stringResource(R.string.lock_after_desc),
+                            icon = { Icon(painterResource(R.drawable.timer), null) },
+                            selectedValue = lockTimeout,
+                            values = AppLockTimeout.entries,
+                            valueText = { timeoutLabel(it) },
+                            onValueSelected = onLockTimeoutChange,
+                        )
+                    }
+
+                    item {
+                        ListPreference(
+                            title = { Text(stringResource(R.string.lock_scope)) },
+                            icon = { Icon(painterResource(R.drawable.lock), null) },
+                            selectedValue = lockScope,
+                            values = AppLockScope.entries,
+                            valueText = {
+                                when (it) {
+                                    AppLockScope.WHOLE_APP -> stringResource(R.string.lock_scope_whole_app)
+                                    AppLockScope.SENSITIVE_ONLY -> stringResource(R.string.lock_scope_sensitive)
+                                }
+                            },
+                            valueDescription = {
+                                when (it) {
+                                    AppLockScope.WHOLE_APP -> stringResource(R.string.lock_scope_whole_app_desc)
+                                    AppLockScope.SENSITIVE_ONLY -> stringResource(R.string.lock_scope_sensitive_desc)
+                                }
+                            },
+                            onValueSelected = onLockScopeChange,
+                        )
+                    }
                 }
             }
 
@@ -393,3 +445,13 @@ fun PinSetupScreen(navController: NavController) {
         )
     }
 }
+
+@Composable
+private fun timeoutLabel(timeout: AppLockTimeout): String =
+    when (timeout) {
+        AppLockTimeout.IMMEDIATELY -> stringResource(R.string.lock_timeout_immediately)
+        AppLockTimeout.THIRTY_SECONDS -> stringResource(R.string.lock_timeout_seconds, 30)
+        AppLockTimeout.ONE_MINUTE -> stringResource(R.string.lock_timeout_minute)
+        AppLockTimeout.FIVE_MINUTES -> stringResource(R.string.lock_timeout_minutes, 5)
+        AppLockTimeout.FIFTEEN_MINUTES -> stringResource(R.string.lock_timeout_minutes, 15)
+    }

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/PrivacySettings.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/PrivacySettings.kt
@@ -83,6 +83,10 @@ fun PrivacySettings(navController: NavController) {
     val (appLockType) = rememberEnumPreference(AppLockTypeKey, defaultValue = AppLockType.NONE)
     val (appLockPinHash) = rememberPreference(AppLockPinHashKey, defaultValue = "")
 
+    val appLockConfigured =
+        appLockEnabled &&
+            (appLockType == AppLockType.BIOMETRIC || (appLockType == AppLockType.PIN && appLockPinHash.isNotBlank()))
+
     val appLockSummary =
         when {
             !appLockEnabled -> stringResource(R.string.no_lock)
@@ -253,12 +257,21 @@ fun PrivacySettings(navController: NavController) {
                 }
 
                 item {
+                    // An app lock keeps the secure flag on: otherwise Recents would keep
+                    // a thumbnail of what the lock is there to hide. The switch shows the
+                    // forced state and stays put until the lock is removed.
                     SwitchPreference(
                         title = { Text(stringResource(R.string.disable_screenshot)) },
-                        description = stringResource(R.string.disable_screenshot_desc),
+                        description =
+                            if (appLockConfigured) {
+                                stringResource(R.string.disable_screenshot_locked_desc)
+                            } else {
+                                stringResource(R.string.disable_screenshot_desc)
+                            },
                         icon = { Icon(painterResource(R.drawable.screenshot), null) },
-                        checked = disableScreenshot,
+                        checked = disableScreenshot || appLockConfigured,
                         onCheckedChange = onDisableScreenshotChange,
+                        isEnabled = !appLockConfigured,
                     )
                 }
             }

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/SettingsDataBuilders.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/SettingsDataBuilders.kt
@@ -32,6 +32,10 @@ import dev.citali.lunartune.constants.CrossfadeEnabledKey
 import dev.citali.lunartune.constants.CrossfadeGaplessKey
 import dev.citali.lunartune.constants.DisableAnimationsKey
 import dev.citali.lunartune.constants.DisableBlurKey
+import dev.citali.lunartune.constants.AppLockEnabledKey
+import dev.citali.lunartune.constants.AppLockPinHashKey
+import dev.citali.lunartune.constants.AppLockType
+import dev.citali.lunartune.constants.AppLockTypeKey
 import dev.citali.lunartune.constants.DisableScreenshotKey
 import dev.citali.lunartune.constants.DynamicThemeKey
 import dev.citali.lunartune.constants.EnableDiscordRPCKey
@@ -72,6 +76,7 @@ import dev.citali.lunartune.constants.UseLyricsV2Key
 import dev.citali.lunartune.constants.UseSystemFontKey
 import dev.citali.lunartune.constants.UseGpuBlurKey
 import dev.citali.lunartune.constants.WakelockKey
+import dev.citali.lunartune.utils.rememberEnumPreference
 import dev.citali.lunartune.utils.rememberPreference
 
 @Composable
@@ -85,6 +90,22 @@ private fun SearchResultSwitch(
         checked = checked,
         onCheckedChange = onCheckedChange,
         enabled = enabled,
+    )
+}
+
+/** Same forced-on state as the Privacy page: an app lock keeps the secure flag set. */
+@Composable
+private fun DisableScreenshotSearchSwitch() {
+    val (checked, onCheckedChange) = rememberPreference(DisableScreenshotKey, false)
+    val (lockEnabled) = rememberPreference(AppLockEnabledKey, false)
+    val (lockType) = rememberEnumPreference(AppLockTypeKey, AppLockType.NONE)
+    val (pinHash) = rememberPreference(AppLockPinHashKey, "")
+    val lockConfigured =
+        lockEnabled && (lockType == AppLockType.BIOMETRIC || (lockType == AppLockType.PIN && pinHash.isNotBlank()))
+    Switch(
+        checked = checked || lockConfigured,
+        onCheckedChange = onCheckedChange,
+        enabled = !lockConfigured,
     )
 }
 
@@ -287,7 +308,7 @@ fun buildSettingsGroups(
                 SettingsChild("Clear search history", "clear_search_history", listOf("clear search", "delete search", "reset search")),
                 SettingsChild("Sync playback to YouTube history", "sync_yt_history", listOf("youtube history", "sync history", "playback history")),
                 SettingsChild("Haptics", "haptics", listOf("haptic", "vibration", "haptic feedback", "vibrate")) { SearchResultSwitch(EnableHapticFeedbackKey, true) },
-                SettingsChild("Disable screenshot", "disable_screenshot", listOf("screenshot", "screen capture", "privacy", "no screenshot")) { SearchResultSwitch(DisableScreenshotKey, false) },
+                SettingsChild("Disable screenshot", "disable_screenshot", listOf("screenshot", "screen capture", "privacy", "no screenshot")) { DisableScreenshotSearchSwitch() },
                 SettingsChild("Network metered", "network_metered", listOf("metered", "mobile data", "cellular", "data saver")) { SearchResultSwitch(NetworkMeteredKey, false) },
                 SettingsChild("Show tags in library", "show_tags_in_library", listOf("tags", "library tags", "show tags")),
                 SettingsChild("App lock", "app_lock", listOf("app lock", "lock", "pin", "security", "privacy", "unlock")),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1163,6 +1163,19 @@
     <string name="change_lock_title">Change lock method?</string>
     <string name="change_lock_message">Your current PIN will be removed.</string>
     <string name="action_unlock">Unlock</string>
+    <string name="app_lock_options">Lock options</string>
+    <string name="lock_after">Lock again after</string>
+    <string name="lock_after_desc">How long the app can sit in the background before it asks again</string>
+    <string name="lock_timeout_immediately">Immediately</string>
+    <string name="lock_timeout_seconds">%1$d seconds</string>
+    <string name="lock_timeout_minute">1 minute</string>
+    <string name="lock_timeout_minutes">%1$d minutes</string>
+    <string name="lock_scope">What to lock</string>
+    <string name="lock_scope_whole_app">Whole app</string>
+    <string name="lock_scope_whole_app_desc">Ask before anything is shown</string>
+    <string name="lock_scope_sensitive">Personal screens only</string>
+    <string name="lock_scope_sensitive_desc">Library, history, stats, account and settings. Home, search and the player stay open.</string>
+    <string name="disable_screenshot_locked_desc">Kept on while an app lock is set, so the app\'s view in Recents cannot show what the lock hides.</string>
     <!-- Moving blur lyrics background -->
     <string name="lyrics_background_moving_blur">Moving blur</string>
     <string name="use_gpu_blur">Use GPU blur</string>


### PR DESCRIPTION
Follow-ups to the app lock (#71, #91). Three things that decide whether people actually leave a lock switched on.

### Lock again after

How long the app may sit in the background before it asks again: **Immediately** (as before, and still the default), 30 seconds, 1, 5 or 15 minutes. Checking a message and coming straight back no longer costs a fingerprint.

- Measured with `SystemClock.elapsedRealtime()`, so winding the system clock back does not extend the grace.
- The leave time is `rememberSaveable`, so rotating the phone or a config change cannot be used to skip the timeout.

### What to lock

- **Whole app** (default) — as before.
- **Personal screens only** — home, search, browsing and the player stay open. The gate drops over the library and everything reached from it (local songs, auto/local/cached/top playlists), listening history, stats, the account page and *every* settings screen — including the lock's own page, so the lock cannot be removed without unlocking first.

The gate now also swallows touches that land beside its controls. It sits over the live app, and in scoped mode the app underneath is usable, so a tap on empty lock-screen space must not fall through.

### Disable screenshot follows the lock

While a lock is configured, **Disable screenshot** (Privacy) is shown on and greyed out, with a description saying why; the settings-search switch matches. The secure flag is what stops Recents keeping a thumbnail of whatever screen the app was left on — exactly what the lock is meant to hide. The user's own value is untouched underneath and comes back the moment the lock is removed. `MainActivity` sets `FLAG_SECURE` when either the preference or a configured lock says so.

### UI

Both options live in a new **Lock options** group on the App lock page, shown for either lock method.
