### PR TITLE
style: song options sheet in the lyrics-search look, and tidy that sheet

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/ui/menu/LyricsMenu.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/menu/LyricsMenu.kt
@@ -79,6 +79,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
@@ -919,8 +920,9 @@ private fun LyricsSearchResultHeader(
             }
 
             is LyricsSearchScreenState.Success -> {
-                stringResource(
-                    R.string.lyrics_search_results_count,
+                pluralStringResource(
+                    R.plurals.lyrics_search_results_found,
+                    state.results.size,
                     state.results.size,
                 )
             }
@@ -1094,18 +1096,29 @@ private fun LyricsSearchResultItem(
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
-                IconButton(
+                Surface(
                     onClick = onExpandedChange,
-                    modifier = Modifier.size(48.dp),
+                    shape = MaterialTheme.shapes.large,
+                    color =
+                        if (isExpanded) {
+                            MaterialTheme.colorScheme.surface.copy(alpha = 0.52f)
+                        } else {
+                            MaterialTheme.colorScheme.surfaceContainerHigh
+                        },
+                    contentColor = contentColor,
+                    modifier = Modifier.size(40.dp),
                 ) {
-                    Icon(
-                        painter =
-                            painterResource(
-                                if (isExpanded) R.drawable.expand_less else R.drawable.expand_more,
-                            ),
-                        contentDescription = stringResource(R.string.details),
-                        tint = contentColor,
-                    )
+                    Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                        Icon(
+                            painter =
+                                painterResource(
+                                    if (isExpanded) R.drawable.expand_less else R.drawable.expand_more,
+                                ),
+                            contentDescription = stringResource(R.string.details),
+                            tint = contentColor,
+                            modifier = Modifier.size(22.dp),
+                        )
+                    }
                 }
             }
             LyricsSearchResultSupportingContent(
@@ -1119,18 +1132,41 @@ private fun LyricsSearchResultItem(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 LyricsSearchMetadataPill(
-                    icon = R.drawable.info,
-                    text = lyricsType,
-                    isExpanded = isExpanded,
-                    modifier = Modifier.weight(1f),
-                )
-                LyricsSearchMetadataPill(
                     icon = R.drawable.text_fields,
                     text = stats,
                     isExpanded = isExpanded,
                     modifier = Modifier.weight(1f),
                 )
+                LyricsSearchUsePill(onClick = onResultSelected)
             }
+        }
+    }
+}
+
+/** The one action a result card has, made visible instead of relying on a tap anywhere. */
+@Composable
+private fun LyricsSearchUsePill(onClick: () -> Unit) {
+    Surface(
+        onClick = onClick,
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.primary,
+        contentColor = MaterialTheme.colorScheme.onPrimary,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.check),
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+            )
+            Text(
+                text = stringResource(R.string.lyrics_search_use_these),
+                style = MaterialTheme.typography.labelMedium,
+                maxLines = 1,
+            )
         }
     }
 }
@@ -1261,20 +1297,34 @@ private fun LyricsSearchLoadingContent() {
 
 @Composable
 private fun LyricsSearchFooterLoading() {
-    Row(
+    Box(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 24.dp, vertical = 12.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
+                .padding(top = 4.dp),
+        contentAlignment = Alignment.Center,
     ) {
-        LoadingIndicator(modifier = Modifier.size(24.dp))
-        Text(
-            text = stringResource(R.string.lyrics_search_still_searching),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        Surface(
+            shape = MaterialTheme.shapes.extraLarge,
+            color = MaterialTheme.colorScheme.surfaceContainerHighest,
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+        ) {
+            Row(
+                modifier = Modifier.padding(start = 12.dp, end = 18.dp, top = 8.dp, bottom = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                LoadingIndicator(
+                    modifier = Modifier.size(22.dp),
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Text(
+                    text = stringResource(R.string.lyrics_search_still_searching),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
     }
 }
 

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/menu/PerSongSettingsDialog.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/menu/PerSongSettingsDialog.kt
@@ -10,18 +10,40 @@ package dev.citali.lunartune.ui.menu
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AlertDialogDefaults
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -30,12 +52,19 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import coil3.compose.AsyncImage
 import dev.citali.lunartune.R
 import dev.citali.lunartune.constants.NeverRecommendSongIdsKey
 import dev.citali.lunartune.constants.PerSongAlbumArtOverridesKey
@@ -56,11 +85,19 @@ import dev.citali.lunartune.utils.setPlayerDesignStyleOverride
 import dev.citali.lunartune.utils.setTabMapValue
 import dev.citali.lunartune.utils.toggleIdSet
 
+/**
+ * Per-song overrides, laid out like the lyrics search sheet: a coloured header
+ * that names the song, then one card per option whose trailing control shows
+ * the current state at a glance.
+ */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun PerSongSettingsDialog(
     songId: String,
     onDismiss: () -> Unit,
+    songTitle: String? = null,
+    songArtist: String? = null,
+    thumbnailUrl: String? = null,
 ) {
     val context = LocalContext.current
     val settingsPlayerDesignStyle by rememberEnumPreference(PlayerDesignStyleKey, defaultValue = PlayerDesignStyle.V4)
@@ -76,10 +113,11 @@ fun PerSongSettingsDialog(
         remember(playerStyleOverrides, songId) {
             parsePlayerDesignStyleOverrides(playerStyleOverrides)[songId]
         }
-    val hasCustomArt =
+    val customArtPath =
         remember(albumArtOverrides, songId) {
-            !parseTabMap(albumArtOverrides)[songId].isNullOrBlank()
+            parseTabMap(albumArtOverrides)[songId]?.takeIf { it.isNotBlank() }
         }
+    val hasCustomArt = customArtPath != null
     val currentTags =
         remember(tagsRaw, songId) {
             parseSongTags(parseTabMap(tagsRaw)[songId].orEmpty())
@@ -88,6 +126,8 @@ fun PerSongSettingsDialog(
         remember(neverRecommendRaw, songId) {
             songId in parseIdSet(neverRecommendRaw)
         }
+    val overrideCount =
+        listOf(songStyle != null, hasCustomArt, neverRecommend, currentTags.isNotEmpty()).count { it }
 
     var showPlayerStyleDialog by rememberSaveable { mutableStateOf(false) }
     var showTagsDialog by rememberSaveable { mutableStateOf(false) }
@@ -118,7 +158,10 @@ fun PerSongSettingsDialog(
                         )
                     },
                     leadingContent = {
-                        Icon(painter = painterResource(R.drawable.settings), contentDescription = null)
+                        Icon(
+                            painter = painterResource(if (songStyle == null) R.drawable.done else R.drawable.settings),
+                            contentDescription = null,
+                        )
                     },
                     modifier =
                         Modifier
@@ -193,114 +236,429 @@ fun PerSongSettingsDialog(
         )
     }
 
-    AlertDialog(
+    Dialog(
         onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.per_song_settings)) },
-        text = {
-            Column {
-                ListItem(
-                    headlineContent = { Text(stringResource(R.string.player_style_for_song)) },
-                    supportingContent = {
-                        Text(
-                            text = songStyle?.let { playerDesignStyleLabel(it) }
-                                ?: stringResource(R.string.player_style_use_default),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        BoxWithConstraints(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(24.dp)
+                    .imePadding()
+                    .navigationBarsPadding(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Surface(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .widthIn(max = 640.dp)
+                        .heightIn(max = maxHeight),
+                shape = MaterialTheme.shapes.extraLarge,
+                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                tonalElevation = AlertDialogDefaults.TonalElevation,
+            ) {
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    PerSongHeader(
+                        title = songTitle,
+                        artist = songArtist,
+                        thumbnailUrl = customArtPath ?: thumbnailUrl,
+                        overrideCount = overrideCount,
+                        onDismiss = onDismiss,
+                    )
+
+                    Column(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .weight(1f, fill = false)
+                                .verticalScroll(rememberScrollState())
+                                .padding(PaddingValues(start = 16.dp, end = 16.dp, top = 14.dp, bottom = 20.dp)),
+                        verticalArrangement = Arrangement.spacedBy(10.dp),
+                    ) {
+                        PerSongOptionCard(
+                            icon = R.drawable.style,
+                            title = stringResource(R.string.player_style_for_song),
+                            state =
+                                songStyle?.let { playerDesignStyleLabel(it) }
+                                    ?: stringResource(R.string.player_style_use_default),
+                            isSet = songStyle != null,
+                            onClick = { showPlayerStyleDialog = true },
+                            trailing = {
+                                PerSongValueChip(
+                                    text =
+                                        songStyle?.let { playerDesignStyleLabel(it) }
+                                            ?: playerDesignStyleLabel(settingsPlayerDesignStyle),
+                                    highlighted = songStyle != null,
+                                )
+                            },
                         )
-                    },
-                    leadingContent = {
-                        Icon(painter = painterResource(R.drawable.style), contentDescription = null)
-                    },
-                    modifier = Modifier.clickable { showPlayerStyleDialog = true },
-                    colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-                )
-                ListItem(
-                    headlineContent = { Text(stringResource(R.string.per_song_album_art)) },
-                    supportingContent = {
-                        Text(
-                            text =
+
+                        PerSongOptionCard(
+                            icon = R.drawable.image,
+                            title = stringResource(R.string.per_song_album_art),
+                            state =
                                 stringResource(
-                                    if (hasCustomArt) {
-                                        R.string.per_song_album_art_custom
-                                    } else {
-                                        R.string.per_song_album_art_default
-                                    },
+                                    if (hasCustomArt) R.string.per_song_album_art_custom else R.string.per_song_album_art_default,
                                 ),
-                        )
-                    },
-                    leadingContent = {
-                        Icon(painter = painterResource(R.drawable.image), contentDescription = null)
-                    },
-                    modifier = Modifier.clickable { galleryLauncher.launch("image/*") },
-                    trailingContent =
-                        if (hasCustomArt) {
-                            {
-                                TextButton(onClick = {
-                                    onAlbumArtOverridesChange(setTabMapValue(albumArtOverrides, songId, null))
-                                }) {
-                                    Text(stringResource(R.string.reset))
+                            isSet = hasCustomArt,
+                            onClick = { galleryLauncher.launch("image/*") },
+                            trailing = {
+                                if (hasCustomArt) {
+                                    Row(
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                    ) {
+                                        AsyncImage(
+                                            model = customArtPath,
+                                            contentDescription = null,
+                                            contentScale = ContentScale.Crop,
+                                            modifier =
+                                                Modifier
+                                                    .size(40.dp)
+                                                    .clip(RoundedCornerShape(12.dp)),
+                                        )
+                                        IconButton(
+                                            onClick = {
+                                                onAlbumArtOverridesChange(setTabMapValue(albumArtOverrides, songId, null))
+                                            },
+                                        ) {
+                                            Icon(
+                                                painter = painterResource(R.drawable.close),
+                                                contentDescription = stringResource(R.string.reset),
+                                                modifier = Modifier.size(20.dp),
+                                            )
+                                        }
+                                    }
+                                } else {
+                                    Icon(
+                                        painter = painterResource(R.drawable.arrow_forward),
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        modifier = Modifier.size(22.dp),
+                                    )
                                 }
-                            }
-                        } else {
-                            null
-                        },
-                    colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-                )
-                ListItem(
-                    headlineContent = { Text(stringResource(R.string.per_song_never_recommend)) },
-                    supportingContent = {
-                        Text(
-                            text =
-                                stringResource(
-                                    if (neverRecommend) {
-                                        R.string.per_song_never_recommend_on
-                                    } else {
-                                        R.string.per_song_never_recommend_off
-                                    },
-                                ),
+                            },
                         )
-                    },
-                    leadingContent = {
-                        Icon(painter = painterResource(R.drawable.block), contentDescription = null)
-                    },
-                    modifier =
-                        Modifier.clickable {
-                            onNeverRecommendChange(toggleIdSet(neverRecommendRaw, songId, !neverRecommend))
-                        },
-                    colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-                )
-                ListItem(
-                    headlineContent = { Text(stringResource(R.string.per_song_custom_tags)) },
-                    supportingContent = {
-                        Text(
-                            text =
+
+                        PerSongOptionCard(
+                            icon = R.drawable.block,
+                            title = stringResource(R.string.per_song_never_recommend),
+                            state =
+                                stringResource(
+                                    if (neverRecommend) R.string.per_song_never_recommend_on else R.string.per_song_never_recommend_off,
+                                ),
+                            isSet = neverRecommend,
+                            onClick = {
+                                onNeverRecommendChange(toggleIdSet(neverRecommendRaw, songId, !neverRecommend))
+                            },
+                            trailing = {
+                                Switch(
+                                    checked = neverRecommend,
+                                    onCheckedChange = {
+                                        onNeverRecommendChange(toggleIdSet(neverRecommendRaw, songId, it))
+                                    },
+                                )
+                            },
+                        )
+
+                        PerSongOptionCard(
+                            icon = R.drawable.edit,
+                            title = stringResource(R.string.per_song_custom_tags),
+                            state =
                                 if (currentTags.isEmpty()) {
                                     stringResource(R.string.per_song_custom_tags_none)
                                 } else {
-                                    formatSongTags(currentTags)
+                                    stringResource(R.string.per_song_tags_count, currentTags.size)
                                 },
-                            maxLines = 2,
-                            overflow = TextOverflow.Ellipsis,
+                            isSet = currentTags.isNotEmpty(),
+                            onClick = {
+                                tagsDraft = formatSongTags(currentTags)
+                                showTagsDialog = true
+                            },
+                            trailing = {
+                                Icon(
+                                    painter = painterResource(R.drawable.arrow_forward),
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.size(22.dp),
+                                )
+                            },
+                            extra =
+                                if (currentTags.isEmpty()) {
+                                    null
+                                } else {
+                                    {
+                                        PerSongTagRow(tags = currentTags, highlighted = true)
+                                    }
+                                },
                         )
-                    },
-                    leadingContent = {
-                        Icon(painter = painterResource(R.drawable.edit), contentDescription = null)
-                    },
-                    modifier =
-                        Modifier.clickable {
-                            tagsDraft = formatSongTags(currentTags)
-                            showTagsDialog = true
-                        },
-                    colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PerSongHeader(
+    title: String?,
+    artist: String?,
+    thumbnailUrl: String?,
+    overrideCount: Int,
+    onDismiss: () -> Unit,
+) {
+    val subtitle =
+        when {
+            !title.isNullOrBlank() && !artist.isNullOrBlank() -> "$title • $artist"
+            !title.isNullOrBlank() -> title
+            overrideCount == 0 -> stringResource(R.string.per_song_no_overrides)
+            else -> stringResource(R.string.per_song_overrides_count, overrideCount)
+        }
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.primaryContainer,
+    ) {
+        Row(
+            modifier = Modifier.padding(start = 20.dp, top = 18.dp, end = 10.dp, bottom = 18.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Surface(
+                modifier = Modifier.size(56.dp),
+                shape = MaterialTheme.shapes.extraLarge,
+                color = MaterialTheme.colorScheme.secondaryContainer,
+            ) {
+                if (thumbnailUrl.isNullOrBlank()) {
+                    Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                        Icon(
+                            painter = painterResource(R.drawable.tune),
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                            modifier = Modifier.size(30.dp),
+                        )
+                    }
+                } else {
+                    AsyncImage(
+                        model = thumbnailUrl,
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.per_song_settings),
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
-        },
-        confirmButton = {
-            TextButton(onClick = onDismiss, shapes = ButtonDefaults.shapes()) {
-                Text(stringResource(android.R.string.ok))
+            if (overrideCount > 0 && !title.isNullOrBlank()) {
+                Surface(
+                    shape = MaterialTheme.shapes.large,
+                    color = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                ) {
+                    Text(
+                        text = overrideCount.toString(),
+                        style = MaterialTheme.typography.labelLarge,
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                    )
+                }
             }
-        },
-    )
+            IconButton(
+                onClick = onDismiss,
+                modifier = Modifier.size(48.dp),
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.close),
+                    contentDescription = stringResource(R.string.close),
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * One option. A set override is drawn in the secondary container with a primary
+ * outline, the way an expanded lyrics result is, so the eye lands on what has
+ * actually been changed for this song.
+ */
+@Composable
+private fun PerSongOptionCard(
+    icon: Int,
+    title: String,
+    state: String,
+    isSet: Boolean,
+    onClick: () -> Unit,
+    trailing: @Composable () -> Unit,
+    extra: (@Composable () -> Unit)? = null,
+) {
+    val containerColor =
+        if (isSet) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surfaceContainerHighest
+    val contentColor =
+        if (isSet) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurface
+    val outlineColor =
+        if (isSet) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant
+
+    Surface(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.extraLarge,
+        color = containerColor,
+        contentColor = contentColor,
+        border = BorderStroke(1.dp, outlineColor),
+    ) {
+        Column(
+            modifier = Modifier.padding(start = 16.dp, end = 12.dp, top = 14.dp, bottom = 14.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(14.dp),
+            ) {
+                Surface(
+                    modifier = Modifier.size(44.dp),
+                    shape = MaterialTheme.shapes.extraLarge,
+                    color =
+                        if (isSet) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.surfaceContainerHigh
+                        },
+                ) {
+                    Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                        Icon(
+                            painter = painterResource(icon),
+                            contentDescription = null,
+                            tint =
+                                if (isSet) {
+                                    MaterialTheme.colorScheme.onPrimary
+                                } else {
+                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                },
+                            modifier = Modifier.size(22.dp),
+                        )
+                    }
+                }
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleMedium,
+                        color = contentColor,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = state,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color =
+                            if (isSet) contentColor else MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                trailing()
+            }
+            extra?.invoke()
+        }
+    }
+}
+
+@Composable
+private fun PerSongValueChip(
+    text: String,
+    highlighted: Boolean,
+) {
+    Surface(
+        shape = MaterialTheme.shapes.large,
+        color =
+            if (highlighted) {
+                MaterialTheme.colorScheme.primary
+            } else {
+                MaterialTheme.colorScheme.surfaceContainerHigh
+            },
+        contentColor =
+            if (highlighted) {
+                MaterialTheme.colorScheme.onPrimary
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            },
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelMedium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier =
+                Modifier
+                    .widthIn(max = 120.dp)
+                    .padding(horizontal = 10.dp, vertical = 6.dp),
+        )
+    }
+}
+
+@Composable
+private fun PerSongTagRow(
+    tags: List<String>,
+    highlighted: Boolean,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(0.dp)),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        // The row is not scrollable on purpose: the card is a summary, the
+        // editor is one tap away. Show what fits and count the rest.
+        val shown = tags.take(4)
+        shown.forEach { tag ->
+            Surface(
+                shape = MaterialTheme.shapes.large,
+                color =
+                    if (highlighted) {
+                        MaterialTheme.colorScheme.surface.copy(alpha = 0.52f)
+                    } else {
+                        MaterialTheme.colorScheme.surfaceContainerHigh
+                    },
+            ) {
+                Text(
+                    text = tag,
+                    style = MaterialTheme.typography.labelMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier =
+                        Modifier
+                            .widthIn(max = 110.dp)
+                            .padding(horizontal = 10.dp, vertical = 5.dp),
+                )
+            }
+        }
+        if (tags.size > shown.size) {
+            Text(
+                text = "+${tags.size - shown.size}",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(vertical = 5.dp),
+            )
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/menu/PlayerMenu.kt
@@ -313,6 +313,9 @@ fun PlayerMenu(
         PerSongSettingsDialog(
             songId = mediaMetadata.id,
             onDismiss = { showPerSongSettings = false },
+            songTitle = mediaMetadata.title,
+            songArtist = mediaMetadata.artists.joinToString(separator = " • ") { it.name },
+            thumbnailUrl = mediaMetadata.thumbnailUrl,
         )
     }
 

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -353,6 +353,9 @@
     <string name="per_song_custom_tags">Custom tags</string>
     <string name="per_song_custom_tags_hint">lofi, night, guitar</string>
     <string name="per_song_custom_tags_none">No tags yet</string>
+    <string name="per_song_tags_count">%1$d tags</string>
+    <string name="per_song_no_overrides">Nothing changed for this song</string>
+    <string name="per_song_overrides_count">%1$d changed for this song</string>
     <string name="player_background_blur">Blur</string>
     <string name="coloring">Coloring</string>
     <string name="blur_gradient">Blur Gradient</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -246,6 +246,11 @@
     <string name="lyrics_search_still_searching">Still searching</string>
     <string name="lyrics_search_results_count">%1$d results</string>
     <string name="lyrics_search_result_stats">%1$d lines, %2$d chars</string>
+    <string name="lyrics_search_use_these">Use these</string>
+    <plurals name="lyrics_search_results_found">
+        <item quantity="one">%1$d result</item>
+        <item quantity="other">%1$d results</item>
+    </plurals>
     <string name="edit_song">Edit song</string>
     <string name="song_title">Song title</string>
     <string name="song_artists">Song artists</string>


### PR DESCRIPTION
Both pop-ups open from the player menu, so they now share one look.

### Song options

Was a stock `AlertDialog` — four `ListItem`s and an OK button. Now built like the lyrics search sheet:

- **Header** in the primary container: the song's artwork (the custom one, if set), title and artist, a close button, and a badge counting how many overrides this song has.
- **One card per option.** A card whose override is *set* switches to the secondary container with a primary outline and a filled icon disc — the same treatment as an expanded lyrics result — so what has been changed for this song is visible before reading anything.
- The trailing control states the value instead of a second line of text: a chip naming the player style (yours, or the settings default), the custom artwork itself as a 40dp thumb with a clear button, a real `Switch` for *Never recommend*, and the tags laid out as pills under the row (first four, then `+N`).
- `PlayerMenu` now passes title / artist / thumbnail through; the `songId`-only signature still works for any other caller.

### Lyrics search

- **"1 results" → "1 result"** — the count is a `<plurals>` now.
- The second pill on a result card repeated the sync type that is already the card's title. It's replaced by a **Use these** button — the card's only action, which until now was an invisible tap-anywhere.
- The expand chevron sits on a small tonal disc so it no longer reads as a tick mark next to the provider name.
- **Still searching** is a bordered, centred pill with the loading indicator in primary, instead of a loose line under the list.

No behaviour changes anywhere — same preferences, same launcher, same view-model calls.
