### PR TITLE
feat: bump version to 5.2.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
     applicationId = "dev.citali.lunartune"
         minSdk = 26
         targetSdk = 37
-        versionCode = 510
-        versionName = "5.1.0"
+        versionCode = 520
+        versionName = "5.2.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
`versionCode` 510 → **520**, `versionName` 5.1.0 → **5.2.0**.

Merging this touches `app/build.gradle.kts` on `main`, which is what the *Bump to new version* workflow watches — it will tag `v5.2.0`, build the FOSS / GMS APKs and publish the release with notes generated from the merged PR titles.

### Since 5.1.0 (#63–#93)

**New**
- App lock — custom PIN or the device screen lock, with lock-after timeout, whole-app or personal-screens scope, and the secure flag held while a lock is set (#71, #91, #92)
- Moving blur lyrics backdrop, GPU-blurred on Android 12+, with crossfade between tracks (#72–#78, #83–#85)
- Quick picks from YouTube Music instead of listening history (#66, #67)
- Parallel downloads with automatic retry (#68)
- New app icon, full-bleed launcher artwork, Play Store listing icon (#86–#90)

**Fixed**
- Player blur backgrounds had no blur at all below Android 12 (#79)
- Home category chips not showing their content (#65)

**Polish / perf**
- Song options sheet and lyrics search sheet share one look (#93)
- Max refresh rate only while the UI is animating (#63, #81)
- Home scroll: dropped animateItem look-ahead passes, OptimizeNonSkippingGroups (#64)
- Spotify account moved to the Integration screen (#70)

#94 (onboarding moon mark) is still open — merge it before this one if you want it in 5.2.0.
