### PR TITLE
docs: add download verification section and update VirusTotal badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
     <img src="https://img.shields.io/badge/Language-Kotlin-7f52ff?style=for-the-badge&logo=kotlin&color=6366f1&labelColor=1e1e2e" alt="Kotlin Language" />
     <img src="https://img.shields.io/badge/Toolkit-Jetpack_Compose-4285f4?style=for-the-badge&logo=jetpack-compose&color=6366f1&labelColor=1e1e2e" alt="Jetpack Compose Toolkit" />
     <img src="https://img.shields.io/badge/Design-Material_3-000000?style=for-the-badge&logo=material-design&color=6366f1&labelColor=1e1e2e" alt="Material Design 3" />
-    <a href="https://www.virustotal.com/gui/file/176bea37aff02a606d04ff0a61478fabdb0bd079f9e97319645452af420e5d84/detection/f-176bea37aff02a606d04ff0a61478fabdb0bd079f9e97319645452af420e5d84-1778840479" target="_blank"><img src="https://img.shields.io/badge/VirusTotal-SAFE-green?style=for-the-badge&logo=virustotal&logoColor=white&labelColor=1e1e2e&color=5865F2" alt="VirusTotal" /></a>
+    <a href="https://www.virustotal.com/gui/file/1385eba76b03cd9b6bc141fcfd1e57b67d9f3d7b466982b15d8bfe546483debf" target="_blank"><img src="https://img.shields.io/badge/VirusTotal-Clean-5865F2?style=for-the-badge&logo=virustotal&logoColor=white&labelColor=1e1e2e" alt="VirusTotal scan of the latest release" /></a>
     <a href="https://t.me/LunarTuneGC"><img src="https://img.shields.io/badge/Telegram-2CA5E0?style=for-the-badge&logo=telegram&logoColor=white" alt="Telegram" /></a>
   </div>
   
@@ -154,6 +154,29 @@
 </table>
 
 </div>
+
+---
+
+## 🔐 Verify your download
+
+Every release APK is signed with the same LunarTune key. If an APK was repackaged by someone else, the signature check below fails — even if a virus scanner says it is clean.
+
+**Signing certificate (SHA-256):**
+
+```
+37:3D:CE:20:61:AC:1F:8A:37:FE:7B:AD:51:D2:27:C3:9D:75:01:B1:36:BA:AC:69:DA:F4:CE:B5:97:1A:BD:A9
+```
+
+- **On your phone:** install [AppVerifier](https://github.com/soupslurpr/AppVerifier) (open source), pick LunarTune and compare the SHA-256 of the signing certificate with the fingerprint above.
+- **On a computer:** with the Android SDK build-tools installed, run
+  ```
+  apksigner verify --print-certs app-gms-mobile-arm64-release.apk
+  ```
+  and check that `Signer #1 certificate SHA-256 digest` matches the fingerprint above (without the colons).
+- **File checksums:** each release page lists the SHA-256 of every APK under *Assets* (the *Digest* next to each file). `sha256sum <file>.apk` on your side must print the same value.
+- **Virus scan:** the VirusTotal badge at the top links to the scan of the latest release. VirusTotal reports are per file, so its hash must match the APK you downloaded.
+
+> Only download LunarTune from [GitHub Releases](https://github.com/cognitiveshadows03/LunarTune/releases) or the [Telegram channel](https://t.me/LunarTuneGC). Android refuses to update an app when the signing key changes, so an APK that does not match this certificate will not install over an existing LunarTune.
 
 ---
 


### PR DESCRIPTION
## Why

The README's VirusTotal badge still pointed at an old file hash (`176bea37…`) that is not any of the v5.2.0 assets, so the "SAFE" badge was describing an APK nobody downloads any more. VirusTotal reports are per file: the badge has to follow the release.

Scanners also can't tell whether an APK is really *ours*. The signing certificate can — every published APK (v5.1.0 and all seven v5.2.0 files) is signed with the same key, and a repackaged build fails that check even with a clean scan. The README had nothing for users to compare against.

## What changes (README.md only)

- **VirusTotal badge** → links to the scan of `app-gms-mobile-arm64-release.apk` from v5.2.0 (`sha256 1385eba76b03cd9b6bc141fcfd1e57b67d9f3d7b466982b15d8bfe546483debf`), the file that was uploaded and came back clean. Label changed to a neutral "Clean" (no engine count baked in).
- **New "🔐 Verify your download" section** before *Need Help*:
  - SHA-256 fingerprint of the release signing certificate: `37:3D:CE:20:61:AC:1F:8A:37:FE:7B:AD:51:D2:27:C3:9D:75:01:B1:36:BA:AC:69:DA:F4:CE:B5:97:1A:BD:A9` (`CN=LunarTune, O=Citali`, valid until 2054) — extracted from the released APKs (v1 + v2 signatures agree, identical across FOSS/GMS/universal/arm64 and v5.1.0).
  - How to check it on the phone (AppVerifier) and on a computer (`apksigner verify --print-certs`).
  - Where the per-file SHA-256 digests live on the release page and how to compare with `sha256sum`.
  - Official download sources only (GitHub Releases, Telegram).

## Keeping it current

The certificate fingerprint is stable as long as the release keystore does not change, so that part never needs editing. The VirusTotal badge is per file: after each release, upload one APK and swap the hash in the badge URL (one line) — or tell me and I'll automate it in the release workflow.
