### PR TITLE
feat: tap lyrics page artwork to return to the player

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
@@ -906,16 +906,27 @@ private fun AppleMusicTrackHeader(
             mediaMetadata.artists.joinToString { it.name }
         }
 
+    val backToPlayerDescription = stringResource(R.string.lyrics_back_to_player)
+
     Row(
         modifier = modifier.heightIn(min = 64.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        // Tapping the shrunken artwork brings the user back to the main player,
+        // mirroring the close button so the large target is reachable one-handed.
         Box(
             modifier =
                 Modifier
                     .size(58.dp)
                     .clip(RoundedCornerShape(7.dp))
-                    .background(foregroundColor.copy(alpha = 0.18f)),
+                    .background(foregroundColor.copy(alpha = 0.18f))
+                    .semantics { contentDescription = backToPlayerDescription }
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = ripple(),
+                        role = Role.Button,
+                        onClick = onDismissClick,
+                    ),
             contentAlignment = Alignment.Center,
         ) {
             AsyncImage(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -240,6 +240,7 @@
     <string name="unknown">Unknown</string>
     <string name="copied">Copied to clipboard</string>
     <string name="search_lyrics">Search lyrics</string>
+    <string name="lyrics_back_to_player">Back to player</string>
     <string name="lyrics_synced_badge">Synced</string>
     <string name="lyrics_search_plain_badge">Plain</string>
     <string name="lyrics_searching_providers">Searching providers</string>


### PR DESCRIPTION
## What
On the lyrics page, the shrunken album artwork in the header is now a button. Tapping it returns to the main player, exactly like the small close icon next to it.

## Why
The artwork is the largest, most obvious element in that header, but it did nothing. Returning to the player meant hitting the 36 dp close icon at the far side of the row, which is awkward one-handed. Making the artwork tappable gives a big, natural target right where the thumb already is.

## How
- `AppleMusicTrackHeader` (`ui/player/LyricsScreen.kt`): the 58 dp artwork `Box` gets `clickable(role = Button, onClick = onDismissClick)` with a ripple clipped to the rounded corners, plus a `contentDescription` so TalkBack announces it as "Back to player".
- New string `lyrics_back_to_player` ("Back to player") in `values/strings.xml`; other locales fall back to English.
- No behaviour change anywhere else: `onDismissClick` is the same callback the close icon already uses (`onBackClick` → `isLyricsScreenVisible = false` in `Player.kt`).

## Testing
Verified against `upstream/main` (8e3119f). Builds are covered by the PR workflow; please give it a quick tap on the device (Android 10) — the ripple and the return-to-player transition should match the close icon.