### PR TITLE
feat: restore ArchiveTune backups

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/RestoreBackupFileActivity.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/RestoreBackupFileActivity.kt
@@ -54,6 +54,7 @@ import dev.citali.lunartune.ui.menu.LoadingScreen
 import dev.citali.lunartune.ui.theme.LunarTuneTheme
 import dev.citali.lunartune.viewmodels.BackupCategory
 import dev.citali.lunartune.viewmodels.BackupRestoreViewModel
+import dev.citali.lunartune.viewmodels.BackupSource
 
 @AndroidEntryPoint
 class RestoreBackupFileActivity : ComponentActivity() {
@@ -106,6 +107,9 @@ private fun RestoreBackupFileScreen(
     LaunchedEffect(uri) {
         val result = viewModel.validateBackup(context, uri)
         if (result.isValid) {
+            if (result.source == BackupSource.ARCHIVETUNE) {
+                Toast.makeText(context, R.string.restore_archivetune_backup_detected, Toast.LENGTH_LONG).show()
+            }
             selectedCategories = result.availableCategories
             screenState = BackupScreenState.Ready(availableCategories = result.availableCategories)
             showRestoreDialog = true

--- a/app/src/main/kotlin/dev/citali/lunartune/backup/BackupArchiveRepository.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/backup/BackupArchiveRepository.kt
@@ -203,6 +203,38 @@ class BackupArchiveRepository
             const val SETTINGS_XML_FILENAME = "settings.xml"
             private const val BUFFER_SIZE = 64 * 1024
 
+            /**
+             * Preference keys that must never be imported from a backup written by
+             * another app (ArchiveTune). They cache the *other* project's GitHub
+             * release feed, update reminders and contributor list; importing them
+             * would make the updater offer ArchiveTune releases as LunarTune updates.
+             */
+            val FOREIGN_BACKUP_EXCLUDED_PREFERENCE_KEYS: Set<String> =
+                setOf(
+                    "github_releases_json",
+                    "github_releases_etag",
+                    "github_releases_fingerprint",
+                    "github_releases_last_checked_at",
+                    "daily_nightly_releases_json",
+                    "daily_nightly_releases_etag",
+                    "daily_nightly_releases_fingerprint",
+                    "daily_nightly_releases_last_checked_at",
+                    "github_contributors_json",
+                    "github_contributors_etag",
+                    "github_contributors_last_checked_at",
+                    "lastNotifiedVersion",
+                    "lastUpdateCheck",
+                    // Discord sessions are bound to the issuing application id; the
+                    // ArchiveTune token cannot be used with LunarTune's app id.
+                    "discordToken",
+                    "discordRefreshToken",
+                    "discordTokenExpiresAt",
+                    "discordApplicationId",
+                    "discordUsername",
+                    "discordName",
+                    "discordAvatarUrl",
+                )
+
             val ACCOUNT_PREFERENCE_KEYS: Set<String> =
                 setOf(
                     "innerTubeCookie",

--- a/app/src/main/kotlin/dev/citali/lunartune/db/MusicDatabase.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/db/MusicDatabase.kt
@@ -165,6 +165,39 @@ abstract class InternalDatabase : RoomDatabase() {
     companion object {
         const val DB_NAME = "song.db"
 
+        /**
+         * Prepares a database file that was just restored from a backup so Room can
+         * open it without falling back to destructive migration.
+         *
+         * Room wipes any database whose `user_version` is *higher* than this build's
+         * schema version ("downgrade"), which is exactly what happens with backups
+         * from ArchiveTune (same layout, newer version number) or from a newer
+         * LunarTune build. When [foreign] is `true`, or the stored version is higher
+         * than ours, the file is reconciled in place: columns unknown to this build
+         * are dropped, missing ones are added with their defaults, and the version
+         * plus Room identity hash are stamped. Rows are preserved.
+         *
+         * Returns `false` only when a reconcile was required but failed, so the caller
+         * can warn the user that the library could not be converted.
+         */
+        fun prepareRestoredDatabaseFile(
+            context: Context,
+            name: String = DB_NAME,
+            foreign: Boolean = false,
+        ): Boolean {
+            val storedVersion =
+                runCatching { SchemaTools.readDatabaseFileVersion(context, name) }
+                    .onFailure { Log.w(TAG, "Could not read version of restored database $name", it) }
+                    .getOrNull()
+            val needsReconcile = foreign || (storedVersion != null && storedVersion > CURRENT_VERSION)
+            if (!needsReconcile) return true
+
+            Log.i(TAG, "Reconciling restored database $name (version=$storedVersion, foreign=$foreign)")
+            return runCatching { SchemaTools.adoptForeignDatabaseFile(context = context, name = name) }
+                .onFailure { Log.e(TAG, "Failed to reconcile restored database $name", it) }
+                .isSuccess
+        }
+
         fun newInstance(context: Context): MusicDatabase {
             val universalMigrations =
                 (2 until CURRENT_VERSION)
@@ -341,35 +374,110 @@ private class UniversalMigration(
 private object SchemaTools {
     private val IGNORED_TABLES = setOf("android_metadata", "room_master_table", "sqlite_sequence")
 
+    /**
+     * Opens [name] with the plain framework helper at [CURRENT_VERSION] and no
+     * migration callbacks. Merely opening the file this way stamps `user_version`
+     * to [CURRENT_VERSION] (the framework does that after the no-op
+     * onUpgrade/onDowngrade), leaving only the schema itself to reconcile.
+     */
+    private fun openFileHelper(
+        context: Context,
+        name: String,
+    ): SupportSQLiteOpenHelper =
+        FrameworkSQLiteOpenHelperFactory()
+            .create(
+                SupportSQLiteOpenHelper.Configuration
+                    .builder(context)
+                    .name(name)
+                    .callback(
+                        object : SupportSQLiteOpenHelper.Callback(CURRENT_VERSION) {
+                            override fun onCreate(db: SupportSQLiteDatabase) = Unit
+
+                            override fun onUpgrade(
+                                db: SupportSQLiteDatabase,
+                                oldVersion: Int,
+                                newVersion: Int,
+                            ) = Unit
+
+                            override fun onDowngrade(
+                                db: SupportSQLiteDatabase,
+                                oldVersion: Int,
+                                newVersion: Int,
+                            ) = Unit
+                        },
+                    ).build(),
+            )
+
+    /** Reads `PRAGMA user_version` of an on-disk database (no version callbacks are run). */
+    fun readDatabaseFileVersion(
+        context: Context,
+        name: String,
+    ): Int {
+        val dbFile = context.getDatabasePath(name)
+        require(dbFile.exists()) { "Database file $name does not exist" }
+        return SQLiteDatabase
+            .openDatabase(dbFile.path, null, SQLiteDatabase.OPEN_READWRITE)
+            .use { it.version }
+    }
+
+    /**
+     * Brings a database written by a schema-compatible fork (ArchiveTune) or by a
+     * newer build in line with this build's schema so Room opens it as-is instead of
+     * destroying it. Runs in a single transaction: the WAL is folded into the main
+     * file, tables are reconciled (extra columns such as `song.isPodcast` dropped,
+     * missing ones added with defaults), and `room_master_table.identity_hash` is
+     * stamped with this build's hash. Throws if anything fails or the integrity
+     * check does not pass afterwards.
+     */
+    fun adoptForeignDatabaseFile(
+        context: Context,
+        name: String,
+    ) {
+        require(context.getDatabasePath(name).exists()) { "Database file $name does not exist" }
+
+        val expectedDb = Room.inMemoryDatabaseBuilder(context, InternalDatabase::class.java).build()
+        val fileHelper = openFileHelper(context, name)
+        try {
+            val expected = expectedDb.openHelper.writableDatabase
+            val identityHash = readIdentityHash(expected)
+            val db = fileHelper.writableDatabase
+            check(db.version == CURRENT_VERSION) { "Expected version $CURRENT_VERSION after open, found ${db.version}" }
+
+            // Fold a shipped -wal into the main file before rewriting the schema.
+            runCatching { db.query("PRAGMA wal_checkpoint(TRUNCATE)").use { it.moveToFirst() } }
+            // foreign_keys cannot be changed inside a transaction, so do it up front.
+            db.execSQL("PRAGMA foreign_keys=OFF")
+
+            db.beginTransaction()
+            try {
+                reconcileDatabase(db = db, expectedDb = expected)
+                if (identityHash != null) {
+                    updateIdentityHash(db = db, identityHash = identityHash)
+                }
+                db.setTransactionSuccessful()
+            } finally {
+                db.endTransaction()
+            }
+            db.execSQL("PRAGMA foreign_keys=ON")
+
+            val integrity =
+                db.query("PRAGMA integrity_check").use { cursor ->
+                    if (cursor.moveToFirst()) cursor.getString(0) else null
+                }
+            check(integrity == "ok") { "Integrity check failed after reconciling $name: $integrity" }
+            Log.i(TAG, "Reconciled database file $name to schema version ${db.version}")
+        } finally {
+            runCatching { fileHelper.close() }
+            runCatching { expectedDb.close() }
+        }
+    }
+
     fun repairDatabaseFile(
         context: Context,
         name: String,
     ) {
         val expectedDb = Room.inMemoryDatabaseBuilder(context, InternalDatabase::class.java).build()
-        val fileHelper =
-            FrameworkSQLiteOpenHelperFactory()
-                .create(
-                    SupportSQLiteOpenHelper.Configuration
-                        .builder(context)
-                        .name(name)
-                        .callback(
-                            object : SupportSQLiteOpenHelper.Callback(CURRENT_VERSION) {
-                                override fun onCreate(db: SupportSQLiteDatabase) = Unit
-
-                                override fun onUpgrade(
-                                    db: SupportSQLiteDatabase,
-                                    oldVersion: Int,
-                                    newVersion: Int,
-                                ) = Unit
-
-                                override fun onDowngrade(
-                                    db: SupportSQLiteDatabase,
-                                    oldVersion: Int,
-                                    newVersion: Int,
-                                ) = Unit
-                            },
-                        ).build(),
-                )
+        val fileHelper = openFileHelper(context, name)
 
         try {
             val expected = expectedDb.openHelper.writableDatabase
@@ -398,6 +506,14 @@ private object SchemaTools {
         val expectedTriggers = expectedMaster.filter { it.type == "trigger" && it.sql != null }
 
         db.execSQL("PRAGMA foreign_keys=OFF")
+        // ensureTableSchema() rebuilds a table via `ALTER TABLE x RENAME TO _old_x`.
+        // Since SQLite 3.26 that rename also rewrites `REFERENCES x` in every child
+        // table (even with foreign_keys off) unless legacy_alter_table is on, which
+        // would leave every child pointing at `_old_x` once it is dropped. Android
+        // compiles its SQLite with the legacy behaviour as default, but pin it
+        // explicitly so the rebuild is safe on any SQLite build; older versions
+        // that predate the pragma simply ignore it.
+        db.execSQL("PRAGMA legacy_alter_table=ON")
         dropNonTableObjects(db)
 
         expectedTables.forEach { table ->

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/BackupAndRestore.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/BackupAndRestore.kt
@@ -10,6 +10,7 @@
 package dev.citali.lunartune.ui.screens.settings
 
 import android.net.Uri
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
@@ -88,6 +89,7 @@ import dev.citali.lunartune.ui.utils.backToMain
 import dev.citali.lunartune.utils.rememberPreference
 import dev.citali.lunartune.viewmodels.BackupCategory
 import dev.citali.lunartune.viewmodels.BackupRestoreViewModel
+import dev.citali.lunartune.viewmodels.BackupSource
 import dev.citali.lunartune.viewmodels.ScheduledBackupScreenState
 import dev.citali.lunartune.viewmodels.ScheduledBackupUiData
 import java.time.Instant
@@ -163,6 +165,11 @@ fun BackupAndRestore(
                 coroutineScope.launch {
                     val result = viewModel.validateBackup(context, uri)
                     if (result.isValid) {
+                        if (result.source == BackupSource.ARCHIVETUNE) {
+                            Toast
+                                .makeText(context, R.string.restore_archivetune_backup_detected, Toast.LENGTH_LONG)
+                                .show()
+                        }
                         pendingRestoreCategories = result.availableCategories
                         pendingRestoreUri = uri
                         showRestoreOptionsDialog = true

--- a/app/src/main/kotlin/dev/citali/lunartune/viewmodels/BackupRestoreViewModel.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/viewmodels/BackupRestoreViewModel.kt
@@ -10,6 +10,7 @@ package dev.citali.lunartune.viewmodels
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.provider.OpenableColumns
 import android.widget.Toast
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Immutable
@@ -84,10 +85,19 @@ enum class BackupCategory {
     DOWNLOADS,
 }
 
+/** Which app produced a backup archive. */
+enum class BackupSource {
+    LUNARTUNE,
+
+    /** Backup written by ArchiveTune (same archive layout, different settings root tag and DB version). */
+    ARCHIVETUNE,
+}
+
 data class BackupValidationResult(
     val isValid: Boolean,
     val availableCategories: Set<BackupCategory>,
     val errorMessage: String?,
+    val source: BackupSource = BackupSource.LUNARTUNE,
 )
 
 sealed interface ScheduledBackupScreenState {
@@ -399,7 +409,7 @@ class BackupRestoreViewModel
                     val includeAccount = BackupCategory.ACCOUNT in categories
                     val includeLibrary = BackupCategory.LIBRARY in categories
                     val includeDownloads = BackupCategory.DOWNLOADS in categories
-                    val settingsExcludedKeys = if (includeAccount) emptySet() else ACCOUNT_PREF_KEYS
+                    val baseSettingsExcludedKeys = if (includeAccount) emptySet() else ACCOUNT_PREF_KEYS
                     emitProgress(
                         title = title,
                         step = context.getString(R.string.restore_step_verifying),
@@ -409,17 +419,30 @@ class BackupRestoreViewModel
 
                     val entryNames = ArrayList<String>()
                     var hasDb = false
+                    var xmlSource: BackupSource? = null
                     context.applicationContext.contentResolver.openInputStream(uri)?.use { stream ->
                         stream.zipInputStream().use { zip ->
                             var entry = zip.nextEntry
                             while (entry != null) {
                                 entryNames.add(entry.name)
                                 if (entry.name == InternalDatabase.DB_NAME) hasDb = true
+                                if (entry.name == SETTINGS_XML_FILENAME) {
+                                    xmlSource = detectSettingsXmlSource(zip)
+                                }
                                 entry = zip.nextEntry
                             }
                         }
                     }
                     if (includeLibrary && !hasDb) throw IllegalStateException("Backup missing database")
+
+                    val source = resolveBackupSource(context, uri, xmlSource)
+                    val isForeignBackup = source == BackupSource.ARCHIVETUNE
+                    val settingsExcludedKeys =
+                        if (isForeignBackup) {
+                            baseSettingsExcludedKeys + BackupArchiveRepository.FOREIGN_BACKUP_EXCLUDED_PREFERENCE_KEYS
+                        } else {
+                            baseSettingsExcludedKeys
+                        }
 
                     val restoreEntries =
                         entryNames.filter { name ->
@@ -453,6 +476,11 @@ class BackupRestoreViewModel
                         runCatching { database.awaitIdle() }
                         runCatching { database.checkpoint() }
                         runCatching { database.close() }
+                        // Never let a leftover -wal/-shm of the old database be replayed on
+                        // top of the freshly restored file.
+                        listOf("-wal", "-shm", "-journal").forEach { suffix ->
+                            runCatching { context.getDatabasePath("${InternalDatabase.DB_NAME}$suffix").delete() }
+                        }
                         completedUnits++
                     }
 
@@ -501,6 +529,19 @@ class BackupRestoreViewModel
                         }
                     }
 
+                    var databasePrepared = true
+                    if (includeLibrary) {
+                        // Must run before Room touches the file: a database with a higher
+                        // user_version (ArchiveTune, or a newer LunarTune) would otherwise be
+                        // wiped by fallbackToDestructiveMigrationOnDowngrade on next launch.
+                        emit(context.getString(R.string.backup_step_checkpoint_database), indeterminate = true)
+                        databasePrepared =
+                            InternalDatabase.prepareRestoredDatabaseFile(
+                                context = context,
+                                foreign = isForeignBackup,
+                            )
+                    }
+
                     emitProgress(
                         title = title,
                         step = context.getString(R.string.restore_step_restarting),
@@ -509,7 +550,14 @@ class BackupRestoreViewModel
                     )
 
                     withContext(Dispatchers.Main) {
-                        Toast.makeText(context, R.string.restore_success, Toast.LENGTH_SHORT).show()
+                        if (databasePrepared) {
+                            Toast.makeText(context, R.string.restore_success, Toast.LENGTH_SHORT).show()
+                        } else {
+                            // The file is left in place: when its version was already stamped Room
+                            // reports an identity mismatch on relaunch and SchemaTools gets one more
+                            // repair attempt; otherwise the app starts with an empty library.
+                            Toast.makeText(context, R.string.restore_database_incompatible, Toast.LENGTH_LONG).show()
+                        }
                     }
 
                     try {
@@ -538,6 +586,57 @@ class BackupRestoreViewModel
                 }
             }
         }
+
+        /**
+         * Decides which app wrote the archive. The `settings.xml` root tag is
+         * authoritative; when the archive has no settings (library-only backup) the
+         * file name is used, since ArchiveTune names its archives `ArchiveTune_….backup`.
+         */
+        private fun resolveBackupSource(
+            context: Context,
+            uri: Uri,
+            xmlSource: BackupSource?,
+        ): BackupSource {
+            xmlSource?.let { return it }
+            val displayName =
+                runCatching {
+                    context.applicationContext.contentResolver
+                        .query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+                        ?.use { cursor ->
+                            val index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                            if (index >= 0 && cursor.moveToFirst()) cursor.getString(index) else null
+                        }
+                }.getOrNull() ?: uri.lastPathSegment.orEmpty()
+            return if (displayName.substringAfterLast('/').startsWith(ARCHIVETUNE_FILE_PREFIX, ignoreCase = true)) {
+                BackupSource.ARCHIVETUNE
+            } else {
+                BackupSource.LUNARTUNE
+            }
+        }
+
+        /**
+         * Identifies the app that wrote a `settings.xml` by its document root
+         * (`LunarTuneBackup` vs ArchiveTune's `ArchiveTuneBackup`). Only the first
+         * start tag is read; unknown roots are treated as LunarTune so older archives
+         * keep restoring unchanged. The stream is left open (the caller owns the zip).
+         */
+        private fun detectSettingsXmlSource(inputStream: java.io.InputStream): BackupSource =
+            runCatching {
+                val parser = android.util.Xml.newPullParser()
+                parser.setInput(inputStream, Charsets.UTF_8.name())
+                var eventType = parser.eventType
+                while (eventType != XmlPullParser.END_DOCUMENT) {
+                    if (eventType == XmlPullParser.START_TAG) {
+                        return@runCatching if (parser.name.equals(ARCHIVETUNE_SETTINGS_ROOT_TAG, ignoreCase = true)) {
+                            BackupSource.ARCHIVETUNE
+                        } else {
+                            BackupSource.LUNARTUNE
+                        }
+                    }
+                    eventType = parser.next()
+                }
+                BackupSource.LUNARTUNE
+            }.getOrDefault(BackupSource.LUNARTUNE)
 
         private suspend fun restoreSettingsFromXml(
             context: Context,
@@ -801,13 +900,18 @@ class BackupRestoreViewModel
                     stream.use { inputStream ->
                         val zipStream = inputStream.zipInputStream()
                         val entryNames = mutableSetOf<String>()
+                        var xmlSource: BackupSource? = null
                         zipStream.use { zip ->
                             var entry = zip.nextEntry
                             while (entry != null) {
                                 entryNames.add(entry.name)
+                                if (entry.name == SETTINGS_XML_FILENAME) {
+                                    xmlSource = detectSettingsXmlSource(zip)
+                                }
                                 entry = zip.nextEntry
                             }
                         }
+                        val source = resolveBackupSource(context, uri, xmlSource)
                         if (entryNames.isEmpty()) {
                             return@withContext BackupValidationResult(
                                 isValid = false,
@@ -837,6 +941,7 @@ class BackupRestoreViewModel
                             isValid = true,
                             availableCategories = categories,
                             errorMessage = null,
+                            source = source,
                         )
                     }
                 } catch (e: Exception) {
@@ -852,6 +957,8 @@ class BackupRestoreViewModel
         companion object {
             const val SETTINGS_FILENAME = "settings.preferences_pb"
             const val SETTINGS_XML_FILENAME = BackupArchiveRepository.SETTINGS_XML_FILENAME
+            const val ARCHIVETUNE_SETTINGS_ROOT_TAG = "ArchiveTuneBackup"
+            const val ARCHIVETUNE_FILE_PREFIX = "ArchiveTune"
 
             val ACCOUNT_PREF_KEYS: Set<String> = BackupArchiveRepository.ACCOUNT_PREFERENCE_KEYS
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -700,6 +700,8 @@
     <string name="backup_create_failed">Couldn\'t create backup</string>
     <string name="restore_success">Backup restored successfully</string>
     <string name="restore_failed">Failed to restore backup</string>
+    <string name="restore_archivetune_backup_detected">ArchiveTune backup detected. It will be converted to LunarTune format.</string>
+    <string name="restore_database_incompatible">The library database in this backup could not be converted for this version of LunarTune.</string>
     <string name="discord_integration">Discord Integration</string>
     <string name="account_integrations_summary">Discord, Last.fm, Libre.fm, ListenBrainz</string>
     <string name="discord_login_description">Connect your Discord account with OAuth so LunarTune can publish Rich Presence.</string>


### PR DESCRIPTION
## What
LunarTune can now restore backups created by ArchiveTune. When one is selected (Settings → Backup and restore, or by opening a `.backup` file), a toast says **"ArchiveTune backup detected. It will be converted to LunarTune format."** before the restore options dialog, and the library, playlists, history, settings and account come across intact.

Tested against the real `ArchiveTune_20260910221504.backup` sample (416 songs, 205 artists, 11 albums, 2 playlists, 962 history events, 332 lyrics).

## Why it did not work before
ArchiveTune archives have the same layout as ours (`settings.xml`, `song.db`, `song.db-wal`), so validation already accepted them — but:
1. `settings.xml` uses `<ArchiveTuneBackup>` as root; we never told the user what they were importing.
2. The Room database is `user_version 35` with an extra `song.isPodcast` column. LunarTune is at 34, so on the next launch Room saw a *downgrade* and `fallbackToDestructiveMigrationOnDowngrade()` silently recreated an empty database. The restore "succeeded" and the library was gone.
3. ArchiveTune's settings also carry its cached GitHub release feed (`v15.0.0`, rukamori/ArchiveTune) and update reminders; imported as-is they would make our updater offer ArchiveTune releases.

## How
**Detection** (`BackupRestoreViewModel`): the source is read from the first start tag of `settings.xml` (`ArchiveTuneBackup` → ArchiveTune), with the `ArchiveTune_…` file-name prefix as fallback for library-only archives. `BackupValidationResult` gains `source`; `BackupAndRestore.kt` and `RestoreBackupFileActivity` show the toast when it is ArchiveTune.

**Database conversion before Room** (`MusicDatabase.kt`): new `InternalDatabase.prepareRestoredDatabaseFile(context, foreign)` runs right after the DB files are copied. It only acts when the archive is foreign or the stored version is higher than ours (so a normal LunarTune restore is unchanged). It opens the file with a plain framework helper at our version (which stamps `user_version = 34` without any migration), folds the WAL, then reuses `SchemaTools.reconcileDatabase` in one transaction to rebuild mismatching tables (drops `isPodcast`, keeps every row), writes our Room identity hash and runs `PRAGMA integrity_check`. Room then opens the file as a normal current-version database — no migration, no destructive fallback. If the conversion fails the restore finishes with a clear toast instead of pretending it worked.

**Settings filtering** (`BackupArchiveRepository.FOREIGN_BACKUP_EXCLUDED_PREFERENCE_KEYS`): release-feed caches, `lastNotifiedVersion`/`lastUpdateCheck`, contributor cache and the Discord session (tokens are bound to ArchiveTune's application id; the app would drop them anyway on launch — this just makes it explicit). Everything else — theme, player style, lyrics providers, accounts, Last.fm, custom font, speed dial, saved YouTube accounts — is imported. All 181 keys in the sample match our key names and types; ArchiveTune-only keys (Tidal/Qobuz, video playback…) are simply ignored.

**Safety fix in `SchemaTools.reconcileDatabase`**: the table rebuild does `ALTER TABLE x RENAME TO _old_x` → recreate → copy → drop. On SQLite ≥ 3.26 with the modern rename semantics that rename also rewrites every child table's `REFERENCES x` to `_old_x`, which leaves all foreign keys dangling once `_old_x` is dropped (verified: 1681 `foreign_key_check` violations and "no such table: main._old_song" on every insert). Android compiles SQLite with `SQLITE_DEFAULT_LEGACY_ALTER_TABLE`, so devices were fine, but the code now pins `PRAGMA legacy_alter_table=ON` explicitly so the rebuild is safe on any SQLite build. This path is shared by the repair-on-open logic and the universal migration.

Also: stale `-wal/-shm/-journal` sidecars of the previous database are deleted before the restored files are written, so nothing old gets replayed onto the new file.

## Verification
- Full emulation of the reconcile sequence on the sample (`user_version` stamp → checkpoint → FK off → rename/rebuild → indices/views → identity hash): all 19 tables keep their row counts, `foreign_key_check` = 0, `integrity_check` = ok, `song` ends up with exactly LunarTune's 18 columns, views (`sorted_song_artist_map` etc.) work.
- No change for LunarTune-authored backups: `prepareRestoredDatabaseFile` returns early when the version is ≤ ours and the archive is not foreign.
- Android 10: the framework helper path and pragmas used here are all available on SQLite 3.22; the `legacy_alter_table` pragma is simply a no-op there.

Please test on the device: restore the ArchiveTune sample with all four categories, confirm the toast, then check Library → Songs/Playlists/History after relaunch.