### PR TITLE
fix: show listening stats when the last week has no plays

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/db/DatabaseDao.kt
@@ -1486,6 +1486,10 @@ interface DatabaseDao {
     @Query("SELECT songId FROM event ORDER BY rowId DESC LIMIT 1")
     fun lastEventSongId(): Flow<String?>
 
+    /** Timestamp of the most recent play, or `null` when there is no listening history at all. */
+    @Query("SELECT MAX(timestamp) FROM event")
+    fun latestEventTimestamp(): Flow<Long?>
+
     @Transaction
     @Query("DELETE FROM event")
     fun clearListenHistory()

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/StatsScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/StatsScreen.kt
@@ -341,6 +341,13 @@ fun StatsScreen(
                     }
                 }
 
+                if (!data.hasPlaysInPeriod) {
+                    item(key = "periodEmpty", contentType = "status") {
+                        StatsPeriodEmptyMessage(modifier = Modifier.animateItem())
+                    }
+                    return@LazyColumn
+                }
+
                 item(key = "overview", contentType = "overview") {
                     StatsSummarySection(
                         summary = listeningSummary,
@@ -660,6 +667,30 @@ private fun StatsStatusScreen(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun StatsPeriodEmptyMessage(modifier: Modifier = Modifier) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 48.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.stats_period_empty_title),
+            style = MaterialTheme.typography.titleMedium,
+            textAlign = TextAlign.Center,
+        )
+        Text(
+            text = stringResource(R.string.stats_period_empty_message),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
     }
 }
 

--- a/app/src/main/kotlin/dev/citali/lunartune/viewmodels/StatsViewModel.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/viewmodels/StatsViewModel.kt
@@ -19,11 +19,14 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import dev.citali.lunartune.R
+import dev.citali.lunartune.constants.StatPeriod
 import dev.citali.lunartune.constants.statToPeriod
 import dev.citali.lunartune.db.MusicDatabase
 import dev.citali.lunartune.db.entities.Album
@@ -71,6 +74,8 @@ data class StatsUiData(
     val firstEvent: EventWithSong?,
     val isSongListExpanded: Boolean,
     val canExpandSongList: Boolean,
+    /** False when the library has listening history but none of it falls inside the selected range. */
+    val hasPlaysInPeriod: Boolean,
 )
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -85,6 +90,9 @@ class StatsViewModel
         private val isSongListExpanded = MutableStateFlow(false)
         private val isYearPickerOpen = MutableStateFlow(false)
         private val refreshRequest = MutableStateFlow(0L)
+
+        /** Set once the opening time range has been chosen from the actual history. */
+        private val initialPeriodResolved = MutableStateFlow(false)
 
         val yearPickerOpen: StateFlow<Boolean> = isYearPickerOpen
 
@@ -205,6 +213,10 @@ class StatsViewModel
             database
                 .firstEvent()
 
+        private val latestEventTimestamp =
+            database
+                .latestEventTimestamp()
+
         private val primaryStats =
             combine(
                 mostPlayedSongsStats,
@@ -226,17 +238,22 @@ class StatsViewModel
                 listeningByDayOfWeek,
                 listeningTotals,
                 firstEvent,
-            ) { byHour, byDay, totals, first ->
+                latestEventTimestamp,
+            ) { byHour, byDay, totals, first, latest ->
                 ListeningStats(
                     byHour = byHour,
                     byDay = byDay,
                     totals = totals,
                     firstEvent = first,
+                    latestEventTimestamp = latest,
                 )
             }
 
         val screenState: StateFlow<StatsScreenState> =
-            refreshRequest
+            combine(refreshRequest, initialPeriodResolved) { request, resolved -> request to resolved }
+                // Hold the first frame until the opening range is known, so the screen
+                // never flashes an empty "last week" before jumping to the right period.
+                .filter { (_, resolved) -> resolved }
                 .flatMapLatest {
                     combine(
                         primaryStats,
@@ -253,7 +270,10 @@ class StatsViewModel
                                 uniqueArtistsCount = primary.artists.size,
                                 uniqueAlbumsCount = primary.albums.size,
                             )
-                        if (summary.totalPlayCount == 0 && primary.rankedSongs.isEmpty()) {
+                        // Only a library with no history at all is "empty". A range without
+                        // plays keeps the full screen (and its range chips) so the user can
+                        // widen the period instead of being told there are no stats.
+                        if (listening.latestEventTimestamp == null) {
                             StatsScreenState.Empty
                         } else {
                             StatsScreenState.Success(
@@ -276,6 +296,7 @@ class StatsViewModel
                                     firstEvent = listening.firstEvent,
                                     isSongListExpanded = expanded,
                                     canExpandSongList = primary.rankedSongs.size > COLLAPSED_SONG_COUNT,
+                                    hasPlaysInPeriod = summary.totalPlayCount > 0 || primary.rankedSongs.isNotEmpty(),
                                 ),
                             )
                         }
@@ -291,6 +312,18 @@ class StatsViewModel
                 )
 
         init {
+            viewModelScope.launch {
+                // Open on the shortest continuous range that actually contains plays. A
+                // library restored from a backup, or simply a listening break, would
+                // otherwise greet the user with an empty last-week view and no hint that
+                // older stats exist.
+                val latest = runCatching { database.latestEventTimestamp().first() }.getOrNull()
+                if (latest != null && selectedOption.value == OptionStats.CONTINUOUS && indexChips.value == 0) {
+                    val period = StatPeriod.entries.firstOrNull { it.toTimeMillis() < latest } ?: StatPeriod.ALL
+                    indexChips.value = period.ordinal
+                }
+                initialPeriodResolved.value = true
+            }
             viewModelScope.launch {
                 mostPlayedArtists.collect { artists ->
                     artists
@@ -346,6 +379,7 @@ class StatsViewModel
             val byDay: List<ListeningBySlot>,
             val totals: ListeningTotals,
             val firstEvent: EventWithSong?,
+            val latestEventTimestamp: Long?,
         )
 
         private companion object {

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -575,6 +575,8 @@
     <string name="stats_show_top_songs">Show top 5</string>
     <string name="stats_empty_title">No listening stats yet</string>
     <string name="stats_empty_message">Songs you play will appear here with listening trends and rankings.</string>
+    <string name="stats_period_empty_title">No plays in this time range</string>
+    <string name="stats_period_empty_message">Choose a longer range above to see your listening stats.</string>
     <string name="stats_time_range">Time range</string>
     <string name="stats_listening_patterns">Listening patterns</string>
     <string name="stats_artist_breakdown">Artist breakdown</string>


### PR DESCRIPTION
## Problem
After restoring an ArchiveTune backup (#100) the Stats page still said **"No listening stats yet"**, so it looked like the listening history had not been imported.

It had. Every one of the 962 plays from `ArchiveTune_20260910221504.backup` is in `event` after the conversion (the table is copied untouched; only `song` is rebuilt). The screen was hiding them:

- `StatsViewModel` always opens on **Continuous / 1 week**.
- If that one range comes back with zero plays, `screenState` becomes `Empty`, which renders the "No listening stats yet" status screen — **without the time-range chips**, so there is no way to widen the period.
- The newest play in the backup is 2026-08-28. Since 2026-09-04 that is outside the last week → empty screen, while *1 month* has 942 plays / 31 h 34 min and *All* has 962 plays / 32 h 12 min.

The same thing happens to anyone who takes a week off listening, without any backup involved.

## Fix
- **Open on the shortest continuous range that actually contains plays** (1 week → 1 month → 3 months → 6 months → 1 year → All), decided from `MAX(event.timestamp)` before the first frame is emitted so nothing flashes. With the sample this opens on *1 month*.
- **Only treat the screen as empty when the `event` table itself is empty.** A range without plays now keeps the range selector and shows a small "No plays in this time range — choose a longer range above" hint instead of the full-screen empty state.
- New DAO query `latestEventTimestamp()` (`SELECT MAX(timestamp) FROM event`).

No changes to how plays are recorded or to the queries behind the numbers. Weeks/Months/Years modes are untouched (they already let the user pick a period).

## Verification
Emulated the new selection logic against the restored sample: latest event 2026-08-28 → opening chip **1 month** → 942 plays, 31 h 34 m, 249 distinct songs. `Empty` is only produced when `MAX(timestamp)` is `NULL`.

Please check on the device after restoring the ArchiveTune backup: Settings → Listening Stats should open on *1 month* with the totals, favourite artist/song, hourly/day-of-week patterns and the ranked list.