### PR TITLE
feat: add Solar broken icon watermarks to Library hub cards

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/library/LibraryMixScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/library/LibraryMixScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -27,8 +28,10 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -70,6 +73,7 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.graphics.ColorUtils
@@ -1215,10 +1219,16 @@ private fun MostPlayedAlbumSpotlightCard(
                 .padding(horizontal = 24.dp)
                 .clip(RoundedCornerShape(32.dp))
                 .background(backgroundBrush)
-                .clickable(onClick = onOpenAlbum)
-                .padding(16.dp),
+                .clickable(onClick = onOpenAlbum),
     ) {
-        Column {
+        CardWatermarkIcon(
+            iconRes = R.drawable.star,
+            color = primaryColor,
+            size = 164.dp,
+            endBleed = 46.dp,
+        )
+
+        Column(modifier = Modifier.padding(16.dp)) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
@@ -1410,9 +1420,17 @@ fun ShortcutCard(
                 .clickable(
                     interactionSource = interactionSource,
                     onClick = onClick,
-                ).padding(12.dp),
+                ),
     ) {
+        CardWatermarkIcon(
+            iconRes = iconRes,
+            color = iconColor,
+            size = 116.dp,
+            endBleed = 28.dp,
+        )
+
         Column(
+            modifier = Modifier.padding(12.dp),
             verticalArrangement = Arrangement.spacedBy(6.dp),
         ) {
             Box(
@@ -1443,5 +1461,34 @@ fun ShortcutCard(
                 )
             }
         }
+    }
+}
+
+private const val CARD_WATERMARK_ALPHA = 0.44f
+
+/**
+ * Oversized copy of a card's Solar (broken) icon, drawn behind the card content as a
+ * theme-tinted watermark at 44% opacity. It is anchored to the end edge and pushed
+ * past it by [endBleed] so the parent's rounded clip crops it, matching the hub design.
+ * The watermark is measured against the parent's size and never grows the card.
+ */
+@Composable
+private fun BoxScope.CardWatermarkIcon(
+    iconRes: Int,
+    color: Color,
+    size: Dp,
+    endBleed: Dp,
+) {
+    Box(modifier = Modifier.matchParentSize()) {
+        Icon(
+            painter = painterResource(id = iconRes),
+            contentDescription = null,
+            tint = color.copy(alpha = CARD_WATERMARK_ALPHA),
+            modifier =
+                Modifier
+                    .align(Alignment.CenterEnd)
+                    .offset(x = endBleed)
+                    .requiredSize(size),
+        )
     }
 }


### PR DESCRIPTION
## What

The Library hub cards now carry a large decorative copy of their own Solar Icons (Broken style) icon behind the content, as in the reference design:

- **Liked songs** → `favorite`, **Offline** → `offline`, **Cached** → `cached`, **Local Files** → `snippet_folder`, **My top 50** → `trending_up`
- **Most played** spotlight card → `star`

The watermark is tinted with the card's dynamic theme colour (`error` / `primary` / `tertiary` / `secondary`, same as the small badge icon) at exactly **44 % opacity**, so it follows Material You / dynamic colour and both light and dark themes.

## How

- New private `BoxScope.CardWatermarkIcon(iconRes, color, size, endBleed)` in `LibraryMixScreen.kt`.
- It sits in a `matchParentSize()` layer so it never grows the card, is aligned `CenterEnd`, offset past the end edge and drawn with `requiredSize`, so the existing rounded `clip` of the card crops it (bleeds over the top/right/bottom edges like the reference).
- Shortcut cards: 116 dp icon, 28 dp bleed; spotlight card: 164 dp icon, 46 dp bleed (sizes measured from the reference screenshot).
- Card padding moved from the outer `Box` to the content `Column` so the watermark can reach the card edges; card dimensions, ripple/clickable areas and the press-scale animation are unchanged.
- Text and the small icon badge are drawn on top of the watermark; the watermark only occupies the end half of the card, so labels stay readable.

No shading/gradient changes in this PR — background colours are untouched.
