### PR TITLE
feat: auto-hide lyrics player controls after 5 seconds

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/constants/PreferenceKeys.kt
@@ -757,6 +757,7 @@ val LyricsTextSizeKey = floatPreferencesKey("lyricsTextSize")
 val LyricsLineSpacingKey = floatPreferencesKey("lyricsLineSpacing")
 val LyricsLineBlurKey = booleanPreferencesKey("lyricsLineBlur")
 val ShowLyricsPlayerControlsKey = booleanPreferencesKey("showLyricsPlayerControls")
+val LyricsAutoHidePlayerControlsKey = booleanPreferencesKey("lyricsAutoHidePlayerControls")
 
 val TopSize = stringPreferencesKey("topSize")
 

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/menu/LyricsMenu.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/menu/LyricsMenu.kt
@@ -140,11 +140,14 @@ fun LyricsMenu(
     onLyricsSyncOffsetChange: (Int) -> Unit,
     showPlayerControlsState: State<Boolean>,
     onShowPlayerControlsChange: (Boolean) -> Unit,
+    autoHidePlayerControlsState: State<Boolean>,
+    onAutoHidePlayerControlsChange: (Boolean) -> Unit,
     onDismiss: () -> Unit,
     viewModel: LyricsMenuViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
     val showPlayerControls by showPlayerControlsState
+    val autoHidePlayerControls by autoHidePlayerControlsState
 
     var showEditDialog by rememberSaveable {
         mutableStateOf(false)
@@ -776,17 +779,47 @@ fun LyricsMenu(
                 )
                 NewMenuItem(
                     headlineContent = {
-                        Text(stringResource(R.string.show_lyrics_player_controls))
+                        Text(stringResource(R.string.lyrics_auto_hide_player_controls))
                     },
                     trailingContent = {
                         Switch(
-                            checked = showPlayerControls,
+                            checked = autoHidePlayerControls,
+                            onCheckedChange = onAutoHidePlayerControlsChange,
+                        )
+                    },
+                    onClick = {
+                        onAutoHidePlayerControlsChange(!autoHidePlayerControls)
+                    },
+                    modifier =
+                        Modifier.padding(
+                            start = 8.dp,
+                            end = 8.dp,
+                        ),
+                )
+                // Auto-hide implies the controls are shown (and then faded), so the plain
+                // toggle is forced on and locked while it is active; the user's own choice
+                // is kept and comes back as soon as auto-hide is switched off again.
+                NewMenuItem(
+                    headlineContent = {
+                        Text(
+                            text = stringResource(R.string.show_lyrics_player_controls),
+                            color =
+                                MaterialTheme.colorScheme.onSurface.copy(
+                                    alpha = if (autoHidePlayerControls) 0.38f else 1f,
+                                ),
+                        )
+                    },
+                    trailingContent = {
+                        Switch(
+                            checked = showPlayerControls || autoHidePlayerControls,
                             onCheckedChange = onShowPlayerControlsChange,
+                            enabled = !autoHidePlayerControls,
                         )
                     },
                     onClick = {
                         onShowPlayerControlsChange(!showPlayerControls)
                     },
+                    enabled = !autoHidePlayerControls,
                     modifier =
                         Modifier.padding(
                             start = 8.dp,

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
@@ -12,7 +12,14 @@ package dev.citali.lunartune.ui.player
 import android.content.res.Configuration
 import android.view.HapticFeedbackConstants
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -51,6 +58,7 @@ import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -108,6 +116,7 @@ import dev.citali.lunartune.R
 import dev.citali.lunartune.constants.BlurRadiusKey
 import dev.citali.lunartune.constants.DisableBlurKey
 import dev.citali.lunartune.constants.EnableHapticFeedbackKey
+import dev.citali.lunartune.constants.LyricsAutoHidePlayerControlsKey
 import dev.citali.lunartune.constants.LyricsBackgroundStyle
 import dev.citali.lunartune.constants.LyricsBackgroundStyleKey
 import dev.citali.lunartune.constants.UseGpuBlurKey
@@ -140,6 +149,37 @@ private val AppleMusicFallbackGradient =
         Color(0xFF141414),
         Color(0xFF050505),
     )
+
+/** How long the player controls stay on screen after the last touch before they fade. */
+private const val LYRICS_CONTROLS_AUTO_HIDE_DELAY_MS = 5_000L
+
+/**
+ * Timing for the controls leaving and returning. The opacity always runs ahead of the height:
+ * on the way out the controls are gone before the lyrics have taken much of their space, and on
+ * the way back the space opens first and the controls then fade into it — so neither direction
+ * ever shows a clipped edge, only a soft fade while the lyrics settle. Fresh specs per call
+ * because the animation apis keep the type open (Float for opacity, IntSize for height).
+ */
+private val ControlsFadeEasing = CubicBezierEasing(0.4f, 0f, 0.2f, 1f)
+private val ControlsLayoutEasing = CubicBezierEasing(0.2f, 0f, 0f, 1f)
+private const val CONTROLS_FADE_OUT_MS = 300
+private const val CONTROLS_COLLAPSE_MS = 520
+private const val CONTROLS_FADE_IN_MS = 450
+private const val CONTROLS_FADE_IN_DELAY_MS = 60
+private const val CONTROLS_EXPAND_MS = 320
+
+private fun controlsFadeOutSpec() = tween<Float>(durationMillis = CONTROLS_FADE_OUT_MS, easing = ControlsFadeEasing)
+
+private fun controlsFadeInSpec() =
+    tween<Float>(
+        durationMillis = CONTROLS_FADE_IN_MS,
+        delayMillis = CONTROLS_FADE_IN_DELAY_MS,
+        easing = ControlsFadeEasing,
+    )
+
+private fun <T> controlsCollapseSpec() = tween<T>(durationMillis = CONTROLS_COLLAPSE_MS, easing = ControlsLayoutEasing)
+
+private fun <T> controlsExpandSpec() = tween<T>(durationMillis = CONTROLS_EXPAND_MS, easing = ControlsLayoutEasing)
 
 @Suppress("UNUSED_PARAMETER")
 @Composable
@@ -198,6 +238,32 @@ fun LyricsScreen(
                 showPlayerControlsState.value = showControls
             }
         }
+    val autoHidePlayerControlsState =
+        rememberPreference(LyricsAutoHidePlayerControlsKey, false)
+    val autoHidePlayerControls by autoHidePlayerControlsState
+    val onAutoHidePlayerControlsChange =
+        remember(autoHidePlayerControlsState) {
+            { autoHide: Boolean ->
+                autoHidePlayerControlsState.value = autoHide
+            }
+        }
+    // Auto-hide implies the controls exist (and then fade), so it overrides a switched-off
+    // "Show player controls" without touching the stored preference.
+    val controlsEnabled = showPlayerControls || autoHidePlayerControls
+
+    // Apple Music style auto-hide: the controls stay for a few seconds after the last
+    // interaction and then fade away; any tap on the page brings them back and restarts
+    // the timer. `controlsRevealed` is the visible/hidden state, `controlsInteraction`
+    // only exists to restart the countdown while the controls are already showing.
+    var controlsRevealed by remember { mutableStateOf(true) }
+    var controlsInteraction by remember { mutableIntStateOf(0) }
+    val revealControls: () -> Unit =
+        remember {
+            {
+                controlsInteraction++
+                controlsRevealed = true
+            }
+        }
 
     val hapticClick =
         remember(enableHapticFeedback, view) {
@@ -250,6 +316,20 @@ fun LyricsScreen(
     val durationState = remember(mediaMetadata.id) { mutableLongStateOf(C.TIME_UNSET) }
     var sliderPosition by remember(mediaMetadata.id) { mutableStateOf<Long?>(null) }
     var gradientColors by remember(mediaMetadata.thumbnailUrl) { mutableStateOf(AppleMusicFallbackGradient) }
+
+    val isScrubbing = sliderPosition != null
+    LaunchedEffect(autoHidePlayerControls, controlsRevealed, controlsInteraction, isScrubbing) {
+        if (!autoHidePlayerControls) {
+            controlsRevealed = true
+            return@LaunchedEffect
+        }
+        // A finger on the progress slider keeps the controls up; the countdown starts over
+        // once it lifts.
+        if (!controlsRevealed || isScrubbing) return@LaunchedEffect
+        delay(LYRICS_CONTROLS_AUTO_HIDE_DELAY_MS)
+        controlsRevealed = false
+    }
+    val controlsVisible = controlsEnabled && controlsRevealed
 
     val gradientColorsCache =
         remember {
@@ -336,6 +416,8 @@ fun LyricsScreen(
                 onLyricsSyncOffsetChange = onLyricsSyncOffsetChange,
                 showPlayerControlsState = showPlayerControlsState,
                 onShowPlayerControlsChange = onShowPlayerControlsChange,
+                autoHidePlayerControlsState = autoHidePlayerControlsState,
+                onAutoHidePlayerControlsChange = onAutoHidePlayerControlsChange,
                 onDismiss = menuState::dismiss,
             )
         }
@@ -349,7 +431,8 @@ fun LyricsScreen(
     Box(
         modifier =
             modifier
-                .fillMaxSize(),
+                .fillMaxSize()
+                .observeTaps(onTap = revealControls),
     ) {
         LyricsScreenBackground(
             style = lyricsBackground,
@@ -389,7 +472,7 @@ fun LyricsScreen(
                         .padding(horizontal = 24.dp),
             )
 
-            if (orientation == Configuration.ORIENTATION_LANDSCAPE && showPlayerControls) {
+            if (orientation == Configuration.ORIENTATION_LANDSCAPE && controlsEnabled) {
                 Row(
                     modifier =
                         Modifier
@@ -410,10 +493,21 @@ fun LyricsScreen(
                                 .padding(end = 32.dp),
                     )
 
+                    // Landscape keeps the two-pane layout and only fades the controls in place,
+                    // so the lyrics column does not reflow sideways every time they come and go.
+                    // Faded-out controls stop taking touches; a tap there just brings them back.
+                    val controlsAlpha by animateFloatAsState(
+                        targetValue = if (controlsVisible) 1f else 0f,
+                        animationSpec = if (controlsVisible) controlsFadeInSpec() else controlsFadeOutSpec(),
+                        label = "lyricsPlayerControlsAlpha",
+                    )
                     Column(
-                Modifier
+                        modifier =
+                            Modifier
                                 .weight(0.85f)
-                                .widthIn(max = 420.dp),
+                                .widthIn(max = 420.dp)
+                                .graphicsLayer { alpha = controlsAlpha }
+                                .blockPointerInput(enabled = !controlsVisible),
                         verticalArrangement = Arrangement.Center,
                     ) {
                         AppleMusicControls(
@@ -430,18 +524,25 @@ fun LyricsScreen(
                                     positionState.longValue = it
                                 }
                                 sliderPosition = null
+                                revealControls()
                             },
-                            onVolumeChange = onVolumeChange,
+                            onVolumeChange = {
+                                revealControls()
+                                onVolumeChange(it)
+                            },
                             onPreviousClick = {
                                 hapticClick()
+                                revealControls()
                                 playerConnection.seekToPrevious()
                             },
                             onPlayPauseClick = {
                                 hapticClick()
+                                revealControls()
                                 player.togglePlayPause()
                             },
                             onNextClick = {
                                 hapticClick()
+                                revealControls()
                                 playerConnection.seekToNext()
                             },
                             foregroundColor = foregroundColor,
@@ -461,7 +562,19 @@ fun LyricsScreen(
                             .fillMaxWidth(),
                 )
 
-                if (showPlayerControls) {
+                // The controls fade in place while the lyrics pane above grows into the space
+                // they leave — the same soft hand-off Apple Music does — and come back the
+                // same way. The lyrics list re-anchors its focused line as the pane resizes.
+                AnimatedVisibility(
+                    visible = controlsVisible,
+                    enter =
+                        fadeIn(controlsFadeInSpec()) +
+                            expandVertically(controlsExpandSpec(), expandFrom = Alignment.Bottom),
+                    exit =
+                        fadeOut(controlsFadeOutSpec()) +
+                            shrinkVertically(controlsCollapseSpec(), shrinkTowards = Alignment.Bottom),
+                    label = "lyricsPlayerControls",
+                ) {
                     AppleMusicControls(
                         positionProvider = { positionState.longValue },
                         durationProvider = { durationState.longValue },
@@ -476,18 +589,25 @@ fun LyricsScreen(
                                 positionState.longValue = it
                             }
                             sliderPosition = null
+                            revealControls()
                         },
-                        onVolumeChange = onVolumeChange,
+                        onVolumeChange = {
+                            revealControls()
+                            onVolumeChange(it)
+                        },
                         onPreviousClick = {
                             hapticClick()
+                            revealControls()
                             playerConnection.seekToPrevious()
                         },
                         onPlayPauseClick = {
                             hapticClick()
+                            revealControls()
                             player.togglePlayPause()
                         },
                         onNextClick = {
                             hapticClick()
+                            revealControls()
                             playerConnection.seekToNext()
                         },
                         foregroundColor = foregroundColor,

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/PointerInputModifiers.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/PointerInputModifiers.kt
@@ -7,8 +7,11 @@
 
 package dev.citali.lunartune.ui.player
 
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
 import androidx.compose.ui.input.pointer.pointerInput
 
 internal fun Modifier.consumeUnhandledPointerInput(): Modifier =
@@ -20,6 +23,50 @@ internal fun Modifier.consumeUnhandledPointerInput(): Modifier =
                     if (!pointerInputChange.isConsumed) {
                         pointerInputChange.consume()
                     }
+                }
+            }
+        }
+    }
+
+/**
+ * Reports taps anywhere inside the node without taking them away from whatever is underneath:
+ * the gesture is only watched on the initial pass and nothing is consumed, so lyric lines,
+ * buttons and sliders keep working exactly as before. A press that moves past the touch slop or
+ * gains a second finger is a scroll or a pinch, not a tap, and is ignored.
+ */
+internal fun Modifier.observeTaps(onTap: () -> Unit): Modifier =
+    pointerInput(onTap) {
+        val touchSlop = viewConfiguration.touchSlop
+        awaitEachGesture {
+            val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+            var isTap = true
+            while (true) {
+                val event = awaitPointerEvent(PointerEventPass.Initial)
+                if (event.changes.size > 1) isTap = false
+                val change = event.changes.firstOrNull { it.id == down.id } ?: break
+                if ((change.position - down.position).getDistance() > touchSlop) isTap = false
+                if (change.changedToUpIgnoreConsumed()) {
+                    if (isTap) onTap()
+                    break
+                }
+                if (!change.pressed) break
+            }
+        }
+    }
+
+/**
+ * Swallows every touch while [enabled], so controls that have faded out cannot be pressed by
+ * accident. Consuming on the initial pass means the children never see an unconsumed press;
+ * ancestors watching the same pass (such as [observeTaps]) still do.
+ */
+internal fun Modifier.blockPointerInput(enabled: Boolean): Modifier =
+    if (!enabled) {
+        this
+    } else {
+        pointerInput(Unit) {
+            awaitPointerEventScope {
+                while (true) {
+                    awaitPointerEvent(PointerEventPass.Initial).changes.forEach { it.consume() }
                 }
             }
         }

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/SettingsDataBuilders.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/SettingsDataBuilders.kt
@@ -50,6 +50,7 @@ import dev.citali.lunartune.constants.HideVideoKey
 import dev.citali.lunartune.constants.EnableHapticFeedbackKey
 import dev.citali.lunartune.constants.ListenBrainzEnabledKey
 import dev.citali.lunartune.constants.LowDataModeKey
+import dev.citali.lunartune.constants.LyricsAutoHidePlayerControlsKey
 import dev.citali.lunartune.constants.LyricsClickKey
 import dev.citali.lunartune.constants.LyricsScrollKey
 import dev.citali.lunartune.constants.NetworkMeteredKey
@@ -258,6 +259,7 @@ fun buildSettingsGroups(
                 SettingsChild("Lyrics click to seek", "lyrics_click", listOf("click lyrics", "tap lyrics", "seek lyrics")) { SearchResultSwitch(LyricsClickKey, false) },
                 SettingsChild("Lyrics auto-scroll", "lyrics_scroll", listOf("scroll", "auto scroll", "lyrics scroll")) { SearchResultSwitch(LyricsScrollKey, true) },
                 SettingsChild("Show lyrics player controls", "show_lyrics_player_controls", listOf("player controls", "lyrics controls")) { SearchResultSwitch(ShowLyricsPlayerControlsKey, true) },
+                SettingsChild("Hide lyrics player controls after 5 seconds", "lyrics_auto_hide_player_controls", listOf("auto hide", "hide controls", "fade controls", "lyrics controls")) { SearchResultSwitch(LyricsAutoHidePlayerControlsKey, false) },
                 SettingsChild("Preload queue lyrics", "preload_queue_lyrics", listOf("preload", "preload lyrics", "queue lyrics", "preload count", "queue lyrics count", "preload amount", "preload size")),
                 SettingsChild("Lyrics background style", "lyrics_background_style", listOf("lyrics background", "lyrics bg")),
                 SettingsChild("BetterLyrics", "betterlyrics", listOf("betterlyrics", "better lyrics", "better lyrics provider")),

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -262,6 +262,7 @@
     <string name="lyrics_share_background_blur_value">%1$d px</string>
     <string name="lyrics_line_blur">Blur lyrics lines</string>
     <string name="show_lyrics_player_controls">Show player controls</string>
+    <string name="lyrics_auto_hide_player_controls">Hide player controls after 5 seconds</string>
     <string name="lyrics_share_background_dim">Background dim</string>
     <string name="lyrics_share_background_dim_value">%1$d%%</string>
     <string name="lyrics_share_show_cover">Show album cover</string>


### PR DESCRIPTION
## What

New option in the lyrics page ⋯ menu, placed **above** *Show player controls*:

**Hide player controls after 5 seconds**

- Turning it on forces *Show player controls* on and **locks** that row (switch disabled, label dimmed). The user's stored choice is untouched and comes back the moment auto-hide is switched off.
- With auto-hide on, the controls stay for **5 s after the last interaction** and then fade away Apple Music style. **Tapping anywhere on the page** brings them back with the same smooth fade and restarts the countdown.
- Pressing previous / play-pause / next, moving the volume slider or finishing a seek also restarts the 5 s timer, and the controls never hide while a finger is on the progress slider.
- Also searchable from Settings search ("auto hide", "hide controls", "fade controls").

## Animation

- Portrait: `AnimatedVisibility` with `fadeOut` (300 ms, standard ease) + `shrinkVertically` (520 ms, emphasized decelerate) on the way out, so the opacity leaves first and the lyrics pane then eases into the freed space; on the way back the space opens (320 ms) and the controls fade into it (450 ms, 60 ms delay). No clipped edges in either direction.
- Landscape keeps the two-pane layout and fades the controls in place (`animateFloatAsState` on a `graphicsLayer` alpha) so the lyrics column never reflows sideways. Faded-out controls stop taking touches.

## Implementation notes

- `LyricsAutoHidePlayerControlsKey` (`lyricsAutoHidePlayerControls`, default off) in `PreferenceKeys.kt`.
- `Modifier.observeTaps` (new, `PointerInputModifiers.kt`) watches the **initial** pointer pass and consumes nothing — lyric-line taps, scrolling, buttons and sliders behave exactly as before. Drags past touch slop and multi-finger gestures are not treated as taps.
- `Modifier.blockPointerInput` swallows touches on the invisible landscape controls.
- `LyricsMenu` gains `autoHidePlayerControlsState` / `onAutoHidePlayerControlsChange` (only caller is `LyricsScreen`).
- New string `lyrics_auto_hide_player_controls`.
