### PR TITLE
fix: recover Discord presence after the service outlives a stop request

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/playback/MusicService.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/playback/MusicService.kt
@@ -451,6 +451,12 @@ class MusicService :
     private var pausedPresenceGate = PausedPresenceGate.FollowPreference
 
     @Volatile
+    /**
+     * Set on the way out (task removed, destroy) so the last Discord sync clears the presence
+     * instead of publishing one. Android does not always honour the stop — a client re-binding
+     * or the media session keeps the same service instance alive — so this is reset again the
+     * moment playback comes back, otherwise every later sync would stay Hidden(ServiceStopping).
+     */
     private var discordServiceStopping = false
 
     @Volatile
@@ -2189,6 +2195,24 @@ class MusicService :
 
             currentMediaMetadata.value = player.currentMetadata.takeIf { player.mediaItemCount > 0 }
             updateNotification()
+        }
+    }
+
+    /**
+     * Lifts the "service is stopping" Discord gate when the service turns out to still be in
+     * use. Called from the paths that prove it: a new start command, a client binding, and a
+     * new media item / play request. Cheap no-op while the flag is already clear.
+     */
+    private fun clearDiscordServiceStoppingIfRevived(reason: String) {
+        if (!discordServiceStopping) return
+        discordServiceStopping = false
+        Timber.tag(DISCORD_SYNC_TAG).i("service revived (%s); lifting stopping gate", reason)
+        // With nothing loaded there is nothing to publish yet; the first playback event syncs.
+        if (::player.isInitialized && player.currentMediaItem != null) {
+            requestDiscordSync(
+                reason = "service_revived:$reason",
+                force = true,
+            )
         }
     }
 
@@ -7075,6 +7099,11 @@ class MusicService :
             if (events.contains(Player.EVENT_MEDIA_ITEM_TRANSITION)) {
                 currentMediaMetadata.value = player.currentMetadata
             }
+            // A stopping service does not start playing something new: if it does, the stop
+            // never happened and the presence gate must come off before this sync runs.
+            if (player.playWhenReady && player.currentMediaItem != null) {
+                clearDiscordServiceStoppingIfRevived("playback_resumed")
+            }
             requestDiscordSync(
                 reason = "is_playing_or_media_item_transition",
                 force = true,
@@ -8645,6 +8674,7 @@ class MusicService :
     override fun onBind(intent: Intent?): android.os.IBinder? {
         hasBoundClients = true
         cancelIdleStop()
+        clearDiscordServiceStoppingIfRevived("bind")
         val result = super.onBind(intent) ?: binder
         if (player.mediaItemCount > 0 && player.currentMediaItem != null) {
             currentMediaMetadata.value = player.currentMetadata
@@ -8665,6 +8695,7 @@ class MusicService :
     override fun onRebind(intent: Intent?) {
         hasBoundClients = true
         cancelIdleStop()
+        clearDiscordServiceStoppingIfRevived("rebind")
         super.onRebind(intent)
     }
 
@@ -8761,6 +8792,7 @@ class MusicService :
         }
 
         ensureStartedAsForeground()
+        clearDiscordServiceStoppingIfRevived("start_command")
         when (intent?.action) {
             "dev.citali.lunartune.WIDGET_PLAY_PAUSE" -> {
                 if (player.isPlaying) player.pause() else player.play()

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/DiscordPresenceManager.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/screens/settings/DiscordPresenceManager.kt
@@ -69,10 +69,17 @@ object DiscordPresenceManager {
     ): DiscordRPC {
         val activeToken = DiscordOAuthRepository.getValidAccessToken(context) ?: token
         if (rpcInstance == null || rpcToken != activeToken) {
-            runCatching { rpcInstance?.stopActivity() }
-                .onFailure { Timber.tag(LOG_TAG).v(it, "failed to stop previous activity") }
-            runCatching { rpcInstance?.closeRPC() }
-                .onFailure { Timber.tag(LOG_TAG).v(it, "failed to close previous RPC instance") }
+            val previous = rpcInstance
+            if (previous != null) {
+                // The previous token may already be revoked (log-out, re-login), so it is only
+                // used to clear over a socket that is still open, never to open a new one.
+                if (DiscordSocialPresenceClient.isStarted) {
+                    runCatching { previous.stopActivity() }
+                        .onFailure { Timber.tag(LOG_TAG).v(it, "failed to stop previous activity") }
+                }
+                runCatching { previous.closeRPC() }
+                    .onFailure { Timber.tag(LOG_TAG).v(it, "failed to close previous RPC instance") }
+            }
 
             rpcInstance = DiscordRPC(context.applicationContext, activeToken)
             rpcToken = activeToken
@@ -207,8 +214,22 @@ object DiscordPresenceManager {
             startedState.value = true
         }
 
-        if (token.isNotBlank()) {
-            rpcToken = token
+        if (token.isNotBlank() && token != rpcToken) {
+            // A session with a different token than the live instance was built with: that
+            // instance must not be reused (its token is most likely revoked). It is closed and
+            // the next update or clear connects with the current token.
+            val stale = rpcInstance
+            rpcInstance = null
+            rpcToken = null
+            if (stale != null) {
+                Timber.tag(LOG_TAG).d("start: dropping RPC instance built with a previous token")
+                cleanupScope.launch {
+                    rpcMutex.withLock {
+                        runCatching { withTimeout(STOP_TIMEOUT_MS) { stale.closeRPC() } }
+                            .onFailure { Timber.tag(LOG_TAG).v(it, "stale instance close failed or timed out") }
+                    }
+                }
+            }
         }
         Timber.tag(LOG_TAG).d("started manager runtime; awaiting external sync trigger")
     }
@@ -238,8 +259,30 @@ object DiscordPresenceManager {
         context: Context,
         token: String? = null,
     ): Boolean {
+        val activeToken = DiscordOAuthRepository.getValidAccessToken(context) ?: token.orEmpty()
         val existingRpc = rpcInstance
-        if (existingRpc != null) {
+
+        if (existingRpc != null && activeToken.isBlank()) {
+            // Logged out. The instance's token is revoked, so it must never dial the gateway
+            // again — that is what produced a 4004 "Authentication failed" on every clear.
+            // One empty presence still goes over the socket if it is open, then it is closed;
+            // a presence whose session is gone is dropped by Discord on its own.
+            Timber.tag(LOG_TAG).d("clearPresenceLocked closing RPC instance after log-out")
+            if (DiscordSocialPresenceClient.isStarted) {
+                DiscordSocialPresenceClient.clearPresence().onFailure {
+                    Timber.tag(LOG_TAG).v(it, "final clear over the open socket failed")
+                }
+            }
+            runCatching { existingRpc.closeRPC() }
+                .onFailure { Timber.tag(LOG_TAG).v(it, "failed to close RPC instance after log-out") }
+            rpcInstance = null
+            rpcToken = null
+            setLastRpcTimestamps(null, null)
+            consecutiveFailures = 0
+            return true
+        }
+
+        if (existingRpc != null && rpcToken == activeToken) {
             Timber.tag(LOG_TAG).d("clearPresenceLocked using existing RPC instance")
             existingRpc.stopActivity()
             setLastRpcTimestamps(null, null)
@@ -247,12 +290,13 @@ object DiscordPresenceManager {
             return true
         }
 
-        val activeToken = DiscordOAuthRepository.getValidAccessToken(context) ?: token.orEmpty()
         if (activeToken.isBlank()) {
             Timber.tag(LOG_TAG).w("clearPresenceLocked skipped because token is missing")
             return false
         }
 
+        // No instance, or one built with a token that is no longer current (re-login):
+        // getOrCreateRpc closes the stale one and connects with the current token.
         Timber.tag(LOG_TAG).d("clearPresenceLocked creating RPC instance for clear")
         val rpc = getOrCreateRpc(context, activeToken)
         rpc.stopActivity()
@@ -280,7 +324,9 @@ object DiscordPresenceManager {
                 rpcMutex.withLock {
                     runCatching {
                         withTimeout(STOP_TIMEOUT_MS) {
-                            if (clearActivity) {
+                            // Clearing is only worth a send over a socket that is still open;
+                            // reconnecting for it would fail outright once the token is revoked.
+                            if (clearActivity && DiscordSocialPresenceClient.isStarted) {
                                 rpcToClose.stopActivity()
                             }
                             rpcToClose.closeRPC()


### PR DESCRIPTION
## Symptom

Rich Presence stops publishing and never comes back — the Experimental card shows *Presence manager: stopped / INACTIVE*, manual **Refresh** does nothing, and logging out/in makes it worse. Reproduced from a device log.

## What the log shows

1. `13:23:13` — the app was swiped away with *Stop music on task clear* on → `task_removed_stop_music_on_task_clear` sets `discordServiceStopping = true` and the presence is cleared (correct).
2. `13:25:04` — playback starts again **in the same `MusicService` instance** (Android kept it alive), but the flag is still `true`, so **every** sync from then on — song changes, manual refresh, the RPC toggle, keep-alive — resolves to `decision=Hidden(reason=ServiceStopping)` and *clears* the presence instead of publishing it. There is no code path that ever reset the flag.
3. `13:26:47` — the user logs out. `DiscordPresenceManager.clearPresenceLocked` reuses the existing RPC instance (built with the now-revoked token) and reconnects the gateway with it → `gateway closed code=4004 reason=Authentication failed` on every clear attempt, repeated four times.

## Fix

**MusicService**
- New `clearDiscordServiceStoppingIfRevived(reason)`: lifts the gate when the service is proven alive — `onStartCommand`, `onBind`/`onRebind`, and a play request for a loaded media item in the player-events handler (`playback_resumed`) — and forces a sync so the presence is republished immediately.
- The flag is still set on `onTaskRemoved` / `onDestroy` exactly as before, so the terminal clear on a real stop is unchanged.

**DiscordPresenceManager**
- `clearPresenceLocked`: after log-out (no current token) the instance is closed — one empty presence is still sent if the socket is open — instead of reconnecting with a revoked token. An instance whose token is no longer current is replaced via `getOrCreateRpc` (which now only clears over an open socket, never dials with the old token).
- `start()` drops an instance built with a previous token instead of relabelling it, so the next update connects with the current session.
- `stop()` only sends the final clear when the socket is still open.

## Expected behaviour after the fix
- Swipe the app away with *Stop music on task clear*, start playing again → presence comes back on the first play event.
- Log out → at most one clear over the open socket, no `4004` storm. Log back in → fresh connection with the new token, presence published.
