### PR TITLE
fix: keep the lyrics controls fade smooth while breathing dots animate

### DIFF
--- a/app/src/main/kotlin/dev/citali/lunartune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/component/LyricsEnhanced.kt
@@ -88,6 +88,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -161,6 +162,20 @@ private const val SMOOTH_PLAYBACK_DRIFT_CORRECTION = 0.55f
 private const val LYRIC_FOCUS_SCROLL_DURATION_MS = 520
 private const val MIN_KARAOKE_SYLLABLE_DURATION_MS = 1
 
+/** How far down the pane the focused line sits. */
+private const val LYRICS_FOCUS_HEIGHT_RATIO = 0.38f
+
+/** Space both lyrics panes keep below their list; the lyrics page relies on it matching. */
+internal val LyricsPaneBottomPadding = 12.dp
+
+/** Height of the fade the lyrics library draws over the bottom of the Enhanced list. */
+internal val LyricsEnhancedBottomFade = 100.dp
+
+/**
+ * @param focusAnchorHeight Pane height the focused line is positioned against; defaults to the
+ * pane's own height. The lyrics page passes the height the pane has while the player controls are
+ * shown, so the line does not move when they hide or come back.
+ */
 @Composable
 fun LyricsEnhanced(
     sliderPositionProvider: () -> Long?,
@@ -168,6 +183,7 @@ fun LyricsEnhanced(
     modifier: Modifier = Modifier,
     textColorOverride: Color? = null,
     lyricsLineBlurOverride: Boolean? = null,
+    focusAnchorHeight: Dp? = null,
 ) {
     val playerConnection = LocalPlayerConnection.current ?: return
     val player = playerConnection.player
@@ -629,7 +645,7 @@ fun LyricsEnhanced(
         modifier =
             modifier
                 .fillMaxSize()
-                .padding(bottom = 12.dp),
+                .padding(bottom = LyricsPaneBottomPadding),
     ) {
         when {
             lyrics == LYRICS_NOT_FOUND -> {
@@ -702,7 +718,11 @@ fun LyricsEnhanced(
                             .fillMaxSize()
                             .nestedScroll(nestedScrollConnection),
                 ) {
-                    val lyricsViewportOffset = remember(maxHeight) { maxHeight * 0.38f }
+                    val lyricsViewportOffset =
+                        remember(maxHeight, focusAnchorHeight) {
+                            val focusHeight = focusAnchorHeight?.let { it - LyricsPaneBottomPadding } ?: maxHeight
+                            focusHeight.coerceAtLeast(0.dp) * LYRICS_FOCUS_HEIGHT_RATIO
+                        }
 
                     key(lyricsSessionKey, syncedLyricsRenderVersion) {
                         KaraokeLyricsView(

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/component/LyricsV2.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/component/LyricsV2.kt
@@ -93,6 +93,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -162,6 +163,12 @@ private const val MANUAL_SCROLL_TIMEOUT_MS = 3000L
 /** Sentinel entry prepended so auto-scroll has headroom above the first line. */
 private val HEAD_LYRICS_ENTRY = LyricsEntry(time = 0L, text = "")
 
+/** How far down the pane the focused line sits. */
+private const val LYRICS_FOCUS_HEIGHT_RATIO = 0.35f
+
+/** Height of the fade drawn over the top and bottom of the V2 list. */
+internal val LyricsV2EdgeFade = 80.dp
+
 private fun isRtlText(text: String): Boolean {
     for (ch in text) {
         when (Character.getDirectionality(ch)) {
@@ -184,6 +191,11 @@ private fun isRtlText(text: String): Boolean {
 // Main Composable
 // ──────────────────────────────────────────────────────────────────────
 
+/**
+ * @param focusAnchorHeight Pane height the focused line is positioned against; defaults to the
+ * pane's own height. The lyrics page passes the height the pane has while the player controls are
+ * shown, so the line does not move when they hide or come back.
+ */
 @OptIn(ExperimentalLayoutApi::class, ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun LyricsV2(
@@ -192,11 +204,21 @@ fun LyricsV2(
     modifier: Modifier = Modifier,
     textColorOverride: Color? = null,
     lyricsLineBlurOverride: Boolean? = null,
+    focusAnchorHeight: Dp? = null,
 ) {
     val playerConnection = LocalPlayerConnection.current ?: return
     val player = playerConnection.player
     val context = LocalContext.current
     val density = LocalDensity.current
+    val focusAnchorHeightPx =
+        remember(density, focusAnchorHeight) {
+            focusAnchorHeight?.let { with(density) { (it - LyricsPaneBottomPadding).coerceAtLeast(0.dp).roundToPx() } }
+        }
+    // Where the focused line is scrolled to, measured from the top of the list.
+    val focusOffsetPx: (viewportHeight: Int) -> Int =
+        remember(focusAnchorHeightPx) {
+            { viewportHeight -> ((focusAnchorHeightPx ?: viewportHeight) * LYRICS_FOCUS_HEIGHT_RATIO).toInt() }
+        }
     val scope = rememberCoroutineScope()
 
     val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
@@ -398,8 +420,7 @@ fun LyricsV2(
         if (currentLineIndex < 0 || currentLineIndex >= entriesWithWords.size) return@LaunchedEffect
 
         val visibleInfo = listState.layoutInfo
-        val viewportHeight = visibleInfo.viewportSize.height
-        val targetOffset = (viewportHeight * 0.35f).toInt() // Center bias at 35% from top
+        val targetOffset = focusOffsetPx(visibleInfo.viewportSize.height)
 
         val distance = abs(currentLineIndex - (listState.firstVisibleItemIndex))
         if (distance > 15) {
@@ -447,7 +468,7 @@ fun LyricsV2(
         modifier =
             modifier
                 .fillMaxSize()
-                .padding(bottom = 12.dp),
+                .padding(bottom = LyricsPaneBottomPadding),
     ) {
         if (lyrics == LYRICS_NOT_FOUND) {
             Box(
@@ -494,7 +515,7 @@ fun LyricsV2(
                 Modifier
                     .fillMaxSize()
                     .nestedScroll(nestedScrollConnection)
-                    .smoothFadingEdge(vertical = 80.dp)
+                    .smoothFadingEdge(vertical = LyricsV2EdgeFade)
                     .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen },
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
@@ -944,10 +965,9 @@ fun LyricsV2(
                 onClick = {
                     isManualScrolling = false
                     scope.launch {
-                        val viewportHeight = listState.layoutInfo.viewportSize.height
                         listState.animateScrollToItem(
                             index = currentLineIndex,
-                            scrollOffset = -(viewportHeight * 0.35f).toInt(),
+                            scrollOffset = -focusOffsetPx(listState.layoutInfo.viewportSize.height),
                         )
                     }
                 },

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/player/LyricsScreen.kt
@@ -12,14 +12,10 @@ package dev.citali.lunartune.ui.player
 import android.content.res.Configuration
 import android.view.HapticFeedbackConstants
 import androidx.activity.compose.BackHandler
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -56,6 +52,7 @@ import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -69,14 +66,22 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ColorMatrix
 import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -87,7 +92,10 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.constrainHeight
+import androidx.compose.ui.unit.constrainWidth
 import androidx.compose.ui.unit.dp
 import androidx.compose.runtime.collectAsState
 import androidx.compose.animation.core.tween
@@ -109,7 +117,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlin.math.floor
 import dev.citali.lunartune.LocalDatabase
 import dev.citali.lunartune.LocalPlayerConnection
 import dev.citali.lunartune.R
@@ -133,9 +143,13 @@ import dev.citali.lunartune.extensions.togglePlayPause
 import dev.citali.lunartune.models.MediaMetadata
 import dev.citali.lunartune.ui.component.LocalMenuState
 import dev.citali.lunartune.ui.component.LyricsEnhanced
+import dev.citali.lunartune.ui.component.LyricsEnhancedBottomFade
+import dev.citali.lunartune.ui.component.LyricsPaneBottomPadding
 import dev.citali.lunartune.ui.component.LyricsV2
+import dev.citali.lunartune.ui.component.LyricsV2EdgeFade
 import dev.citali.lunartune.ui.component.PlayerSliderTrack
 import dev.citali.lunartune.ui.menu.LyricsMenu
+import dev.citali.lunartune.ui.utils.SmoothFadingEdgeStops
 import dev.citali.lunartune.ui.theme.PlayerColorExtractor
 import dev.citali.lunartune.utils.LyricsArtBlurCache
 import dev.citali.lunartune.utils.makeTimeString
@@ -154,19 +168,23 @@ private val AppleMusicFallbackGradient =
 private const val LYRICS_CONTROLS_AUTO_HIDE_DELAY_MS = 5_000L
 
 /**
- * Timing for the controls leaving and returning. The opacity always runs ahead of the height:
- * on the way out the controls are gone before the lyrics have taken much of their space, and on
- * the way back the space opens first and the controls then fade into it — so neither direction
- * ever shows a clipped edge, only a soft fade while the lyrics settle. Fresh specs per call
- * because the animation apis keep the type open (Float for opacity, IntSize for height).
+ * Timing for the controls leaving and returning. The controls only ever fade — their layout size
+ * is never animated. Resizing the lyrics pane frame by frame made the lyrics list re-measure and
+ * re-anchor its focused line on every one of those frames, which is heavy enough on weaker phones
+ * to swallow the whole fade (most visibly while an instrumental section keeps the breathing dots
+ * redrawing). Instead the pane changes size in a single step and a soft edge sweeps across the
+ * space the controls give up or take back; see [LyricsWithControls]. The opacity still runs
+ * ahead of the edge on the way out (the edge sets off once the controls have started to thin) and
+ * behind it on the way back, so the hand-off reads as one motion in both directions.
  */
 private val ControlsFadeEasing = CubicBezierEasing(0.4f, 0f, 0.2f, 1f)
-private val ControlsLayoutEasing = CubicBezierEasing(0.2f, 0f, 0f, 1f)
+private val LyricsEdgeEasing = CubicBezierEasing(0.2f, 0f, 0f, 1f)
 private const val CONTROLS_FADE_OUT_MS = 300
-private const val CONTROLS_COLLAPSE_MS = 520
+private const val LYRICS_REVEAL_MS = 520
+private const val LYRICS_REVEAL_DELAY_MS = 120
 private const val CONTROLS_FADE_IN_MS = 450
 private const val CONTROLS_FADE_IN_DELAY_MS = 60
-private const val CONTROLS_EXPAND_MS = 320
+private const val LYRICS_COVER_MS = 320
 
 private fun controlsFadeOutSpec() = tween<Float>(durationMillis = CONTROLS_FADE_OUT_MS, easing = ControlsFadeEasing)
 
@@ -177,9 +195,39 @@ private fun controlsFadeInSpec() =
         easing = ControlsFadeEasing,
     )
 
-private fun <T> controlsCollapseSpec() = tween<T>(durationMillis = CONTROLS_COLLAPSE_MS, easing = ControlsLayoutEasing)
+private fun lyricsRevealSpec() =
+    tween<Float>(
+        durationMillis = LYRICS_REVEAL_MS,
+        delayMillis = LYRICS_REVEAL_DELAY_MS,
+        easing = LyricsEdgeEasing,
+    )
 
-private fun <T> controlsExpandSpec() = tween<T>(durationMillis = CONTROLS_EXPAND_MS, easing = ControlsLayoutEasing)
+private fun lyricsCoverSpec() = tween<Float>(durationMillis = LYRICS_COVER_MS, easing = LyricsEdgeEasing)
+
+/**
+ * How a lyrics pane fades out at its bottom: the fade's height and its opacity profile from fully
+ * visible (0) to gone (1). The moving edge in [LyricsWithControls] copies the pane's own fade
+ * exactly, so swapping one for the other is invisible: the Enhanced list fades linearly over its
+ * last 100 dp (fixed inside the lyrics library), the V2 list over its last 80 dp with the profile
+ * of `smoothFadingEdge`.
+ */
+@Immutable
+private class LyricsPaneEdge(
+    val fade: Dp,
+    val stops: Array<Pair<Float, Color>>,
+)
+
+private val LyricsEnhancedPaneEdge =
+    LyricsPaneEdge(
+        fade = LyricsEnhancedBottomFade,
+        stops = arrayOf(0f to Color.Black, 1f to Color.Transparent),
+    )
+
+private val LyricsV2PaneEdge =
+    LyricsPaneEdge(
+        fade = LyricsV2EdgeFade,
+        stops = SmoothFadingEdgeStops,
+    )
 
 @Suppress("UNUSED_PARAMETER")
 @Composable
@@ -551,72 +599,66 @@ fun LyricsScreen(
                     }
                 }
             } else {
-                AppleMusicLyricsPane(
-                    lyricsMode = lyricsMode,
-                    foregroundColor = foregroundColor,
-                    sliderPositionProvider = { sliderPosition },
-                    lyricsSyncOffset = lyricsSyncOffset,
+                LyricsWithControls(
+                    controlsVisible = controlsVisible,
+                    paneEdge = if (lyricsMode == LyricsMode.V2) LyricsV2PaneEdge else LyricsEnhancedPaneEdge,
                     modifier =
                         Modifier
                             .weight(1f)
                             .fillMaxWidth(),
+                    lyrics = { focusAnchorHeight ->
+                        AppleMusicLyricsPane(
+                            lyricsMode = lyricsMode,
+                            foregroundColor = foregroundColor,
+                            sliderPositionProvider = { sliderPosition },
+                            lyricsSyncOffset = lyricsSyncOffset,
+                            focusAnchorHeight = focusAnchorHeight,
+                        )
+                    },
+                    controls = {
+                        AppleMusicControls(
+                            positionProvider = { positionState.longValue },
+                            durationProvider = { durationState.longValue },
+                            sliderPosition = sliderPosition,
+                            isPlaying = isPlaying,
+                            isLoading = isLoading,
+                            volume = deviceMusicVolumeController.volumeFraction,
+                            onPositionChange = { sliderPosition = it },
+                            onPositionChangeFinished = {
+                                sliderPosition?.let {
+                                    player.seekTo(it)
+                                    positionState.longValue = it
+                                }
+                                sliderPosition = null
+                                revealControls()
+                            },
+                            onVolumeChange = {
+                                revealControls()
+                                onVolumeChange(it)
+                            },
+                            onPreviousClick = {
+                                hapticClick()
+                                revealControls()
+                                playerConnection.seekToPrevious()
+                            },
+                            onPlayPauseClick = {
+                                hapticClick()
+                                revealControls()
+                                player.togglePlayPause()
+                            },
+                            onNextClick = {
+                                hapticClick()
+                                revealControls()
+                                playerConnection.seekToNext()
+                            },
+                            foregroundColor = foregroundColor,
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 40.dp),
+                        )
+                    },
                 )
-
-                // The controls fade in place while the lyrics pane above grows into the space
-                // they leave — the same soft hand-off Apple Music does — and come back the
-                // same way. The lyrics list re-anchors its focused line as the pane resizes.
-                AnimatedVisibility(
-                    visible = controlsVisible,
-                    enter =
-                        fadeIn(controlsFadeInSpec()) +
-                            expandVertically(controlsExpandSpec(), expandFrom = Alignment.Bottom),
-                    exit =
-                        fadeOut(controlsFadeOutSpec()) +
-                            shrinkVertically(controlsCollapseSpec(), shrinkTowards = Alignment.Bottom),
-                    label = "lyricsPlayerControls",
-                ) {
-                    AppleMusicControls(
-                        positionProvider = { positionState.longValue },
-                        durationProvider = { durationState.longValue },
-                        sliderPosition = sliderPosition,
-                        isPlaying = isPlaying,
-                        isLoading = isLoading,
-                        volume = deviceMusicVolumeController.volumeFraction,
-                        onPositionChange = { sliderPosition = it },
-                        onPositionChangeFinished = {
-                            sliderPosition?.let {
-                                player.seekTo(it)
-                                positionState.longValue = it
-                            }
-                            sliderPosition = null
-                            revealControls()
-                        },
-                        onVolumeChange = {
-                            revealControls()
-                            onVolumeChange(it)
-                        },
-                        onPreviousClick = {
-                            hapticClick()
-                            revealControls()
-                            playerConnection.seekToPrevious()
-                        },
-                        onPlayPauseClick = {
-                            hapticClick()
-                            revealControls()
-                            player.togglePlayPause()
-                        },
-                        onNextClick = {
-                            hapticClick()
-                            revealControls()
-                            playerConnection.seekToNext()
-                        },
-                        foregroundColor = foregroundColor,
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 40.dp),
-                    )
-                }
             }
         }
     }
@@ -1151,6 +1193,7 @@ private fun AppleMusicLyricsPane(
     sliderPositionProvider: () -> Long?,
     lyricsSyncOffset: Int,
     modifier: Modifier = Modifier,
+    focusAnchorHeight: Dp? = null,
 ) {
     LyricsContent(
         lyricsMode = lyricsMode,
@@ -1161,7 +1204,162 @@ private fun AppleMusicLyricsPane(
                 .fillMaxSize()
                 .padding(horizontal = 20.dp),
         textColor = foregroundColor,
+        focusAnchorHeight = focusAnchorHeight,
     )
+}
+
+private enum class LyricsWithControlsSlot { Lyrics, Controls }
+
+/** Measured geometry shared between the measure pass and the edge drawing; deliberately not state. */
+private class LyricsWithControlsGeometry {
+    var controlsHeightPx = 0
+}
+
+/**
+ * Portrait arrangement of the lyrics pane with the player controls beneath it.
+ *
+ * The controls only fade; their layout size is never animated. When they hide, the pane is handed
+ * the full height in one step and a soft edge — shaped like the pane's own bottom fade — sweeps
+ * down over the freshly exposed lines, so the lyrics appear to flow into the space while the
+ * controls dissolve above them. Showing the controls runs the sequence backwards: they fade in over
+ * the lyrics while the edge sweeps back up, and the pane gives the space back only once the edge
+ * rests where the pane's own fade will be, which makes that step invisible. Every frame in between
+ * is alpha and draw work; the lyrics list is measured once per transition instead of once per
+ * frame, which is what let the breathing dots of an instrumental section turn the old
+ * shrink-and-fade into a stutter and an instant cut on slower phones.
+ *
+ * The pane keeps positioning its current line against the height it has while the controls are
+ * shown (the `focusAnchorHeight` handed to [lyrics]), so the line stays exactly where it is in both
+ * directions and the extra room only ever shows more of the upcoming lines.
+ *
+ * Controls on their way out stop taking touches and leave the composition once faded, so the lines
+ * that now occupy their space can be scrolled and tapped like any others.
+ */
+@Composable
+private fun LyricsWithControls(
+    controlsVisible: Boolean,
+    paneEdge: LyricsPaneEdge,
+    modifier: Modifier = Modifier,
+    lyrics: @Composable (focusAnchorHeight: Dp?) -> Unit,
+    controls: @Composable () -> Unit,
+) {
+    val controlsAlpha = remember { Animatable(if (controlsVisible) 1f else 0f) }
+    // 0f while the controls own the bottom of the layout, 1f once the lyrics have all of it.
+    val lyricsReveal = remember { Animatable(if (controlsVisible) 0f else 1f) }
+    var controlsComposed by remember { mutableStateOf(controlsVisible) }
+    var controlsHoldSpace by remember { mutableStateOf(controlsVisible) }
+    val geometry = remember { LyricsWithControlsGeometry() }
+    val revealLayerPaint = remember { Paint() }
+
+    LaunchedEffect(controlsVisible) {
+        if (controlsVisible) {
+            controlsComposed = true
+            if (controlsAlpha.value < 1f) launch { controlsAlpha.animateTo(1f, controlsFadeInSpec()) }
+            if (lyricsReveal.value > 0f) lyricsReveal.animateTo(0f, lyricsCoverSpec())
+            controlsHoldSpace = true
+        } else {
+            controlsHoldSpace = false
+            if (lyricsReveal.value < 1f) launch { lyricsReveal.animateTo(1f, lyricsRevealSpec()) }
+            if (controlsAlpha.value > 0f) controlsAlpha.animateTo(0f, controlsFadeOutSpec())
+            controlsComposed = false
+        }
+    }
+
+    SubcomposeLayout(modifier = modifier) { constraints ->
+        val controlsPlaceable =
+            if (controlsComposed) {
+                subcompose(LyricsWithControlsSlot.Controls) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .graphicsLayer { alpha = controlsAlpha.value }
+                                .blockPointerInput(enabled = !controlsVisible),
+                    ) {
+                        controls()
+                    }
+                }.first().measure(constraints.copy(minHeight = 0))
+            } else {
+                null
+            }
+        // Remembered while the controls are gone: the edge still has to finish its sweep and the
+        // pane keeps anchoring its current line as if they were there.
+        controlsPlaceable?.let { geometry.controlsHeightPx = it.height }
+        val controlsHeightPx = geometry.controlsHeightPx
+
+        val reservedHeight = if (controlsHoldSpace) controlsHeightPx else 0
+        val lyricsConstraints: Constraints
+        val focusAnchorHeight: Dp?
+        if (constraints.hasBoundedHeight) {
+            val lyricsHeight = (constraints.maxHeight - reservedHeight).coerceAtLeast(0)
+            lyricsConstraints = constraints.copy(minHeight = lyricsHeight, maxHeight = lyricsHeight)
+            focusAnchorHeight = (constraints.maxHeight - controlsHeightPx).coerceAtLeast(0).toDp()
+        } else {
+            lyricsConstraints = constraints.copy(minHeight = 0)
+            focusAnchorHeight = null
+        }
+        val lyricsPlaceable =
+            subcompose(LyricsWithControlsSlot.Lyrics) {
+                Box(
+                    modifier =
+                        Modifier.drawWithContent {
+                            val reveal = lyricsReveal.value
+                            val edgeControlsHeightPx = geometry.controlsHeightPx
+                            if (controlsHoldSpace || edgeControlsHeightPx <= 0 || reveal >= 1f) {
+                                drawContent()
+                                return@drawWithContent
+                            }
+                            val fadePx = paneEdge.fade.toPx()
+                            val bottomPaddingPx = LyricsPaneBottomPadding.toPx()
+                            // Where the pane's list ended while the controls held the space, and
+                            // where the edge has to get to before it stops touching anything the
+                            // pane draws.
+                            val restingEdgeY = size.height - edgeControlsHeightPx - bottomPaddingPx
+                            val clearedEdgeY = size.height - bottomPaddingPx + fadePx
+                            val edgeY = restingEdgeY + (clearedEdgeY - restingEdgeY) * reveal
+                            // Only the strip the edge travels through goes through a layer;
+                            // everything above it is drawn as is.
+                            val stripTop = floor(restingEdgeY - fadePx).coerceAtLeast(0f)
+                            clipRect(bottom = stripTop) {
+                                this@drawWithContent.drawContent()
+                            }
+                            clipRect(top = stripTop) {
+                                drawIntoCanvas { canvas ->
+                                    canvas.saveLayer(Rect(0f, stripTop, size.width, size.height), revealLayerPaint)
+                                    // Nothing below the edge is drawn at all; above it the fade
+                                    // is applied as a DstIn mask.
+                                    clipRect(bottom = edgeY) {
+                                        this@drawWithContent.drawContent()
+                                    }
+                                    drawRect(
+                                        brush =
+                                            Brush.verticalGradient(
+                                                *paneEdge.stops,
+                                                startY = edgeY - fadePx,
+                                                endY = edgeY,
+                                            ),
+                                        blendMode = BlendMode.DstIn,
+                                    )
+                                    canvas.restore()
+                                }
+                            }
+                        },
+                ) {
+                    lyrics(focusAnchorHeight)
+                }
+            }.first().measure(lyricsConstraints)
+
+        val width = constraints.constrainWidth(maxOf(lyricsPlaceable.width, controlsPlaceable?.width ?: 0))
+        val height =
+            if (constraints.hasBoundedHeight) {
+                constraints.maxHeight
+            } else {
+                constraints.constrainHeight(lyricsPlaceable.height + reservedHeight)
+            }
+        layout(width, height) {
+            lyricsPlaceable.place(0, 0)
+            controlsPlaceable?.let { it.place(0, height - it.height) }
+        }
+    }
 }
 
 @Composable
@@ -1378,6 +1576,7 @@ private fun LyricsContent(
     lyricsSyncOffset: Int,
     textColor: Color,
     modifier: Modifier = Modifier,
+    focusAnchorHeight: Dp? = null,
 ) {
     when (lyricsMode) {
         LyricsMode.V2 -> {
@@ -1386,6 +1585,7 @@ private fun LyricsContent(
                 lyricsSyncOffset = lyricsSyncOffset,
                 modifier = modifier,
                 textColorOverride = textColor,
+                focusAnchorHeight = focusAnchorHeight,
             )
         }
 
@@ -1395,6 +1595,7 @@ private fun LyricsContent(
                 lyricsSyncOffset = lyricsSyncOffset,
                 modifier = modifier,
                 textColorOverride = textColor,
+                focusAnchorHeight = focusAnchorHeight,
             )
         }
     }

--- a/app/src/main/kotlin/dev/citali/lunartune/ui/utils/FadingEdge.kt
+++ b/app/src/main/kotlin/dev/citali/lunartune/ui/utils/FadingEdge.kt
@@ -95,6 +95,20 @@ fun Modifier.fadingEdge(
     bottom = vertical,
 )
 
+/**
+ * Opacity profile of a [smoothFadingEdge], from fully visible (0) to fully faded (1). Shared so
+ * other fades can match it exactly.
+ */
+val SmoothFadingEdgeStops: Array<Pair<Float, Color>> =
+    arrayOf(
+        0.0f to Color.Black,
+        0.15f to Color.Black.copy(alpha = 0.9f),
+        0.3f to Color.Black.copy(alpha = 0.7f),
+        0.5f to Color.Black.copy(alpha = 0.4f),
+        0.7f to Color.Black.copy(alpha = 0.15f),
+        1.0f to Color.Transparent,
+    )
+
 fun Modifier.smoothFadingEdge(
     top: Dp? = null,
     bottom: Dp? = null,
@@ -126,15 +140,7 @@ fun Modifier.smoothFadingEdge(
             drawRect(
                 brush =
                     Brush.verticalGradient(
-                        colorStops =
-                            arrayOf(
-                                0.0f to Color.Black,
-                                0.15f to Color.Black.copy(alpha = 0.9f),
-                                0.3f to Color.Black.copy(alpha = 0.7f),
-                                0.5f to Color.Black.copy(alpha = 0.4f),
-                                0.7f to Color.Black.copy(alpha = 0.15f),
-                                1.0f to Color.Transparent,
-                            ),
+                        *SmoothFadingEdgeStops,
                         startY = size.height - bottomPx,
                         endY = size.height,
                     ),


### PR DESCRIPTION
## Problem
With **Hide player controls after 5 seconds** on, the controls on the lyrics page were supposed to fade out Apple-Music style. When they hid during an instrumental section — while the three breathing dots are pulsing — the fade lagged and then the controls simply vanished in one step (sometimes with a flash).

## Cause
The portrait hide/show used `AnimatedVisibility` with `shrinkVertically` / `expandVertically`. Animating the controls' **height** resized the lyrics pane on every frame, so the lyrics list was re-measured and re-anchored its focused line ~60×/s during the fade. The breathing dots already redraw their lyric line every frame during an interlude; the two together were enough on slower phones (API 29 Motorola) to drop the whole transition.

## Fix
- The controls now **only fade** (`Animatable` alpha on a `graphicsLayer`); their layout size is never animated.
- A new `LyricsWithControls` layout hands the pane the freed space in **one** layout step. To keep the soft hand-off, an edge shaped exactly like the pane's own bottom fade (Enhanced: linear 100 dp from the lyrics library; V2: the `smoothFadingEdge` profile, 80 dp) **sweeps down** over the exposed lines while the controls dissolve above them. Showing runs the sequence backwards, and the pane takes the space back only when the edge rests where its own fade will be, so the step is invisible. Every in-between frame is alpha/draw work only.
- The pane keeps anchoring its **focused line to the height it has with the controls shown** (`focusAnchorHeight` passed through to `LyricsEnhanced` / `LyricsV2`), so the current line never moves when the controls come or go — the extra room only reveals more of the upcoming lines.
- Faded-out controls still block touches and leave the composition once gone; tap-anywhere-to-reveal and the 5 s delay are unchanged. Landscape (which already faded in place) is untouched.

## Files
- `ui/player/LyricsScreen.kt` — `LyricsWithControls`, reveal edge, timing docs
- `ui/component/LyricsEnhanced.kt`, `ui/component/LyricsV2.kt` — optional `focusAnchorHeight`, shared bottom padding / fade constants
- `ui/utils/FadingEdge.kt` — `SmoothFadingEdgeStops` exposed so the edge matches V2 exactly

## Test
1. Lyrics page → ⋯ → enable *Hide player controls after 5 seconds*.
2. Play a song with an instrumental intro/interlude (breathing dots showing) and wait 5 s: controls fade out smoothly, lyrics flow into the space, current line does not jump.
3. Tap anywhere: controls fade back in just as smoothly; the focused line stays put.
4. Repeat in V2 lyrics mode and while scrubbing (slider keeps the controls up until release).
